### PR TITLE
UNI-39999 make sure set name doesn't contain invalid chars

### DIFF
--- a/Assets/Integrations/Autodesk/maya/scripts/unityCommands.mel
+++ b/Assets/Integrations/Autodesk/maya/scripts/unityCommands.mel
@@ -129,7 +129,7 @@ proc string checkNamespaceNeedsUpdate(string $unitySet, string $unityFbxNamespac
     return $unityFbxNamespace;
 }
 
-global proc string getMayaValidName(string $input)
+global proc string formValidObjectName(string $input)
 {
     string $output = "";
     for ($n = 1 ; $n < size($input)+1 ; $n++)
@@ -173,7 +173,7 @@ proc importFile(string $filePathStr){
         
         $fileNameWithoutExt = match("[^@]+", $fileNameWithoutExt);
     }
-    $fileNameWithoutExt = getMayaValidName($fileNameWithoutExt);
+    $fileNameWithoutExt = formValidObjectName($fileNameWithoutExt);
     
     $unityExportSet = `format -stringArg $fileNameWithoutExt $UnityExportSetNameFormat`;
 


### PR DESCRIPTION
same for the namespace.

Since we use the filename for naming the set and namespace, have to make sure there are no invalid characters to avoid naming issues.