### PR TITLE
Uni-23220 fix tooltip in FBXPrefab

### DIFF
--- a/Assets/FbxExporters/Editor/FbxPrefabInspector.cs
+++ b/Assets/FbxExporters/Editor/FbxPrefabInspector.cs
@@ -18,7 +18,7 @@ namespace FbxExporters.EditorTools {
 
             var fbxPrefabUtility = new FbxPrefabAutoUpdater.FbxPrefabUtility (fbxPrefab);
             var oldFbxAsset = fbxPrefabUtility.GetFbxAsset();
-            var newFbxAsset = EditorGUILayout.ObjectField(new GUIContent("Source Fbx Asset", "Which FBX file does this refer to?"), oldFbxAsset,
+            var newFbxAsset = EditorGUILayout.ObjectField(new GUIContent("Source Fbx Asset", "The FBX file that is linked to this Prefab"), oldFbxAsset,
                     typeof(GameObject), allowSceneObjects: false) as GameObject;
             if (newFbxAsset && !AssetDatabase.GetAssetPath(newFbxAsset).EndsWith(".fbx")) {
                 Debug.LogError("FbxPrefab must point to an Fbx asset (or none).");


### PR DESCRIPTION
So there IS a tooltip in there already, but apparently the SerializedField.Tooltip function is broken, and is a known bug which has not been fixed by unity. ([source](https://forum.unity.com/threads/serializedproperty-tooltip-not-working.454076/))

I just attached the existing tooltip to the label instead of the field itself.