### PR TITLE
UNI-33083 fix threejs import vertex color error

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -1512,7 +1512,7 @@ namespace FbxExporters
                 }
 
                 public bool HasValidNormals(){
-                    return Normals != null && Normals.Length >= 0;
+                    return Normals != null && Normals.Length > 0;
                 }
 
                 public bool HasValidBinormals(){
@@ -1520,11 +1520,11 @@ namespace FbxExporters
                 }
 
                 public bool HasValidTangents(){
-                    return Tangents != null && Tangents.Length >= 0;
+                    return Tangents != null && Tangents.Length > 0;
                 }
 
                 public bool HasValidVertexColors(){
-                    return VertexColors != null && VertexColors.Length >= 0;
+                    return VertexColors != null && VertexColors.Length > 0;
                 }
             }
 


### PR DESCRIPTION
make sure vertex colors don't get exported if array is 0 length. same for normals and tangents