### PR TITLE
Uni 32843 allow multi file import maya

### DIFF
--- a/Assets/Integrations/Autodesk/maya/scripts/unityCommands.mel
+++ b/Assets/Integrations/Autodesk/maya/scripts/unityCommands.mel
@@ -120,23 +120,6 @@ proc importFile(string $filePathStr){
     
     if ((!$isAnimFile || ($isAnimFile && $setCreated)) && $tempPath != ""){
         storeAttribute($unityExportSet, $UnityFbxFilePathAttr, $tempPath);
-        
-        // Change Unity project if fbx is from a different Unity project.
-        // Get the project based on the folder structure (i.e. folder above Assets)
-        $head = dirname($tempPath);
-        $tail = basename($tempPath, "");
-        // Check that we are not at the root directory.
-        // dirname($head) returns the last directory name in the path, 
-        // or head if head is the root directory.
-        while ($head != "" && dirname($head) != $head){
-            if (`strcmp $tail "Assets"` == 0){
-                // this is a valid Unity project, so set it
-                optionVar -sv "UnityProject" $head;
-                break;
-            }
-            $head = dirname($head);
-            $tail = basename($head, "");
-        }
     }
     
     if ((!$isAnimFile || ($isAnimFile && $setCreated)) && $tempName != ""){
@@ -213,6 +196,24 @@ global proc unityImport(){
     for($i=0; $i<size($filePaths); ++$i){
         $filePathStr = $filePaths[$i];
         importFile($filePathStr);
+    }
+    
+    $tempPath = dirname($filePaths[0]);
+    // Change Unity project if fbx is from a different Unity project.
+    // Get the project based on the folder structure (i.e. folder above Assets)
+    $head = dirname($tempPath);
+    $tail = basename($tempPath, "");
+    // Check that we are not at the root directory.
+    // dirname($head) returns the last directory name in the path, 
+    // or head if head is the root directory.
+    while ($head != "" && dirname($head) != $head){
+        if (`strcmp $tail "Assets"` == 0){
+            // this is a valid Unity project, so set it
+            optionVar -sv "UnityProject" $head;
+            break;
+        }
+        $head = dirname($head);
+        $tail = basename($head, "");
     }
 }
 


### PR DESCRIPTION
Support selecting multiple files on import.

On importing the files, a new selection set will be created per file imported

If a filename contains the "@" symbol, then it will be treated as an animation file and imported onto the model that already exists in the scene with 2 additional attributes added to the export set (anim path + anim name). If no model exists then it will be treated similar to a model file.