### PR TITLE
Uni 22019 working scene remembers what to publish

### DIFF
--- a/Assets/Integrations/Autodesk/maya2017/scripts/unityOneClick/commands.py
+++ b/Assets/Integrations/Autodesk/maya2017/scripts/unityOneClick/commands.py
@@ -98,11 +98,7 @@ class importCmd(BaseCommand):
         
         # Get or create the Unity Fbx Export Set
         allSets = maya.cmds.listSets(allSets=True)
-        if self._exportSet in allSets:
-            if maya.cmds.sets(self._exportSet, size=True, q=True) > 0:
-                self.displayDebug('Set {0} is not empty, cannot update'.format(self._exportSet))
-                return
-        else:
+        if not self._exportSet in allSets:
             # couldn't find export set so create it
             maya.cmds.sets(name=self._exportSet)
         


### PR DESCRIPTION
Create an export set containing everything in the FBX file. 

(After conversation with Julien) If multiple FBX files are loaded with the Unity tool, then they should be added to the same export set as well, and when we publish everything gets published to the first FBX file's location.