### PR TITLE
UNI-32785 fix inconsistent camera unit test

### DIFF
--- a/Assets/FbxExporters/Editor/UnitTests/ModelExporterTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/ModelExporterTest.cs
@@ -349,6 +349,7 @@ namespace FbxExporters.UnitTests
             camera.nearClipPlane = 19;
             camera.farClipPlane = 500.6f;
 
+            filename = GetRandomFbxFilePath (); // export to a different file
             fbxCamera = ExportCamera (filename, cameraObj);
             CompareCameraValues (camera, fbxCamera);
             Assert.AreEqual (camera.orthographicSize, fbxCamera.orthographicSize);


### PR DESCRIPTION
save second camera to a new file instead of reusing the first file path.