### PR TITLE
UNI-39456 Motion T.* animated on timeline not exporting correctly

### DIFF
--- a/Assets/FbxExporters/Editor/FbxExporter.cs
+++ b/Assets/FbxExporters/Editor/FbxExporter.cs
@@ -1620,7 +1620,7 @@ namespace FbxExporters
                 {
                     System.StringComparison cc = System.StringComparison.CurrentCulture;
 
-                    bool partT = uniPropertyName.StartsWith ("m_LocalPosition.", cc);
+                    bool partT = uniPropertyName.StartsWith ("m_LocalPosition.", cc) || uniPropertyName.EndsWith("T.", cc);
                     bool partTx = uniPropertyName.EndsWith ("Position.x", cc) || uniPropertyName.EndsWith ("T.x", cc);
 
                     convertLtoR |= partTx;


### PR DESCRIPTION
handle case where Motion T.* is animated

Haven't been able to figure out how to animate Motion T instead of position again, so wasn't able to test if the fix worked.