### PR TITLE
UNI-32730 refresh asset database in between deleting/copying

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -1318,6 +1318,9 @@ namespace FbxExporters
                 } catch (IOException) {
                 }
 
+                // refresh the database so Unity knows the file's been deleted
+                AssetDatabase.Refresh();
+
                 if (File.Exists (m_lastFilePath)) {
                     Debug.LogWarning ("Failed to delete file: " + m_lastFilePath);
                 }

--- a/Assets/FbxExporters/Editor/UnitTests/FbxPrefabTest.cs
+++ b/Assets/FbxExporters/Editor/UnitTests/FbxPrefabTest.cs
@@ -425,10 +425,16 @@ namespace FbxExporters.UnitTests
             var newCopyPath = ModelExporter.ExportObject(
                 GetRandomFbxFilePath(), root);
             SleepForFileTimestamp();
+
+            var destFile = new FbxPrefabAutoUpdater.FbxPrefabUtility (original.GetComponent<FbxPrefab> ()).GetFbxAssetPath ();
+            if (System.IO.File.Exists (destFile)) {
+                System.IO.File.Delete (destFile);
+            }
+            AssetDatabase.Refresh ();
             System.IO.File.Copy(
                 newCopyPath,
-                new FbxPrefabAutoUpdater.FbxPrefabUtility(original.GetComponent<FbxPrefab>()).GetFbxAssetPath(),
-                overwrite: true);
+                destFile,
+                overwrite: false);
             AssetDatabase.Refresh();
 
             // Make sure the update took.


### PR DESCRIPTION
-Otherwise AssetDatabase tries to get the old (deleted) object and
throws an error