### PR TITLE
Uni 27028 error adding vfx component

### DIFF
--- a/Assets/FbxExporters/Editor/ConvertToModel.cs
+++ b/Assets/FbxExporters/Editor/ConvertToModel.cs
@@ -400,6 +400,10 @@ namespace FbxExporters
                     }
 
                     var json = EditorJsonUtility.ToJson(component);
+                    if (string.IsNullOrEmpty (json)) {
+                        // this happens for missing scripts
+                        continue;
+                    }
 
                     System.Type expectedType = component.GetType();
                     Component toComponent = null;


### PR DESCRIPTION
Adding a particle system component automatically adds a particle system renderer component. Since CopyComponents adds this first, then tries to add the particle system renderer, we get an error that we cannot add this component again.
Fix is to check if the component gets added properly, and only then try to copy over the values.

Also fix an issue with copying missing scripts onto the Fbx Prefab.