### PR TITLE
UT-585 Fixing 2018.2 deprecated timeline code, breaks 2018.1

### DIFF
--- a/Assets/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
+++ b/Assets/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
@@ -3305,7 +3305,13 @@ namespace FbxExporters
 					object selClipItem = editorClipSelected.GetType().GetProperty("item").GetValue(editorClipSelected, null);
 					object selClipItemParentTrack = selClipItem.GetType().GetProperty("parentTrack").GetValue(selClipItem, null);
 					AnimationTrack editorClipAnimationTrack = selClipItemParentTrack as AnimationTrack;
-                    Object animationTrackObject = UnityEditor.Timeline.TimelineEditor.inspectedDirector.GetGenericBinding (editorClipAnimationTrack);
+
+#if UNITY_2018_2_OR_NEWER
+                    Object animationTrackObject = UnityEditor.Timeline.TimelineEditor.inspectedDirector.GetGenericBinding(editorClipAnimationTrack);
+#else // UNITY_2018_2_OR_NEWER
+                    Object animationTrackObject = UnityEditor.Timeline.TimelineEditor.playableDirector.GetGenericBinding(editorClipAnimationTrack);
+#endif // UNITY_2018_2_OR_NEWER
+
                     GameObject animationTrackGO = null;
                     if (animationTrackObject is GameObject)
                     {


### PR DESCRIPTION
* Now using a define to use UnityEditor.Timeline.TimelineEditor.inspectedDirector when the Unity version is >= 2018.2. Fallback to UnityEditor.Timeline.TimelineEditor.playableDirector for earlier versions
