### PR TITLE
Fix (hopefully) bugs in windows path names.

### DIFF
--- a/Assets/FbxExporters/Editor/UnitTests/ExportPerformanceTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/ExportPerformanceTest.cs
@@ -62,7 +62,7 @@ namespace FbxExporters.UnitTests
         {
             Assert.IsNotNull (m_toExport);
 
-            var filename = GetRandomFileNamePath();
+            var filename = GetRandomFbxFilePath();
 
             UnityEngine.Debug.unityLogger.logEnabled = false;
 

--- a/Assets/FbxExporters/Editor/UnitTests/ExporterTestBase.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/ExporterTestBase.cs
@@ -37,8 +37,11 @@ namespace FbxExporters.UnitTests
 
         private string MakeFileName(string baseName = null, string prefixName = null, string extName = null)
         {
-            if (baseName==null)
-                baseName = Path.GetRandomFileName();
+            if (baseName==null) {
+                // GetRandomFileName makes a random 8.3 filename
+                // We don't want the extension.
+                baseName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
+            }
 
             if (prefixName==null)
                 prefixName = this.fileNamePrefix;
@@ -49,7 +52,31 @@ namespace FbxExporters.UnitTests
             return prefixName + baseName + extName;
         }
 
-        protected string GetRandomFileNamePath(string pathName = null, string prefixName = null, string extName = null)
+        /// <summary>
+        /// Create a random path for a file.
+        ///
+        /// By default the pathName is null, which defaults to a particular
+        /// folder in the Assets folder that will be deleted on termination of
+        /// this test.
+        ///
+        /// By default the prefix is a fixed string. You can set it differently if you care.
+        ///
+        /// By default the extension is ".fbx". You can set it differently if you care.
+        ///
+        /// By default we use platform path separators. If you want a random
+        /// asset path e.g. for AssetDatabase.LoadMainAssetAtPath or for
+        /// PrefabUtility.CreatePrefab, you need to use the '/' as separator
+        /// (even on windows).
+        ///
+        /// See also convenience functions like:
+        ///     GetRandomPrefabAssetPath()
+        ///     GetRandomFbxFilePath()
+        /// </summary>
+        protected string GetRandomFileNamePath(
+                string pathName = null,
+                string prefixName = null,
+                string extName = null,
+                bool unityPathSeparator = false)
         {
             string temp;
 
@@ -60,10 +87,30 @@ namespace FbxExporters.UnitTests
             // repeat until you find a file that does not already exist
             do {
                 temp = Path.Combine (pathName, MakeFileName(prefixName: prefixName, extName: extName));
-
             } while(File.Exists (temp));
 
+            // Unity asset paths need a slash on all platforms.
+            if (unityPathSeparator) {
+                temp = temp.Replace('\\', '/');
+            }
+
             return temp;
+        }
+
+        /// <summary>
+        /// Return a random .fbx path that you can use in
+        /// the File APIs.
+        /// </summary>
+        protected string GetRandomFbxFilePath() {
+            return GetRandomFileNamePath(extName: ".fbx", unityPathSeparator: false);
+        }
+
+        /// <summary>
+        /// Return a random .prefab path that you can use in
+        /// PrefabUtility.CreatePrefab.
+        /// </summary>
+        protected string GetRandomPrefabAssetPath() {
+            return GetRandomFileNamePath(extName: ".prefab", unityPathSeparator: true);
         }
 
         /// <summary>

--- a/Assets/FbxExporters/Editor/UnitTests/FbxPrefabAutoUpdaterTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/FbxPrefabAutoUpdaterTest.cs
@@ -7,11 +7,9 @@
 
 using UnityEngine;
 using UnityEditor;
-using UnityEngine.TestTools;
 using NUnit.Framework;
 using System.IO;
 using System.Collections.Generic;
-using FbxSdk;
 
 namespace FbxExporters.UnitTests
 {
@@ -37,7 +35,7 @@ namespace FbxExporters.UnitTests
             // Delete the object right away (don't even wait for term).
             var fbxInstance = PrefabUtility.InstantiatePrefab(m_fbx) as GameObject;
             fbxInstance.AddComponent<FbxPrefab>().SetSourceModel(m_fbx);
-            m_prefabPath = GetRandomFileNamePath(extName: ".prefab");
+            m_prefabPath = GetRandomPrefabAssetPath();
             m_prefab = PrefabUtility.CreatePrefab(m_prefabPath, fbxInstance);
             AssetDatabase.Refresh ();
             Assert.AreEqual(m_prefabPath, AssetDatabase.GetAssetPath(m_prefab));
@@ -110,8 +108,8 @@ namespace FbxExporters.PerformanceTests {
             //
             // Then modify one fbx model. Shouldn't take longer than 1s.
             var hierarchy = CreateGameObject("the_root");
-            var baseName = GetRandomFileNamePath(extName: "");
-            FbxExporters.Editor.ModelExporter.ExportObject(baseName + ".fbx", hierarchy);
+            var baseName = GetRandomFbxFilePath();
+            FbxExporters.Editor.ModelExporter.ExportObject(baseName, hierarchy);
 
             // Create N fbx models by copying files. Import them all at once.
             var names = new string[n];
@@ -119,8 +117,8 @@ namespace FbxExporters.PerformanceTests {
             stopwatch.Reset();
             stopwatch.Start();
             for(int i = 1; i < n; ++i) {
-                names[i] = GetRandomFileNamePath(extName : "");
-                System.IO.File.Copy(names[0] + ".fbx", names[i] + ".fbx");
+                names[i] = GetRandomFbxFilePath();
+                System.IO.File.Copy(names[0], names[i]);
             }
             Debug.Log("Created fbx files in " + stopwatch.ElapsedMilliseconds);
 
@@ -136,7 +134,7 @@ namespace FbxExporters.PerformanceTests {
             stopwatch.Start();
             var fbxFiles = new GameObject[n / 2];
             for(int i = 0; i < n / 2; ++i) {
-                fbxFiles[i] = AssetDatabase.LoadMainAssetAtPath(names[i] + ".fbx") as GameObject;
+                fbxFiles[i] = AssetDatabase.LoadMainAssetAtPath(names[i]) as GameObject;
                 Assert.IsTrue(fbxFiles[i]);
             }
             Debug.Log("Loaded fbx files in " + stopwatch.ElapsedMilliseconds);
@@ -148,7 +146,7 @@ namespace FbxExporters.PerformanceTests {
                 Assert.IsTrue(instance);
                 var fbxPrefab = instance.AddComponent<FbxPrefab>();
                 fbxPrefab.SetSourceModel(fbxFiles[i]);
-                UnityEditor.PrefabUtility.CreatePrefab(names[i] + ".prefab", fbxFiles[i]);
+                PrefabUtility.CreatePrefab(GetRandomPrefabAssetPath(), fbxFiles[i]);
             }
             Debug.Log("Created prefabs in " + stopwatch.ElapsedMilliseconds);
 
@@ -156,12 +154,13 @@ namespace FbxExporters.PerformanceTests {
             // Make sure we're timing just the assetdatabase refresh by
             // creating a file and then copying it, and not the FbxExporter.
             var newHierarchy = CreateHierarchy();
-            FbxExporters.Editor.ModelExporter.ExportObject(names[0] + "_new.fbx", newHierarchy);
+            var newHierarchyName = GetRandomFbxFilePath();
+            FbxExporters.Editor.ModelExporter.ExportObject(newHierarchyName, newHierarchy);
             try {
                 UnityEngine.Debug.unityLogger.logEnabled = false;
                 stopwatch.Reset ();
                 stopwatch.Start ();
-                File.Copy(names[0] + "_new.fbx", names[0] + ".fbx", overwrite: true);
+                File.Copy(newHierarchyName, names[0], overwrite: true);
                 AssetDatabase.Refresh(); // force the update right now.
             } finally {
                 UnityEngine.Debug.unityLogger.logEnabled = true;
@@ -169,13 +168,13 @@ namespace FbxExporters.PerformanceTests {
             Debug.Log("Import (one change) in " + stopwatch.ElapsedMilliseconds);
             Assert.LessOrEqual(stopwatch.ElapsedMilliseconds, NoUpdateTimeLimit);
 
-            // Try what happens when nothing gets updated.
+            // Try what happens when no prefab gets updated.
             try {
                 UnityEngine.Debug.unityLogger.logEnabled = false;
                 stopwatch.Reset ();
                 stopwatch.Start ();
-                string newHierarchyFbxFile = GetRandomFileNamePath(extName : ".fbx");
-                File.Copy(names[0] + ".fbx", newHierarchyFbxFile);
+                string newHierarchyFbxFile = GetRandomFbxFilePath();
+                File.Copy(names[0], newHierarchyFbxFile);
                 AssetDatabase.Refresh(); // force the update right now.
             } finally {
                 UnityEngine.Debug.unityLogger.logEnabled = true;

--- a/Assets/FbxExporters/Editor/UnitTests/FbxPrefabTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/FbxPrefabTest.cs
@@ -35,7 +35,7 @@ namespace FbxExporters.UnitTests
             // Convert it to FBX. The asset file will be deleted automatically
             // on termination.
             var fbxAsset = FbxExporters.Editor.ModelExporter.ExportObject(
-                    GetRandomFileNamePath(), m_original);
+                    GetRandomFbxFilePath(), m_original);
             m_source = AssetDatabase.LoadMainAssetAtPath(fbxAsset) as GameObject;
             Assert.IsTrue(m_source);
 
@@ -46,7 +46,7 @@ namespace FbxExporters.UnitTests
                 fbxPrefab.SetSourceModel(m_source);
                 fbxPrefab.SetAutoUpdate(true);
                 m_autoPrefab = PrefabUtility.CreatePrefab(
-                        GetRandomFileNamePath(extName: ".prefab"),
+                        GetRandomPrefabAssetPath(),
                         prefabInstance);
             }
 
@@ -57,7 +57,7 @@ namespace FbxExporters.UnitTests
                 fbxPrefab.SetSourceModel(m_source);
                 fbxPrefab.SetAutoUpdate(false);
                 m_manualPrefab = PrefabUtility.CreatePrefab(
-                        GetRandomFileNamePath(extName: ".prefab"),
+                        GetRandomPrefabAssetPath(),
                         prefabInstance);
             }
         }
@@ -148,7 +148,7 @@ namespace FbxExporters.UnitTests
             // (but is a totally different file). This will cause an update
             // immediately.
             var fbxAsset = FbxExporters.Editor.ModelExporter.ExportObject(
-                    GetRandomFileNamePath(), m_original);
+                    GetRandomFbxFilePath(), m_original);
             var newSource = AssetDatabase.LoadMainAssetAtPath(fbxAsset) as GameObject;
             Assert.IsTrue(newSource);
             manualPrefabComponent.SetSourceModel(newSource);


### PR DESCRIPTION
UNI-23198

Use GetRandomFbxFilePath() or GetRandomPrefabAssetPath() to make sure to get
the right path on all platforms.

This fix makes the unit tests compile, and it makes them pass on windows (I think).