### PR TITLE
Uni-31021 support for multiple vendor locations

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -111,7 +111,7 @@ namespace FbxExporters.EditorTools {
                     throw new System.NotImplementedException ();
                 }
 
-                string dccPath = EditorUtility.OpenFilePanel ("Select Digital Content Creation Application", ExportSettings.DCCVendorLocations[0], ext);
+                string dccPath = EditorUtility.OpenFilePanel ("Select Digital Content Creation Application", ExportSettings.GetFirstValidVendorLocation(), ext);
 
                 // check that the path is valid and references the maya executable
                 if (!string.IsNullOrEmpty (dccPath)) {
@@ -509,6 +509,25 @@ namespace FbxExporters.EditorTools {
                 }
             }
             instance.selectedDCCApp = instance.GetPreferredDCCApp();
+        }
+
+        /// <summary>
+        /// Returns the first valid folder in our list of vendor locations
+        /// </summary>
+        /// <returns>The first valid vendor location</returns>
+        public static string GetFirstValidVendorLocation()
+        {
+            string[] locations = DCCVendorLocations;
+            for (int i = 0; i < locations.Length; i++)
+            {
+                //Look through the list of locations we have and take the first valid one
+                if (Directory.Exists(locations[i]))
+                {
+                    return locations[i];
+                }
+            }
+            //if no valid locations exist, just take us to the project folder
+            return Directory.GetCurrentDirectory();
         }
 
         /// <summary>


### PR DESCRIPTION
we now search the C:/Program Files/Autodesk and D:/Program Files/Autodesk for 3D applications.

In addition, you can set the appropriate environment variable (UNITY_FBX_3DAPP_VENDOR_LOCATIONS) in order to get a program from specified places (it takes a string array of paths). if none of the given paths exist, or if the variable is undefined, we will check the default locations.