### PR TITLE
UNI-31660 avoid changing dcc app selection before list is modified

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -602,7 +602,7 @@ namespace FbxExporters.EditorTools {
             }
 
             // store the selected app
-            var currentSelection = instance.dccOptionPaths[instance.selectedDCCApp];
+            var prevSelection = instance.dccOptionPaths[instance.selectedDCCApp];
 
             // remove options that no longer exist
             List<string> pathsToDelete = new List<string>();
@@ -622,7 +622,7 @@ namespace FbxExporters.EditorTools {
             }
 
             // set the selected DCC app to the previous selection
-            instance.selectedDCCApp = instance.dccOptionPaths.IndexOf (currentSelection);
+            instance.selectedDCCApp = instance.dccOptionPaths.IndexOf (prevSelection);
             if (instance.selectedDCCApp < 0) {
                 // find preferred app if previous selection no longer exists
                 instance.selectedDCCApp = instance.GetPreferredDCCApp ();


### PR DESCRIPTION
- no point changing the index selected before the items are actually
removed from  the list because the indices are still changing.
- try to set the value to the previous selection if it is still in the
list, otherwise get the preferred app