### PR TITLE
Uni 20152 reliable naming

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -21,6 +21,9 @@ namespace FbxExporters
             const string MenuItemName1 = "Assets/Convert To Model";
             const string MenuItemName2 = "GameObject/Convert To Model";
 
+            const string RegexCharStart = "[";
+            const string RegexCharEnd = "]";
+
             /// <summary>
             /// Clean up this class on garbage collection
             /// </summary>
@@ -139,7 +142,8 @@ namespace FbxExporters
 
             private static string ConvertToValidFilename(string filename)
             {
-                return System.Text.RegularExpressions.Regex.Replace (filename, "[" + new string(Path.GetInvalidFileNameChars()) + "]", "_");
+                return System.Text.RegularExpressions.Regex.Replace (filename, 
+                    RegexCharStart + new string(Path.GetInvalidFileNameChars()) + RegexCharEnd, "_");
             }
 
             private static void SetupImportedGameObject(GameObject orig, GameObject imported)

--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -16,14 +16,16 @@ namespace FbxExporters.EditorTools {
 
             exportSettings.weldVertices = EditorGUILayout.Toggle ("Weld Vertices:", exportSettings.weldVertices);
             exportSettings.embedTextures = EditorGUILayout.Toggle ("Embed Textures:", exportSettings.embedTextures);
-            exportSettings.mayaCompatibleNames = EditorGUILayout.Toggle ("Convert to Maya Compatible Naming on export:",
+            exportSettings.mayaCompatibleNames = EditorGUILayout.Toggle (
+                new GUIContent("Convert to Maya Compatible Naming:",
+                    "In Maya some symbols such as spaces and accents get replaced when importing an FBX " +
+                    "(e.g. \"foo bar\" becomes \"fooFBXASC032bar\"). " +
+                    "On export, convert the names of GameObjects so they are Maya compatible." +
+                    (exportSettings.mayaCompatibleNames? "" : 
+                        "\n\nWARNING: Disabling this feature may result in lost material connections," +
+                        " and unexpected character replacements in Maya.")
+                ),
                 exportSettings.mayaCompatibleNames);
-
-            if (!exportSettings.mayaCompatibleNames) {
-                EditorGUILayout.HelpBox (
-                    "Disabling this feature may result in lost material connections, and unexpected character replacements in Maya.",
-                    MessageType.Warning);
-            }
 
             if (GUI.changed) {
                 EditorUtility.SetDirty (exportSettings);

--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -36,6 +36,10 @@ namespace FbxExporters
 
             const string ProgressBarTitle = "Fbx Export";
 
+            const char InvalidCharReplacement = '_';
+
+            const char MayaNamespaceSeparator = ':';
+
             /// <summary>
             /// Create instance of example
             /// </summary>
@@ -1021,6 +1025,12 @@ namespace FbxExporters
                 }
             }
 
+            /// <summary>
+            /// Removes the diacritics (i.e. accents) from letters.
+            /// e.g. é becomes e
+            /// </summary>
+            /// <returns>Text with accents removed.</returns>
+            /// <param name="text">Text.</param>
             private static string RemoveDiacritics(string text) 
             {
                 var normalizedString = text.Normalize(System.Text.NormalizationForm.FormD);
@@ -1043,15 +1053,15 @@ namespace FbxExporters
                 string newName = RemoveDiacritics (name);
 
                 if (char.IsDigit (newName [0])) {
-                    newName = newName.Insert (0, "_");
+                    newName = newName.Insert (0, InvalidCharReplacement.ToString());
                 }
 
                 for (int i = 0; i < newName.Length; i++) {
                     if (!char.IsLetterOrDigit (newName, i)) {
-                        if (i < newName.Length-1 && newName [i] == ':') {
+                        if (i < newName.Length-1 && newName [i] == MayaNamespaceSeparator) {
                             continue;
                         }
-                        newName = newName.Replace (newName [i], '_');
+                        newName = newName.Replace (newName [i], InvalidCharReplacement);
                     }
                 }
                 return newName;


### PR DESCRIPTION
Added an option in the preferences to Convert exported models and materials to Maya compatible names. If selected, then any selected meshes/models with unsupported characters get converted in Unity before being exported.
Also in Convert to Model, make sure that we give a valid filename. For example, currently if we use the object name and it has a colon in it, then we don't give any export errors but the file does not export.

Unity to Maya Name conversion rules:
- If a name starts with a number, add an underscore in front of the number
- If there is a symbol which is not alphanumeric, nor an underscore or colon (with the exception if the colon is the last character), then replace it with an underscore
- Any characters with accents get replaced with an accent free character (e.g. é is replaced with e)

