### PR TITLE
UNI-29415 fix so spot angle animates cone angle in Maya

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -1530,8 +1530,8 @@ namespace FbxExporters
                     Debug.Log ("Exporting animation for " + uniObj.ToString() + " (" + uniPropertyName + ")");
                 }
 
-                FbxPropertyChannelPair fbxPropertyChannelPair;
-                if (!FbxPropertyChannelPair.TryGetValue (uniPropertyName, out fbxPropertyChannelPair)) {
+                FbxPropertyChannelPair[] fbxPropertyChannelPairs;
+                if (!FbxPropertyChannelPair.TryGetValue (uniPropertyName, out fbxPropertyChannelPairs)) {
                     Debug.LogWarning (string.Format ("no mapping from Unity '{0}' to fbx property", uniPropertyName));
                     return;
                 }
@@ -1549,39 +1549,35 @@ namespace FbxExporters
                     return;
                 }
 
-                // map unity property name to fbx property
-                var fbxProperty = fbxNode.FindProperty(fbxPropertyChannelPair.Property, false);
-                if (!fbxProperty.IsValid())
-                {
-                    var fbxNodeAttribute = fbxNode.GetNodeAttribute();
-                    if (fbxNodeAttribute != null)
-                    {
-                        fbxProperty = fbxNodeAttribute.FindProperty(fbxPropertyChannelPair.Property, false);
+                foreach (var fbxPropertyChannelPair in fbxPropertyChannelPairs) {
+                    // map unity property name to fbx property
+                    var fbxProperty = fbxNode.FindProperty (fbxPropertyChannelPair.Property, false);
+                    if (!fbxProperty.IsValid ()) {
+                        var fbxNodeAttribute = fbxNode.GetNodeAttribute ();
+                        if (fbxNodeAttribute != null) {
+                            fbxProperty = fbxNodeAttribute.FindProperty (fbxPropertyChannelPair.Property, false);
+                        }
                     }
-                }
-                if (!fbxProperty.IsValid())
-                {
-                    Debug.LogError(string.Format("no fbx property {0} found on {1} node or nodeAttribute ", fbxPropertyChannelPair.Property, fbxNode.GetName()));
-                    return;
-                }
+                    if (!fbxProperty.IsValid ()) {
+                        Debug.LogError (string.Format ("no fbx property {0} found on {1} node or nodeAttribute ", fbxPropertyChannelPair.Property, fbxNode.GetName ()));
+                        return;
+                    }
 
-                // Create the AnimCurve on the channel
-                FbxAnimCurve fbxAnimCurve = fbxProperty.GetCurve (fbxAnimLayer, fbxPropertyChannelPair.Channel, true);
+                    // Create the AnimCurve on the channel
+                    FbxAnimCurve fbxAnimCurve = fbxProperty.GetCurve (fbxAnimLayer, fbxPropertyChannelPair.Channel, true);
 
-                // create a convert scene helper so that we can convert from Unity to Maya
-                // AxisSystem (LeftHanded to RightHanded) and FBX's default units 
-                // (Meters to Centimetres)
-                var convertSceneHelper = new UnityToMayaConvertSceneHelper (uniPropertyName);
+                    // create a convert scene helper so that we can convert from Unity to Maya
+                    // AxisSystem (LeftHanded to RightHanded) and FBX's default units 
+                    // (Meters to Centimetres)
+                    var convertSceneHelper = new UnityToMayaConvertSceneHelper (uniPropertyName);
 
-                // TODO: we'll resample the curve so we don't have to 
-                // configure tangents
-                if (ModelExporter.ExportSettings.BakeAnimation) 
-                {
-                    ExportAnimationSamples(uniAnimCurve, fbxAnimCurve, frameRate, convertSceneHelper);
-                }
-                else 
-                {
-                    ExportAnimationKeys(uniAnimCurve, fbxAnimCurve, convertSceneHelper);
+                    // TODO: we'll resample the curve so we don't have to 
+                    // configure tangents
+                    if (ModelExporter.ExportSettings.BakeAnimation) {
+                        ExportAnimationSamples (uniAnimCurve, fbxAnimCurve, frameRate, convertSceneHelper);
+                    } else {
+                        ExportAnimationKeys (uniAnimCurve, fbxAnimCurve, convertSceneHelper);
+                    }
                 }
             }
 
@@ -1636,75 +1632,78 @@ namespace FbxExporters
                 /// Map a Unity property name to the corresponding FBX property and
                 /// channel names.
                 /// </summary>
-                public static bool TryGetValue(string uniPropertyName, out FbxPropertyChannelPair prop)
+                public static bool TryGetValue(string uniPropertyName, out FbxPropertyChannelPair[] prop)
                 {
                     System.StringComparison ct = System.StringComparison.CurrentCulture;
 
                     // Transform Scaling
                     if (uniPropertyName.StartsWith ("m_LocalScale.x", ct) || uniPropertyName.EndsWith ("S.x", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_X);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_X) };
                         return true;
                     }
                     if (uniPropertyName.StartsWith ("m_LocalScale.y", ct) || uniPropertyName.EndsWith ("S.y", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_Y);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_Y) };
                         return true;
                     }
                     if (uniPropertyName.StartsWith ("m_LocalScale.z", ct) || uniPropertyName.EndsWith ("S.z", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_Z);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Scaling", Globals.FBXSDK_CURVENODE_COMPONENT_Z) };
                         return true;
                     }
 
                     // Transform Translation
                     if (uniPropertyName.StartsWith ("m_LocalPosition.x", ct) || uniPropertyName.EndsWith ("T.x", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_X);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_X) };
                         return true;
                     }
                     if (uniPropertyName.StartsWith ("m_LocalPosition.y", ct) || uniPropertyName.EndsWith ("T.y", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_Y);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_Y) };
                         return true;
                     }
                     if (uniPropertyName.StartsWith ("m_LocalPosition.z", ct) || uniPropertyName.EndsWith ("T.z", ct)) {
-                        prop = new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_Z);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Lcl Translation", Globals.FBXSDK_CURVENODE_COMPONENT_Z) };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("m_Intensity", ct))
                     {
-                        prop = new FbxPropertyChannelPair ("Intensity", null);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Intensity", null) };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("m_SpotAngle", ct))
                     {
-                        prop = new FbxPropertyChannelPair ("OuterAngle", null);
+                        prop = new FbxPropertyChannelPair[]{ 
+                            new FbxPropertyChannelPair ("OuterAngle", null),
+                            new FbxPropertyChannelPair ("InnerAngle", null)
+                        };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("m_Color.r", ct))
                     {
-                        prop = new FbxPropertyChannelPair ("Color", Globals.FBXSDK_CURVENODE_COLOR_RED);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair ("Color", Globals.FBXSDK_CURVENODE_COLOR_RED) };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("m_Color.g", ct))
                     {
-                        prop = new FbxPropertyChannelPair("Color", Globals.FBXSDK_CURVENODE_COLOR_GREEN);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair("Color", Globals.FBXSDK_CURVENODE_COLOR_GREEN) };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("m_Color.b", ct))
                     {
-                        prop = new FbxPropertyChannelPair("Color", Globals.FBXSDK_CURVENODE_COLOR_BLUE);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair("Color", Globals.FBXSDK_CURVENODE_COLOR_BLUE) };
                         return true;
                     }
 
                     if (uniPropertyName.StartsWith("field of view", ct))
                     {
-                        prop = new FbxPropertyChannelPair("FieldOfView", null);
+                        prop = new FbxPropertyChannelPair[]{ new FbxPropertyChannelPair("FieldOfView", null) };
                         return true;
                     }
 
-                    prop = new FbxPropertyChannelPair ();
+                    prop = new FbxPropertyChannelPair[]{};
                     return false;
                 }
             }


### PR DESCRIPTION
to animate cone angle in Maya, have to export animation on both inner and outer angle attributes, otherwise penumbra angle will be animated.

Allow a single Unity property to map to multiple fbx property channels for animation export.