### PR TITLE
UNI-23805 ensure that the export path setting browser always opens to a valid path

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -54,6 +54,13 @@ namespace FbxExporters.EditorTools {
 
             if (GUILayout.Button ("Browse", EditorStyles.miniButton, GUILayout.Width (BrowseButtonWidth))) {
                 string initialPath = ExportSettings.GetAbsoluteSavePath();
+
+                // if the directory doesn't exist, set it to the default save path
+                // so we don't open somewhere unexpected
+                if (!System.IO.Directory.Exists (initialPath)) {
+                    initialPath = Application.dataPath;
+                }
+
                 string fullPath = EditorUtility.OpenFolderPanel (
                         "Select Model Prefabs Path", initialPath, null
                         );
@@ -99,7 +106,7 @@ namespace FbxExporters.EditorTools {
     [FilePath("ProjectSettings/FbxExportSettings.asset",FilePathAttribute.Location.ProjectFolder)]
     public class ExportSettings : ScriptableSingleton<ExportSettings>
     {
-        public const string kDefaultSavePath = "Objects";
+        public const string kDefaultSavePath = ".";
 
         // Note: default values are set in LoadDefaults().
         public bool weldVertices;


### PR DESCRIPTION
Also, default to a path that we know exists (the Asset root)