### PR TITLE
UNI-30754 ignore missing components on prefab update

### DIFF
--- a/Assets/FbxExporters/Editor/FbxPrefabAutoUpdater.cs
+++ b/Assets/FbxExporters/Editor/FbxPrefabAutoUpdater.cs
@@ -306,6 +306,9 @@ namespace FbxExporters
                         m_children.Add(child.name, new FbxRepresentation(child, isRoot: false));
                     }
                     foreach(var component in xfo.GetComponents<Component>()) {
+                        // ignore missing components
+                        if (component == null) { continue; }
+
                         // Don't save the prefab link, to avoid a logic loop.
                         if (component is FbxPrefab) { continue; }
 
@@ -759,6 +762,10 @@ namespace FbxExporters
                         componentTypes[componentType.ToString()] = componentType;
                     }
                     foreach(var component in prefab.GetComponentsInChildren<Component>()) {
+                        // ignore missing components
+                        if (component == null) {
+                            continue;
+                        }
                         var componentType = component.GetType();
                         componentTypes[componentType.ToString()] = componentType;
                     }


### PR DESCRIPTION
missing components were causing errors on prefab update.

Still have an issue with the prefab instance not updating in the scene if it has a missing component. Not sure what to do about that as it seems to be a Unity issue, and there is no easy way to delete missing components through script.