### PR TITLE
UNI-21369 fix so that the hierarchies match on import

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -194,6 +194,15 @@ namespace FbxExporters
                 }
             }
 
+            /// <summary>
+            /// Sets up the imported GameObject to match the original.
+            /// - Updates the name to be the same as original (i.e. remove the "(Clone)")
+            /// - Moves the imported object to the correct position in the hierarchy
+            /// - Updates the transform of the imported GameObject to match the original
+            /// - Copy over missing components and component values
+            /// </summary>
+            /// <param name="orig">Original GameObject.</param>
+            /// <param name="imported">Imported GameObject.</param>
             private static void SetupImportedGameObject(GameObject orig, GameObject imported)
             {
                 Transform importedTransform = imported.transform;


### PR DESCRIPTION
Make the names unique before exporting, then on import set the sibling index based on the object name.

This shouldn't cause too much of a problem as we delete the old non-fbx GameObjects, and Unity renames non-unique names in FBX files on import anyway.