### PR TITLE
Uni-37712-make-verbose-fbxexportsetting2

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExportSettings.cs
+++ b/Assets/FbxExporters/Editor/FbxExportSettings.cs
@@ -289,6 +289,8 @@ namespace FbxExporters.EditorTools {
         public const string kMayaOptionName = "Maya ";
         public const string kMayaLtOptionName = "Maya LT";
 
+        public bool Verbose = false;
+
         private static string DefaultIntegrationSavePath {
             get{
                 return Path.GetDirectoryName(Application.dataPath);

--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -3480,7 +3480,7 @@ namespace FbxExporters
             {
             }
 
-            public bool Verbose { private set {;} get { return false; } }
+            public bool Verbose { private set {;} get { return EditorTools.ExportSettings.instance.Verbose; } }
 
             /// <summary>
             /// manage the selection of a filename


### PR DESCRIPTION
Add the Verbose option to the FbxExporterSettings so that I can turn in on in a release build if required e.g. debugging.

NOTE: checkin contains only these changes.
