### PR TITLE
UNI-32051 fix camera exporting with 90 degree rotation

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -839,6 +839,11 @@ namespace FbxExporters
 
                 fbxNode.SetNodeAttribute (fbxCamera);
 
+                // set +90 post rotation to counteract for FBX camera's facing +X direction by default
+                fbxNode.SetPostRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(0,90,0));
+                // have to set rotation active to true in order for post rotation to be applied
+                fbxNode.SetRotationActive (true);
+
                 // make the last camera exported the default camera
                 DefaultCamera = fbxNode.GetName ();
 


### PR DESCRIPTION
set post rotation to 90 along y for camera nodes in order to adjust for different default camera direction in fbx