### PR TITLE
UNI-21917 - fix 'convert to model' in GameObject menu

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -54,9 +54,12 @@ namespace FbxExporters
             static void OnContextItem (MenuCommand command)
             {
                 if (command == null || command.context == null) {
-                    Debug.LogError ("Error: No GameObject selected");
+                    // We were actually invoked from the top GameObject menu,
+                    // not the context menu, so treat it as such.
+                    OnMenuItem();
                     return;
                 }
+
                 GameObject selected = command.context as GameObject;
                 if (selected == null) {
                     Debug.LogError (string.Format("Error: {0} is not a GameObject and cannot be converted", command.context.name));


### PR DESCRIPTION
Doesn't seem like you can have an option show up only in the context menu for a
gameobject without also showing up in the gameobject menu. So I just made the
gameobject menu option work exactly like the assets menu option does.