### PR TITLE
(test) show only game window with batchmode

### DIFF
--- a/Assets/FbxExporters/Editor/OpenGameWindow.cs
+++ b/Assets/FbxExporters/Editor/OpenGameWindow.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OpenGameWindow {
+
+    public static void Open(){
+        FbxExporters.Review.TurnTable.GetMainGameView ();
+    }
+}


### PR DESCRIPTION
added script that opens game window. if run from command line with batchmode, then only the Game window will be visible, but it will not be possible to interact with it and close it.

To run:
```
%UNITY3D_PATH% -batchmode -projectPath "%PROJECT_PATH%" -executeMethod OpenGameWindow.Open
```

Actually if you just run the last saved model function, that will work also (and show the turn table anim and everything):
```
%UNITY3D_PATH% -batchmode -projectPath "%PROJECT_PATH%" -executeMethod FbxExporters.Review.TurnTable.LastSavedModel
```

Note: it looks like mouse move and mouse drag events can be caught easily.