### PR TITLE
UNI-20478 maintain material connection on export and reimport

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -9,13 +9,14 @@ namespace FbxExporters.EditorTools {
     [CustomEditor(typeof(ExportSettings))]
     public class ExportSettingsEditor : UnityEditor.Editor {
         public override void OnInspectorGUI() {
-            ExportSettings temp = (ExportSettings)target;
+            ExportSettings exportSettings = (ExportSettings)target;
 
-            temp.weldVertices = EditorGUILayout.Toggle ("Weld Vertices:", temp.weldVertices);
+            exportSettings.weldVertices = EditorGUILayout.Toggle ("Weld Vertices:", exportSettings.weldVertices);
+            exportSettings.embedTextures = EditorGUILayout.Toggle ("Embed Textures:", exportSettings.embedTextures);
 
             if (GUI.changed) {
-                EditorUtility.SetDirty (temp);
-                temp.Dirty ();
+                EditorUtility.SetDirty (exportSettings);
+                exportSettings.Save ();
             }
         }
     }
@@ -24,6 +25,7 @@ namespace FbxExporters.EditorTools {
     public class ExportSettings : FbxExporters.EditorTools.ScriptableSingleton<ExportSettings>
     {
         public bool weldVertices = true;
+        public bool embedTextures = false;
 
         [MenuItem("Edit/Project Settings/Fbx Export", priority = 300)]
         static void ShowManager()
@@ -32,7 +34,7 @@ namespace FbxExporters.EditorTools {
             Selection.activeObject = instance;
         }
 
-        public void Dirty()
+        public void Save()
         {
             instance.Save (true);
         }

--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -507,13 +507,18 @@ namespace FbxExporters
                         fbxManager.SetIOSettings (FbxIOSettings.Create (fbxManager, Globals.IOSROOT));
 
                         // Export texture as embedded
-                        //fbxManager.GetIOSettings ().SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
+                        if(EditorTools.ExportSettings.instance.embedTextures){
+                            fbxManager.GetIOSettings ().SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
+                        }
 
                         // Create the exporter
                         var fbxExporter = FbxExporter.Create (fbxManager, "Exporter");
 
                         // Initialize the exporter.
-                        int fileFormat = fbxManager.GetIOPluginRegistry ().FindWriterIDByDescription ("FBX ascii (*.fbx)");
+                        // fileFormat must be binary if we are embedding textures
+                        int fileFormat = EditorTools.ExportSettings.instance.embedTextures? -1 :
+                            fbxManager.GetIOPluginRegistry ().FindWriterIDByDescription ("FBX ascii (*.fbx)");
+
                         bool status = fbxExporter.Initialize (LastFilePath, fileFormat, fbxManager.GetIOSettings ());
                         // Check that initialization of the fbxExporter was successful
                         if (!status)


### PR DESCRIPTION
Add an FbxLayerElementMaterial to each mesh exported. Without this Unity cannot find the names of the materials to connect with the nodes.

Will need to change the way this is setup when using mulitple materials
per mesh (e.g. won't be able to use all same with only one index)