### PR TITLE
ensure converted model stays in same place as original

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -163,7 +163,9 @@ namespace FbxExporters
                 fbxMaterial.Diffuse.Set(GetMaterialColor(unityMaterial, "_Color"));
                 fbxMaterial.Emissive.Set(GetMaterialColor(unityMaterial, "_EmissionColor"));
                 fbxMaterial.Ambient.Set(new FbxDouble3 ());
-                fbxMaterial.BumpFactor.Set (unityMaterial ? unityMaterial.GetFloat ("_BumpScale") : 0);
+
+                fbxMaterial.BumpFactor.Set (unityMaterial && unityMaterial.HasProperty("_BumpScale") ? unityMaterial.GetFloat ("_BumpScale") : 0);
+
                 if (specular) {
                     (fbxMaterial as FbxSurfacePhong).Specular.Set(GetMaterialColor(unityMaterial, "_SpecColor"));
                 }


### PR DESCRIPTION
on Unity 2017.1+ we have unicode so I need to change how I remove "(Clone)" from the name.

also remove warning generated by trying to access BumpScale from Materials that don't have the property.