### PR TITLE
UNI-31736 fix export settings error when updating package

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -762,8 +762,7 @@ namespace FbxExporters.EditorTools {
         public static string GetIntegrationSavePath()
         {
             //If the save path gets messed up and ends up not being valid, just use the project folder as the default
-            if (instance.IntegrationSavePath == null || 
-                string.IsNullOrEmpty(instance.IntegrationSavePath.Trim()) ||
+            if (string.IsNullOrEmpty(instance.IntegrationSavePath) ||
                 !Directory.Exists(instance.IntegrationSavePath))
             {
                 //The project folder, above the asset folder


### PR DESCRIPTION
missing null check on untrimmed integrationSavePath was causing NullReferenceException as older settings did not have this variable