### PR TITLE
UNI-35928 fix exported frame rate

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -1829,7 +1829,8 @@ namespace FbxExporters
                 if (timeMode == FbxTime.EMode.eCustom) {
                     timeMode = FbxTime.EMode.eFrames30;
                 }
-                FbxTime.SetGlobalTimeMode (timeMode);
+
+                fbxScene.GetGlobalSettings ().SetTimeMode (timeMode);
 
                 // set time correctly
                 var fbxStartTime = FbxTime.FromSecondDouble (0);


### PR DESCRIPTION
set time mode using global settings instead of fbx time.


[FbxSdk_exportFPS.zip](https://github.com/Unity-Technologies/FbxExporters/files/1674555/FbxSdk_exportFPS.zip)
