### PR TITLE
uni-24384: fix selection being wrong after convert to model

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -157,7 +157,7 @@ namespace FbxExporters
                                     prefabFileName, fbxFileName));
                     }
                     // Connect to the prefab file.
-                    PrefabUtility.ConnectGameObjectToPrefab(unityGO, prefab);
+                    unityGO = PrefabUtility.ConnectGameObjectToPrefab(unityGO, prefab);
 
                     // Remove (now redundant) gameobject
                     if (!keepOriginal) {


### PR DESCRIPTION
The GameObjects we were returning were wrong. Seems connecting to a prefab
breaks the link.