### PR TITLE
UNI-24379: don't even try to support skinning for now

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -356,6 +356,15 @@ namespace FbxExporters
             public static void CopyComponents(GameObject from, GameObject to){
                 var originalComponents = new List<Component>(to.GetComponents<Component> ());
                 foreach(var component in from.GetComponents<Component> ()) {
+                    // UNI-24379: we don't support SkinnedMeshRenderer right
+                    // now: we just bake the mesh into its current pose. So
+                    // don't copy the SMR over. There will already be a
+                    // MeshFilter and MeshRenderer due to the static mesh.
+                    // Remove this code when we support skinning.
+                    if (component is SkinnedMeshRenderer) {
+                        continue;
+                    }
+
                     var json = EditorJsonUtility.ToJson(component);
 
                     System.Type expectedType = component.GetType();

--- a/Assets/FbxExporters/Editor/UnitTests/ConvertToModelTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/ConvertToModelTest.cs
@@ -177,5 +177,30 @@ namespace FbxExporters.UnitTests
                     directoryFullPath: path, keepOriginal: false);
             Assert.That(cubePrefabInstance2.GetComponents<FbxPrefab>().Length, Is.EqualTo(1));
         }
+
+        [Test]
+        public void SkinnedMeshTest()
+        {
+            // UNI-24379: in the first release, the plugin only handles static
+            // meshes, not skinned meshes. Rewrite this test when we add that
+            // feature.
+
+            // Create a cube with a bogus skinned-mesh rather than a static
+            // mesh setup.
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.AddComponent<SkinnedMeshRenderer>();
+            var meshFilter = cube.GetComponent<MeshFilter>();
+            var meshRender = cube.GetComponent<MeshRenderer>();
+            Object.DestroyImmediate(meshRender);
+            Object.DestroyImmediate(meshFilter);
+
+            // Convert it. Make sure it gets deleted, to avoid a useless error about internal consistency.
+            var cubeInstance = ConvertToModel.Convert(cube, fbxFullPath: GetRandomFbxFilePath());
+            if (cube) { Object.DestroyImmediate(cube); }
+
+            // Make sure it doesn't have a skinned mesh renderer on it.
+            // In the future we'll want to assert the opposite!
+            Assert.That(cubeInstance.GetComponentsInChildren<SkinnedMeshRenderer>(), Is.Empty);
+        }
     }
 }


### PR DESCRIPTION
There was a bug with a SkinnedMeshRenderer popping up alongside a MeshFilter /
MeshRenderer. That's because we bake the mesh pose when we convert: we don't
set up bone weights and so on. Eventually we'll change that, but for now, just
don't apply the skinned-mesh renderer.