### PR TITLE
uni-24487 Fix unit test.

### DIFF
--- a/Assets/FbxExporters/Editor/UnitTests/FbxExportSettingsTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/FbxExportSettingsTest.cs
@@ -165,7 +165,7 @@ namespace FbxExporters.UnitTests
                     Path.DirectorySeparatorChar);
 
             var defaultAbsolutePath = ExportSettings.GetAbsoluteSavePath();
-            var dataPath = Path.Combine(appDataPath, ExportSettings.kDefaultSavePath);
+            var dataPath = Path.GetFullPath(Path.Combine(appDataPath, ExportSettings.kDefaultSavePath));
             Assert.AreEqual(dataPath, defaultAbsolutePath);
 
             // set; check that the saved value is platform-independent,


### PR DESCRIPTION
It was failing with the new default of '.' because the expected path wasn't
cleaned up.