### PR TITLE
UNI-47705 Clean-up of accessibility levels for the ModelExporter class (public->internal)

### DIFF
--- a/Assets/com.unity.formats.fbx.tests/DefaultSelectionTest.cs
+++ b/Assets/com.unity.formats.fbx.tests/DefaultSelectionTest.cs
@@ -107,7 +107,7 @@ namespace FbxExporters.UnitTests
 
             // test with centered objects
             m_centerObjectsSetting.SetObjectPosition(ExportSettings.ObjectPosition.LocalCentered);
-            var newCenter = FbxExporters.Editor.ModelExporter.FindCenter (goExportSet);
+            var newCenter = ModelExporterReflection.FindCenter (goExportSet);
 
             exportedRoot = ExportSelection (exportSet, m_centerObjectsSetting);
             children = new List<GameObject> ();
@@ -146,7 +146,7 @@ namespace FbxExporters.UnitTests
         /// <param name="center">New center for global transform.</param>
         private FbxAMatrix ConstructTRSMatrix (Transform t, bool local = true, Vector3 center = default(Vector3))
         {
-            var translation = local ? t.localPosition : FbxExporters.Editor.ModelExporter.GetRecenteredTranslation (t, center);
+            var translation = local ? t.localPosition : ModelExporterReflection.GetRecenteredTranslation (t, center);
             var rotation = local ? t.localEulerAngles : t.eulerAngles;
             var scale = local ? t.localScale : t.lossyScale;
             return new FbxAMatrix (

--- a/Assets/com.unity.formats.fbx.tests/ExportTimelineClipTest.cs
+++ b/Assets/com.unity.formats.fbx.tests/ExportTimelineClipTest.cs
@@ -32,7 +32,7 @@ namespace FbxExporters.UnitTests
                     // One file by animation clip
                     foreach (TimelineClip timeLineClip in at.GetClips()) {
                         var filePath = string.Format ("{0}/{1}@{2}", folderPath, atObject.name, "Recorded.fbx");
-                        ModelExporter.ExportSingleTimelineClip (timeLineClip, atObject, filePath);
+                        ModelExporterReflection.ExportSingleTimelineClip (timeLineClip, atObject, filePath);
                         FileAssert.Exists (filePath);
                     }
                 }
@@ -48,7 +48,7 @@ namespace FbxExporters.UnitTests
 
             foreach(GameObject obj in Selection.objects)
             {
-                ModelExporter.ExportAllTimelineClips(obj, folderPath);
+                ModelExporterReflection.ExportAllTimelineClips(obj, folderPath);
                 FileAssert.Exists(string.Format("{0}/{1}@{2}", folderPath, obj.name, "Recorded.fbx"));
             }
         }

--- a/Assets/com.unity.formats.fbx.tests/FbxAnimationTest.cs
+++ b/Assets/com.unity.formats.fbx.tests/FbxAnimationTest.cs
@@ -32,7 +32,7 @@ namespace FbxExporters.UnitTests
         public static IEnumerable<System.Type> m_componentTypes = 
             typeof (Component).Assembly.GetTypes ().
             Where (t => typeof (Component).IsAssignableFrom (t) && 
-                   ModelExporter.MapsToFbxObject.ContainsKey(t)).Except(m_exceptionTypes);
+                   ModelExporterReflection.MapsToFbxObject.ContainsKey(t)).Except(m_exceptionTypes);
 
         public static string [] m_rotationQuaternionNames = new string [4] { "m_LocalRotation.x", "m_LocalRotation.y", "m_LocalRotation.z", "m_LocalRotation.w" };
         public static string [] m_rotationEulerNames = new string [3] { "localEulerAnglesRaw.x", "localEulerAnglesRaw.y", "localEulerAnglesRaw.z" };
@@ -785,7 +785,7 @@ namespace FbxExporters.UnitTests
             Debug.Log (string.Format ("ComponentAnimTest {0}", componentType.ToString()));
             #endif 
 
-            if (!ModelExporter.MapsToFbxObject.ContainsKey(componentType))
+            if (!ModelExporterReflection.MapsToFbxObject.ContainsKey(componentType))
             {
                 #if DEBUG_UNITTEST
                 Debug.Log (string.Format ("skipping {0}; fbx export not supported", componentType.ToString()));
@@ -883,7 +883,7 @@ namespace FbxExporters.UnitTests
                         continue;
                     }
 
-                    GameObject unityGo = ModelExporter.GetGameObject (uniObj);
+                    GameObject unityGo = ModelExporterReflection.GetGameObject(uniObj);
                     if (!unityGo) {
                         continue;
                     }

--- a/Assets/com.unity.formats.fbx.tests/FbxExporterReflection.cs
+++ b/Assets/com.unity.formats.fbx.tests/FbxExporterReflection.cs
@@ -1,0 +1,215 @@
+﻿using FbxExporters.Editor;
+using FbxExporters.EditorTools;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using Unity.FbxSdk;
+using UnityEngine;
+using UnityEngine.Timeline;	
+
+namespace FbxExporters.UnitTests
+{
+    public static class ModelExporterReflection
+    {
+        /// <summary>
+        // This class allows accessing the ModelExporter methods that this
+        // unit test needs to validate
+        /// </summary>
+
+        /////////////
+        // Properties
+        /////////////
+        public static Material DefaultMaterial
+        {
+            get
+            {
+                return (Material)GetStaticProperty("DefaultMaterial");
+            }
+        }
+
+        /////////////
+        // Fields
+        /////////////
+        public static float UnitScaleFactor
+        {
+            get
+            {
+                return (float)GetStaticField("UnitScaleFactor");
+            }
+        }
+        public static Dictionary<System.Type, KeyValuePair<System.Type,ModelExporter.FbxNodeRelationType>> MapsToFbxObject
+        {
+            get
+            {
+                return (Dictionary<System.Type, KeyValuePair<System.Type,ModelExporter.FbxNodeRelationType>>) GetStaticField("MapsToFbxObject");
+            }
+        }
+
+        /////////////
+        // Methods
+        /////////////
+        public static GameObject GetGameObject(UnityEngine.Object obj)
+        {
+            return (GameObject) InvokeMethod("GetGameObject", new object[] { obj });
+        }
+
+        public static HashSet<GameObject> RemoveRedundantObjects(IEnumerable<UnityEngine.Object> unityExportSet)
+        {
+            return (HashSet<GameObject>) InvokeMethod("RemoveRedundantObjects", new object[] {unityExportSet});
+        }
+
+        public static string GetVersionFromReadme()
+        {
+            return (string)InvokeMethod("GetVersionFromReadme", null);
+        }
+
+        public static string ConvertToValidFilename(string filename)
+        {
+            return (string)InvokeMethod("ConvertToValidFilename", new object[] {filename});
+        }
+
+        public static Vector3 FindCenter(IEnumerable<GameObject> gameObjects)
+        {
+            return (Vector3)InvokeMethod("FindCenter", new object[] {gameObjects});
+        }
+
+        public static Vector3 GetRecenteredTranslation(Transform t, Vector3 center)
+        {
+            return (Vector3)InvokeMethod("GetRecenteredTranslation", new object[] {t, center});
+        }
+
+        public static FbxLayer GetOrCreateLayer(FbxMesh fbxMesh, int layer = 0 /* default layer */)
+        {
+            return (FbxLayer)InvokeMethod("GetOrCreateLayer", new object[] {fbxMesh,layer});
+        }
+
+        public static FbxVector4 ConvertToRightHanded(Vector3 leftHandedVector, float unitScale = 1f)
+        {
+            return (FbxVector4)InvokeMethod("ConvertToRightHanded", new object[] {leftHandedVector,unitScale});
+        }
+
+        public static bool ExportMaterial(ModelExporter instance, Material unityMaterial, FbxScene fbxScene, FbxNode fbxNode)
+        {
+            return (bool)InvokeMethod("ExportMaterial", new object[] {unityMaterial,fbxScene,fbxNode},instance);
+        }
+
+        // Redefinition of the internal delegate. There might be a way to re-use the one in ModelExporter
+        public static void RegisterMeshObjectCallback(ModelExporter.GetMeshForObject callback)
+        {
+            InvokeMethod("RegisterMeshObjectCallback", new object[] {callback});
+        }
+
+        public static void RegisterMeshCallback<T>(ModelExporter.GetMeshForComponent<T> callback, bool replace = false)
+                where T : UnityEngine.MonoBehaviour
+        {
+            // Get the template method first (we assume there is only one 
+            // templated RegisterMeshCallback method in ModelExporter
+            var methods = from methodInfo in typeof(ModelExporter).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+                where methodInfo.Name == "RegisterMeshCallback"
+                    && methodInfo.IsGenericMethodDefinition
+                select methodInfo;
+            
+            MethodInfo templateMethod = methods.Single();
+            MethodInfo genericMethod = templateMethod.MakeGenericMethod(new Type[]{typeof(T)});
+            genericMethod.Invoke(null, new object[]{callback, replace});
+        }
+        
+        public static void UnRegisterMeshCallback<T>()
+        {
+            // Get the template method first (we assume there is only one 
+            // templated RegisterMeshCallback method in ModelExporter
+            var methods = from methodInfo in typeof(ModelExporter).GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
+                where methodInfo.Name == "UnRegisterMeshCallback"
+                    && methodInfo.IsGenericMethodDefinition
+                select methodInfo;
+            
+            MethodInfo templateMethod = methods.Single();
+            MethodInfo genericMethod = templateMethod.MakeGenericMethod(new Type[]{typeof(T)});
+            genericMethod.Invoke(null, null);
+        }
+
+        public static void UnRegisterMeshCallback(ModelExporter.GetMeshForObject callback)
+        {
+            InvokeMethodOverload("UnRegisterMeshCallback", 
+                                 new object[] {callback},
+                                 new Type[] {typeof(ModelExporter.GetMeshForObject)});
+        }
+
+
+        public static bool ExportTexture(ModelExporter instance, Material unityMaterial, string unityPropName,
+                           FbxSurfaceMaterial fbxMaterial, string fbxPropName)
+        {
+            return (bool)InvokeMethod("ExportTexture", 
+                                      new object[] {unityMaterial,unityPropName,fbxMaterial,fbxPropName}, 
+                                      instance);
+        }
+
+        public static FbxDouble3 ConvertQuaternionToXYZEuler(Quaternion q)
+        {
+            return (FbxDouble3)InvokeMethodOverload("ConvertQuaternionToXYZEuler", 
+                                                    new object[] {q}, 
+                                                    new Type[] {typeof(Quaternion)});
+        }
+
+        public static bool ExportMesh(ModelExporter instance, Mesh mesh, FbxNode fbxNode, Material[] materials = null)
+        {
+            return (bool)InvokeMethodOverload("ExportMesh",
+                                              new object[] {mesh, fbxNode, materials},
+                                              new Type[] {typeof(Mesh), typeof(FbxNode), typeof(Material [])},
+                                              instance);
+  
+        }
+
+        public static void ExportSingleTimelineClip(TimelineClip timelineClipSelected, GameObject animationTrackGObject, string filePath = null)
+        {
+            InvokeMethod("ExportSingleTimelineClip", 
+                         new object[] {timelineClipSelected, animationTrackGObject, filePath});
+        }
+
+        public static void ExportAllTimelineClips(GameObject objectWithPlayableDirector, string folderPath, IExportOptions exportOptions = null)
+        {
+            InvokeMethod("ExportAllTimelineClips", 
+                         new object[] {objectWithPlayableDirector, folderPath, exportOptions});
+        }
+
+        /////////// Helpers ///////////
+        private static object InvokeMethod(string methodName, object[] argsToPass, ModelExporter instance = null)
+        {
+            // Use reflection to call the internal ModelExporter.GetGameObject static method
+            var internalMethod = typeof(ModelExporter).GetMethod(methodName,
+                                                                 (instance == null ? BindingFlags.Static : BindingFlags.Instance) | BindingFlags.NonPublic);
+            return internalMethod.Invoke(instance, argsToPass);
+        }
+
+        // Same as InvokeMethod, but for a specific overload
+        private static object InvokeMethodOverload(string methodName, 
+                                                   object[] argsToPass, 
+                                                   Type[] overloadArgTypes, 
+                                                   ModelExporter instance = null)
+        {
+            var internalMethod = typeof(ModelExporter).GetMethod(methodName,
+                                                                 (instance == null ? BindingFlags.Static : BindingFlags.Instance) | BindingFlags.NonPublic,
+                                                                 null,
+                                                                 overloadArgTypes,
+                                                                 null);
+            return internalMethod.Invoke(instance, argsToPass);
+        }
+
+        private static object GetStaticProperty(string propertyName)
+        {
+            // Use reflection to get the internal property
+            var internalProperty = typeof(ModelExporter).GetProperty(propertyName, 
+                                          BindingFlags.NonPublic | BindingFlags.Static);
+            return internalProperty.GetValue(null,null);
+        }
+
+        private static object GetStaticField(string fieldName)
+        {
+            // Use reflection to get the internal property
+            var internalField = typeof(ModelExporter).GetField(fieldName, 
+                                                               BindingFlags.NonPublic | BindingFlags.Static);
+            return internalField.GetValue(null);
+        }
+    }
+}

--- a/Assets/com.unity.formats.fbx.tests/ModelExporterTest.cs
+++ b/Assets/com.unity.formats.fbx.tests/ModelExporterTest.cs
@@ -13,15 +13,15 @@ namespace FbxExporters.UnitTests
         [Test]
         public void TestBasics ()
         {
-            Assert.That(!string.IsNullOrEmpty(ModelExporter.GetVersionFromReadme()));
+            Assert.That(!string.IsNullOrEmpty(ModelExporterReflection.GetVersionFromReadme()));
 
             // Test GetOrCreateLayer
             using (var fbxManager = FbxManager.Create()) {
                 var fbxMesh = FbxMesh.Create(fbxManager, "name");
-                var layer0 = ModelExporter.GetOrCreateLayer(fbxMesh);
+                var layer0 = ModelExporterReflection.GetOrCreateLayer(fbxMesh);
                 Assert.That(layer0, Is.Not.Null);
-                Assert.That(ModelExporter.GetOrCreateLayer(fbxMesh), Is.EqualTo(layer0));
-                var layer5 = ModelExporter.GetOrCreateLayer(fbxMesh, layer: 5);
+                Assert.That(ModelExporterReflection.GetOrCreateLayer(fbxMesh), Is.EqualTo(layer0));
+                var layer5 = ModelExporterReflection.GetOrCreateLayer(fbxMesh, layer: 5);
                 Assert.That(layer5, Is.Not.Null);
                 Assert.That(layer5, Is.Not.EqualTo(layer0));
             }
@@ -32,22 +32,22 @@ namespace FbxExporters.UnitTests
             var b = new Vector3(0,0,1);
             var crossLeft = Vector3.Cross(a,b);
 
-            var afbx = ModelExporter.ConvertToRightHanded(a);
-            var bfbx = ModelExporter.ConvertToRightHanded(b);
-            Assert.AreEqual(ModelExporter.ConvertToRightHanded(crossLeft), bfbx.CrossProduct(afbx));
+            var afbx = ModelExporterReflection.ConvertToRightHanded(a);
+            var bfbx = ModelExporterReflection.ConvertToRightHanded(b);
+            Assert.AreEqual(ModelExporterReflection.ConvertToRightHanded(crossLeft), bfbx.CrossProduct(afbx));
 
             // Test scale conversion. Nothing complicated here...
-            var afbxPosition = ModelExporter.ConvertToRightHanded(a, ModelExporter.UnitScaleFactor);
+            var afbxPosition = ModelExporterReflection.ConvertToRightHanded(a, ModelExporterReflection.UnitScaleFactor);
             Assert.AreEqual(100, afbxPosition.Length());
 
             // Test rotation conversion.
             var q = Quaternion.Euler(new Vector3(0, 90, 0));
-            var fbxAngles = ModelExporter.ConvertQuaternionToXYZEuler(q);
+            var fbxAngles = ModelExporterReflection.ConvertQuaternionToXYZEuler(q);
             Assert.AreEqual(fbxAngles.X, 0);
             Assert.That(fbxAngles.Y, Is.InRange(-90.001, -89.999));
             Assert.AreEqual(fbxAngles.Z, 0);
 
-            Assert.That(ModelExporter.DefaultMaterial);
+            Assert.That(ModelExporterReflection.DefaultMaterial);
 
             // Test non-static functions.
             using (var fbxManager = FbxManager.Create()) {
@@ -56,18 +56,18 @@ namespace FbxExporters.UnitTests
                 var exporter = new ModelExporter();
 
                 // Test ExportMaterial: it exports and it re-exports
-                bool result = exporter.ExportMaterial (ModelExporter.DefaultMaterial, fbxScene, fbxNode);
+                bool result = ModelExporterReflection.ExportMaterial(exporter,ModelExporterReflection.DefaultMaterial, fbxScene, fbxNode);
                 Assert.IsTrue (result);
                 var fbxMaterial = fbxNode.GetMaterial (0);
                 Assert.That(fbxMaterial, Is.Not.Null);
 
-                result = exporter.ExportMaterial(ModelExporter.DefaultMaterial, fbxScene, fbxNode);
+                result = ModelExporterReflection.ExportMaterial(exporter, ModelExporterReflection.DefaultMaterial, fbxScene, fbxNode);
                 var fbxMaterial2 = fbxNode.GetMaterial (1);
                 Assert.AreEqual(fbxMaterial, fbxMaterial2);
 
                 // Test ExportTexture: it finds the same texture for the default-material (it doesn't create a new one)
                 var fbxMaterialNew = FbxSurfaceLambert.Create(fbxScene, "lambert");
-                exporter.ExportTexture(ModelExporter.DefaultMaterial, "_MainTex",
+                ModelExporterReflection.ExportTexture(exporter,ModelExporterReflection.DefaultMaterial, "_MainTex",
                     fbxMaterialNew, FbxSurfaceLambert.sBump);
                 Assert.AreEqual(
                     fbxMaterial.FindProperty(FbxSurfaceLambert.sDiffuse).GetSrcObject(),
@@ -77,7 +77,7 @@ namespace FbxExporters.UnitTests
                 // Test ExportMesh: make sure we exported a mesh with welded vertices.
                 var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 var cubeNode = FbxNode.Create(fbxScene, "cube");
-                exporter.ExportMesh(cube.GetComponent<MeshFilter>().sharedMesh, cubeNode);
+                ModelExporterReflection.ExportMesh(exporter,cube.GetComponent<MeshFilter>().sharedMesh, cubeNode);
                 Assert.That(cubeNode.GetMesh(), Is.Not.Null);
                 Assert.That(cubeNode.GetMesh().GetControlPointsCount(), Is.EqualTo(8));
             }
@@ -110,7 +110,7 @@ namespace FbxExporters.UnitTests
             cube2.transform.localScale = new Vector3 (3, 1, 1);
 
             // Find the center
-            var center = FbxExporters.Editor.ModelExporter.FindCenter(new GameObject[]{cube,cube1,cube2});
+            var center = ModelExporterReflection.FindCenter(new GameObject[] { cube, cube1, cube2 });
 
             // Check that it is what we expect
             Assert.AreEqual(center, new Vector3(26, -2.5f, 6.75f));
@@ -126,26 +126,26 @@ namespace FbxExporters.UnitTests
 
             // test set: root
             // expected result: root
-            var result = FbxExporters.Editor.ModelExporter.RemoveRedundantObjects(new Object[]{root});
+            var result = ModelExporterReflection.RemoveRedundantObjects(new Object[] { root });
             Assert.AreEqual (1, result.Count);
             Assert.IsTrue (result.Contains (root));
 
             // test set: root, child1
             // expected result: root
-            result = FbxExporters.Editor.ModelExporter.RemoveRedundantObjects(new Object[]{root, child1});
+            result = ModelExporterReflection.RemoveRedundantObjects(new Object[] { root, child1 });
             Assert.AreEqual (1, result.Count);
             Assert.IsTrue (result.Contains (root));
 
             // test set: root, child1, child2, root2
             // expected result: root, root2
-            result = FbxExporters.Editor.ModelExporter.RemoveRedundantObjects(new Object[]{root, root2, child2, child1});
+            result = ModelExporterReflection.RemoveRedundantObjects(new Object[] { root, root2, child2, child1 });
             Assert.AreEqual (2, result.Count);
             Assert.IsTrue (result.Contains (root));
             Assert.IsTrue (result.Contains (root2));
 
             // test set: child1, child2
             // expected result: child1, child2
-            result = FbxExporters.Editor.ModelExporter.RemoveRedundantObjects(new Object[]{child2, child1});
+            result = ModelExporterReflection.RemoveRedundantObjects(new Object[] { child2, child1 });
             Assert.AreEqual (2, result.Count);
             Assert.IsTrue (result.Contains (child1));
             Assert.IsTrue (result.Contains (child2));
@@ -156,16 +156,16 @@ namespace FbxExporters.UnitTests
         {
             // test already valid filenames
             var filename = "foobar.fbx";
-            var result = FbxExporters.Editor.ModelExporter.ConvertToValidFilename (filename);
+            var result = ModelExporterReflection.ConvertToValidFilename(filename);
             Assert.AreEqual (filename, result);
 
             filename = "foo_bar 1.fbx";
-            result = FbxExporters.Editor.ModelExporter.ConvertToValidFilename (filename);
+            result = ModelExporterReflection.ConvertToValidFilename(filename);
             Assert.AreEqual (filename, result);
 
             // test invalid filenames
             filename = "?foo**bar///.fbx";
-            result = FbxExporters.Editor.ModelExporter.ConvertToValidFilename (filename);
+            result = ModelExporterReflection.ConvertToValidFilename(filename);
 #if UNITY_EDITOR_WIN
             Assert.AreEqual ("_foo__bar___.fbx", result);
 #else
@@ -173,7 +173,7 @@ namespace FbxExporters.UnitTests
 #endif
 
             filename = "foo$?ba%r 2.fbx";
-            result = FbxExporters.Editor.ModelExporter.ConvertToValidFilename (filename);
+            result = ModelExporterReflection.ConvertToValidFilename(filename);
 #if UNITY_EDITOR_WIN
             Assert.AreEqual ("foo$_ba%r 2.fbx", result);
 #else
@@ -226,8 +226,8 @@ namespace FbxExporters.UnitTests
             // No callbacks registered => no calls.
             tester.Verify(0, 0);
 
-            FbxExporters.Editor.ModelExporter.RegisterMeshObjectCallback(tester.CallbackForObject);
-            FbxExporters.Editor.ModelExporter.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab);
+            ModelExporterReflection.RegisterMeshObjectCallback(tester.CallbackForObject);
+            ModelExporterReflection.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab);
 
             // No fbprefab => no component calls, but every object called.
             tester.Verify(0, n);
@@ -242,29 +242,29 @@ namespace FbxExporters.UnitTests
             // Make sure we can't register for a component twice, but we can
             // for an object.  Register twice for an object means two calls per
             // object.
-            Assert.That( () => FbxExporters.Editor.ModelExporter.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab),
+            Assert.That( () => ModelExporterReflection.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab),
                     Throws.Exception);
-            FbxExporters.Editor.ModelExporter.RegisterMeshObjectCallback(tester.CallbackForObject);
+            ModelExporterReflection.RegisterMeshObjectCallback(tester.CallbackForObject);
             tester.Verify(1, 2 * n);
 
             // Register twice but return true => only one call per object.
             tester.Verify(0, n, objectResult: true);
 
             // Unregister once => only one call per object, and no more for the prefab.
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback(tester.CallbackForObject);
+            ModelExporterReflection.UnRegisterMeshCallback<FbxPrefab>();
+            ModelExporterReflection.UnRegisterMeshCallback(tester.CallbackForObject);
             tester.Verify(0, n);
 
             // Legal to unregister if already unregistered.
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
+            ModelExporterReflection.UnRegisterMeshCallback<FbxPrefab>();
             tester.Verify(0, n);
 
             // Register same callback twice gets back to original state.
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback(tester.CallbackForObject);
+            ModelExporterReflection.UnRegisterMeshCallback(tester.CallbackForObject);
             tester.Verify(0, 0);
 
             // Legal to unregister if already unregistered.
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback(tester.CallbackForObject);
+            ModelExporterReflection.UnRegisterMeshCallback(tester.CallbackForObject);
             tester.Verify(0, 0);
 
             ///////////////////////
@@ -281,15 +281,15 @@ namespace FbxExporters.UnitTests
             GameObject asset;
             Mesh assetMesh;
 
-            FbxExporters.Editor.ModelExporter.GetMeshForComponent<FbxPrefab> prefabCallback =
+            ModelExporter.GetMeshForComponent<FbxPrefab> prefabCallback =
                 (ModelExporter exporter, FbxPrefab component, FbxNode node) => {
-                    exporter.ExportMesh(sphereMesh, node);
+                    ModelExporterReflection.ExportMesh(exporter,sphereMesh, node);
                     return true;
                 };
-            FbxExporters.Editor.ModelExporter.RegisterMeshCallback(prefabCallback);
+            ModelExporterReflection.RegisterMeshCallback(prefabCallback);
             filename = GetRandomFbxFilePath();
             FbxExporters.Editor.ModelExporter.ExportObject(filename, tree);
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
+            ModelExporterReflection.UnRegisterMeshCallback<FbxPrefab>();
 
             asset = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             assetMesh = asset.transform.Find("Parent1").GetComponent<MeshFilter>().sharedMesh;
@@ -301,18 +301,18 @@ namespace FbxExporters.UnitTests
             // to make sure we don't pass if the previous pass didn't
             // actually unregister).
             filename = GetRandomFbxFilePath();
-            FbxExporters.Editor.ModelExporter.GetMeshForObject callback =
+            ModelExporter.GetMeshForObject callback =
                 (ModelExporter exporter, GameObject gameObject, FbxNode node) => {
                     if (gameObject.name == "Parent2") {
-                        exporter.ExportMesh(sphereMesh, node);
+                        ModelExporterReflection.ExportMesh(exporter,sphereMesh, node);
                         return true;
                     } else {
                         return false;
                     }
                 };
-            FbxExporters.Editor.ModelExporter.RegisterMeshObjectCallback(callback);
+            ModelExporterReflection.RegisterMeshObjectCallback(callback);
             FbxExporters.Editor.ModelExporter.ExportObject(filename, tree);
-            FbxExporters.Editor.ModelExporter.UnRegisterMeshCallback(callback);
+            ModelExporterReflection.UnRegisterMeshCallback(callback);
 
             asset = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             assetMesh = asset.transform.Find("Parent1").GetComponent<MeshFilter>().sharedMesh;

--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
@@ -98,9 +98,9 @@ namespace FbxExporters
             const string RegexCharStart = "[";
             const string RegexCharEnd = "]";
 
-            public const float UnitScaleFactor = 100f;
+            internal const float UnitScaleFactor = 100f;
 
-            public const string PACKAGE_UI_NAME = "FBX Exporter";
+            internal const string PACKAGE_UI_NAME = "FBX Exporter";
 
             /// <summary>
             /// name of the scene's default camera
@@ -139,7 +139,7 @@ namespace FbxExporters
                 Material
             }
 
-            public static Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> MapsToFbxObject = new Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> ()
+            internal static Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> MapsToFbxObject = new Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> ()
             {
                 { typeof(Transform),            new KeyValuePair<System.Type, FbxNodeRelationType>(typeof(FbxProperty), FbxNodeRelationType.Property) },
                 { typeof(MeshFilter),           new KeyValuePair<System.Type, FbxNodeRelationType>(typeof(FbxMesh), FbxNodeRelationType.NodeAttribute) },
@@ -195,10 +195,9 @@ namespace FbxExporters
             /// <summary>
             /// Gets the export settings.
             /// </summary>
-            public static EditorTools.ExportSettings ExportSettings {
+            internal static EditorTools.ExportSettings ExportSettings {
                 get { return EditorTools.ExportSettings.instance; }
             }
-
 
             private EditorTools.IExportOptions m_exportOptions;
             private EditorTools.IExportOptions ExportOptions {
@@ -215,7 +214,7 @@ namespace FbxExporters
             /// <summary>
             /// Gets the Unity default material.
             /// </summary>
-            public static Material DefaultMaterial {
+            internal static Material DefaultMaterial {
                 get {
                     if (!s_defaultMaterial) {
                         var obj = GameObject.CreatePrimitive (PrimitiveType.Quad);
@@ -238,7 +237,7 @@ namespace FbxExporters
             /// <summary>
             /// Gets the version number of the FbxExporters plugin from the readme.
             /// </summary>
-            public static string GetVersionFromReadme()
+            internal static string GetVersionFromReadme()
             {
                 if (!File.Exists (ChangeLogPath)) {
                     Debug.LogWarning (string.Format("Could not find version number, the ChangeLog file is missing from: {0}", ChangeLogPath));
@@ -274,7 +273,7 @@ namespace FbxExporters
             /// Get a layer (to store UVs, normals, etc) on the mesh.
             /// If it doesn't exist yet, create it.
             /// </summary>
-            public static FbxLayer GetOrCreateLayer(FbxMesh fbxMesh, int layer = 0 /* default layer */)
+            internal static FbxLayer GetOrCreateLayer(FbxMesh fbxMesh, int layer = 0 /* default layer */)
             {
                 int maxLayerIndex = fbxMesh.GetLayerCount() - 1;
                 while (layer > maxLayerIndex) {
@@ -541,7 +540,7 @@ namespace FbxExporters
             ///
             /// Remember you also need to flip the winding order on your polygons.
             /// </summary>
-            public static FbxVector4 ConvertToRightHanded(Vector3 leftHandedVector, float unitScale = 1f)
+            internal static FbxVector4 ConvertToRightHanded(Vector3 leftHandedVector, float unitScale = 1f)
             {
                 // negating the x component of the vector converts it from left to right handed coordinates
                 return unitScale * new FbxVector4 (
@@ -561,7 +560,7 @@ namespace FbxExporters
             /// <param name="unityPropName">Unity property name, e.g. "_MainTex".</param>
             /// <param name="fbxMaterial">Fbx material.</param>
             /// <param name="fbxPropName">Fbx property name, e.g. <c>FbxSurfaceMaterial.sDiffuse</c>.</param>
-            public bool ExportTexture (Material unityMaterial, string unityPropName,
+            internal bool ExportTexture (Material unityMaterial, string unityPropName,
                                        FbxSurfaceMaterial fbxMaterial, string fbxPropName)
             {
                 if (!unityMaterial) {
@@ -613,7 +612,7 @@ namespace FbxExporters
             /// <summary>
             /// Get the color of a material, or grey if we can't find it.
             /// </summary>
-            public FbxDouble3 GetMaterialColor (Material unityMaterial, string unityPropName, float defaultValue = 1)
+            internal FbxDouble3 GetMaterialColor (Material unityMaterial, string unityPropName, float defaultValue = 1)
             {
                 if (!unityMaterial) {
                     return new FbxDouble3(defaultValue);
@@ -628,7 +627,7 @@ namespace FbxExporters
             /// <summary>
             /// Export (and map) a Unity PBS material to FBX classic material
             /// </summary>
-            public bool ExportMaterial (Material unityMaterial, FbxScene fbxScene, FbxNode fbxNode)
+            internal bool ExportMaterial (Material unityMaterial, FbxScene fbxScene, FbxNode fbxNode)
             {
                 if (!unityMaterial) {
                     unityMaterial = DefaultMaterial;
@@ -757,7 +756,7 @@ namespace FbxExporters
             ///
             /// Use fbxNode.GetMesh() to access the exported mesh.
             /// </summary>
-            public bool ExportMesh (Mesh mesh, FbxNode fbxNode, Material[] materials = null)
+            internal bool ExportMesh (Mesh mesh, FbxNode fbxNode, Material[] materials = null)
             {
                 var meshInfo = new MeshInfo(mesh, materials);
                 return ExportMesh(meshInfo, fbxNode);
@@ -1157,7 +1156,7 @@ namespace FbxExporters
             ///       instead of Euler angles, which Maya does not import properly. 
             /// </summary>
             /// <returns>Euler with XYZ rotation order.</returns>
-            public static FbxDouble3 ConvertQuaternionToXYZEuler(Quaternion q)
+            internal static FbxDouble3 ConvertQuaternionToXYZEuler(Quaternion q)
             {
                 FbxQuaternion quat = new FbxQuaternion (q.x, q.y, q.z, q.w);
                 FbxAMatrix m = new FbxAMatrix ();
@@ -1169,7 +1168,7 @@ namespace FbxExporters
                 return new FbxDouble3 (vector4.X, -vector4.Y, -vector4.Z);
             }
 
-            public static FbxVector4 ConvertQuaternionToXYZEuler (FbxQuaternion quat)
+            internal static FbxVector4 ConvertQuaternionToXYZEuler (FbxQuaternion quat)
             {
                 FbxAMatrix m = new FbxAMatrix ();
                 m.SetQ (quat);
@@ -1180,22 +1179,22 @@ namespace FbxExporters
                 return new FbxVector4 (vector4.X, -vector4.Y, -vector4.Z, vector4.W);
             }
 
-            public static FbxDouble3 ToFbxDouble3(Vector3 v)
+            internal static FbxDouble3 ToFbxDouble3(Vector3 v)
             {
                 return new FbxDouble3(v.x, v.y, v.z);
             }
 
-            public static FbxDouble3 ToFbxDouble3(FbxVector4 v)
+            internal static FbxDouble3 ToFbxDouble3(FbxVector4 v)
             {
                 return new FbxDouble3(v.X, v.Y, v.Z);
             }
 
-            public static FbxVector4 ToFbxVector4(FbxDouble3 v)
+            internal static FbxVector4 ToFbxVector4(FbxDouble3 v)
             {
                 return new FbxVector4(v.X, v.Y, v.Z);
             }
 
-            public static FbxDouble3 ConvertToRightHandedEuler(Vector3 rot)
+            internal static FbxDouble3 ConvertToRightHandedEuler(Vector3 rot)
             {
                 rot.y *= -1;
                 rot.z *= -1;
@@ -1207,7 +1206,7 @@ namespace FbxExporters
             /// </summary>
             /// <returns>a quaternion.</returns>
             /// <param name="euler">Euler.</param>
-            public static FbxQuaternion EulerToQuaternion(FbxVector4 euler)
+            internal static FbxQuaternion EulerToQuaternion(FbxVector4 euler)
             {
                 FbxAMatrix m = new FbxAMatrix ();
                 m.SetR (euler);
@@ -1219,7 +1218,7 @@ namespace FbxExporters
             /// </summary>
             /// <returns>a euler.</returns>
             /// <param name="quat">Quaternion.</param>
-            public static FbxVector4 QuaternionToEuler(FbxQuaternion quat)
+            internal static FbxVector4 QuaternionToEuler(FbxQuaternion quat)
             {
                 FbxAMatrix m = new FbxAMatrix ();
                 m.SetQ (quat);
@@ -1227,7 +1226,7 @@ namespace FbxExporters
             }
 
             // get a fbxNode's global default position.
-            protected bool ExportTransform (UnityEngine.Transform unityTransform, FbxNode fbxNode, Vector3 newCenter, TransformExportType exportType)
+            internal bool ExportTransform (UnityEngine.Transform unityTransform, FbxNode fbxNode, Vector3 newCenter, TransformExportType exportType)
             {
                 // Fbx rotation order is XYZ, but Unity rotation order is ZXY.
                 // This causes issues when converting euler to quaternion, causing the final
@@ -1725,7 +1724,7 @@ namespace FbxExporters
             /// <summary>
             /// Return set of sample times to cover all keys on animation curves
             /// </summary>
-            public static HashSet<float> GetSampleTimes(AnimationCurve[] animCurves, double sampleRate)
+            internal static HashSet<float> GetSampleTimes(AnimationCurve[] animCurves, double sampleRate)
             {
                 var keyTimes = new HashSet<float>();
                 double fs = 1.0/sampleRate;
@@ -1752,7 +1751,7 @@ namespace FbxExporters
             /// <summary>
             /// Return set of all keys times on animation curves
             /// </summary>
-            public static HashSet<float> GetKeyTimes(AnimationCurve[] animCurves)
+            internal static HashSet<float> GetKeyTimes(AnimationCurve[] animCurves)
             {
                 var keyTimes = new HashSet<float>();
 
@@ -1769,7 +1768,7 @@ namespace FbxExporters
             /// NOTE : This is a work in progress (WIP). We only export the key time and value on
             /// a Cubic curve using the default tangents.
             /// </summary>
-            protected void ExportAnimationKeys (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve, 
+            internal void ExportAnimationKeys (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve, 
                 UnityToMayaConvertSceneHelper convertSceneHelper)
             {
                 // TODO: complete the mapping between key tangents modes Unity and FBX
@@ -1822,7 +1821,7 @@ namespace FbxExporters
             /// <summary>
             /// Export animation curve key samples
             /// </summary>
-            protected void ExportAnimationSamples (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve,
+            internal void ExportAnimationSamples (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve,
                 double sampleRate,
                 UnityToMayaConvertSceneHelper convertSceneHelper)
             {
@@ -1958,7 +1957,7 @@ namespace FbxExporters
                 }
             }
 
-            public class UnityToMayaConvertSceneHelper
+            internal class UnityToMayaConvertSceneHelper
             {
                 bool convertDistance = false;
                 bool convertLtoR = false;
@@ -2331,7 +2330,7 @@ namespace FbxExporters
                 return Matrix4x4.TRS(sourcePos, sourceRot, sourceScale); 
             }
 
-            struct UnityCurve {
+            internal struct UnityCurve {
                 public string propertyName;
                 public AnimationCurve uniAnimCurve;
                 public System.Type propertyType;
@@ -2484,7 +2483,7 @@ namespace FbxExporters
             /// Creates an FbxNode for each GameObject.
             /// </summary>
             /// <returns>The number of nodes exported.</returns>
-            protected int ExportTransformHierarchy(
+            internal int ExportTransformHierarchy(
                 GameObject  unityGo, FbxScene fbxScene, FbxNode fbxNodeParent,
                 int exportProgress, int objectCount, Vector3 newCenter,
                 TransformExportType exportType = TransformExportType.Local,
@@ -2577,7 +2576,7 @@ namespace FbxExporters
             /// Export data containing what to export when
             /// exporting animation only.
             /// </summary>
-            public struct AnimationOnlyExportData {
+            internal struct AnimationOnlyExportData {
                 // map from animation clip to GameObject that has Animation/Animator
                 // component containing clip
                 public Dictionary<AnimationClip, GameObject> animationClips;
@@ -2653,7 +2652,7 @@ namespace FbxExporters
             ///     but components are only exported if explicitly animated. Meshes are not exported.
             /// </summary>
             /// <returns>The number of nodes exported.</returns>
-            protected int ExportAnimationOnly(
+            internal int ExportAnimationOnly(
                 GameObject unityGO,
                 FbxScene fbxScene,
                 int exportProgress,
@@ -2739,7 +2738,7 @@ namespace FbxExporters
                 return numObjectsExported;
             }
 
-            class SkinnedMeshBoneInfo {
+            internal class SkinnedMeshBoneInfo {
                 public SkinnedMeshRenderer skinnedMesh;
                 public Dictionary<Transform, int> boneDict;
                 public Dictionary<Transform, Matrix4x4> boneToBindPose;
@@ -2952,7 +2951,7 @@ namespace FbxExporters
             /// <returns>The animation only hierarchy count.</returns>
             /// <param name="exportSet">GameObject hierarchies selected for export.</param>
             /// <param name="hierarchyToExportData">Map from GameObject hierarchy to animation export data.</param>
-            protected int GetAnimOnlyHierarchyCount(Dictionary<GameObject, AnimationOnlyExportData> hierarchyToExportData)
+            internal int GetAnimOnlyHierarchyCount(Dictionary<GameObject, AnimationOnlyExportData> hierarchyToExportData)
             {
                 // including any parents of animated objects that are exported
                 var completeExpSet = new HashSet<GameObject>();
@@ -2970,7 +2969,7 @@ namespace FbxExporters
                 return completeExpSet.Count;
             }
 
-            protected Dictionary<GameObject, AnimationOnlyExportData> GetAnimationExportDataFromAnimationTrack(GameObject rootObject, AnimationTrack animationTrack)
+            internal Dictionary<GameObject, AnimationOnlyExportData> GetAnimationExportDataFromAnimationTrack(GameObject rootObject, AnimationTrack animationTrack)
             {
                 // get animation clips for root object from animation track
                 List<AnimationClip> clips = new List<AnimationClip>();
@@ -2984,7 +2983,7 @@ namespace FbxExporters
             }
 
 
-            protected Dictionary<GameObject, AnimationOnlyExportData> GetTimelineAnimationExportData(GameObject rootObject, List<AnimationClip> animationClipsList)
+            internal Dictionary<GameObject, AnimationOnlyExportData> GetTimelineAnimationExportData(GameObject rootObject, List<AnimationClip> animationClipsList)
             {
                 var goToExport = new HashSet<GameObject>();
                 var animationClips = new Dictionary<AnimationClip, GameObject>();
@@ -2998,7 +2997,7 @@ namespace FbxExporters
                 return data;
             }
 
-            protected Dictionary<GameObject, AnimationOnlyExportData> GetAnimationExportData(HashSet<GameObject> exportSet)
+            internal Dictionary<GameObject, AnimationOnlyExportData> GetAnimationExportData(HashSet<GameObject> exportSet)
             {
                 Dictionary<GameObject, AnimationOnlyExportData>  hierarchyToExportData = new Dictionary<GameObject, AnimationOnlyExportData>();
 
@@ -3162,7 +3161,7 @@ namespace FbxExporters
             /// </summary>
             /// <returns>The hierarchy count.</returns>
             /// <param name="exportSet">Export set.</param>
-            public int GetHierarchyCount (HashSet<GameObject> exportSet)
+            internal int GetHierarchyCount (HashSet<GameObject> exportSet)
             {
                 int count = 0;
                 Queue<GameObject> queue = new Queue<GameObject> (exportSet);
@@ -3184,7 +3183,7 @@ namespace FbxExporters
             /// </summary>
             /// <returns>The revised export set</returns>
             /// <param name="unityExportSet">Unity export set.</param>
-            public static HashSet<GameObject> RemoveRedundantObjects(IEnumerable<UnityEngine.Object> unityExportSet)
+            internal static HashSet<GameObject> RemoveRedundantObjects(IEnumerable<UnityEngine.Object> unityExportSet)
             {
                 // basically just remove the descendents from the unity export set
                 HashSet<GameObject> toExport = new HashSet<GameObject> ();
@@ -3259,7 +3258,7 @@ namespace FbxExporters
             /// </summary>
             /// <returns>Center of gameObjects.</returns>
             /// <param name="gameObjects">Game objects.</param>
-            public static Vector3 FindCenter(IEnumerable<GameObject> gameObjects)
+            internal static Vector3 FindCenter(IEnumerable<GameObject> gameObjects)
             {
                 Bounds bounds = new Bounds();
                 // Assign the initial bounds to first GameObject's bounds
@@ -3281,12 +3280,12 @@ namespace FbxExporters
             /// <returns>The recentered translation.</returns>
             /// <param name="t">Transform.</param>
             /// <param name="center">Center point.</param>
-            public static Vector3 GetRecenteredTranslation(Transform t, Vector3 center)
+            internal static Vector3 GetRecenteredTranslation(Transform t, Vector3 center)
             {
                 return t.position - center;
             }
 
-            public enum TransformExportType { Local, Global, Reset };
+            internal enum TransformExportType { Local, Global, Reset };
 
             /// <summary>
             /// Export all the objects in the set.
@@ -3294,7 +3293,7 @@ namespace FbxExporters
             ///
             /// This refreshes the asset database.
             /// </summary>
-            public int ExportAll (
+            internal int ExportAll (
                 IEnumerable<UnityEngine.Object> unityExportSet, 
                 Dictionary<GameObject, AnimationOnlyExportData> animationExportData)
             {
@@ -3619,7 +3618,7 @@ namespace FbxExporters
                 return false;
             }
 
-            public static void ExportSingleTimelineClip(TimelineClip timelineClipSelected, GameObject animationTrackGObject, string filePath = null)
+            internal static void ExportSingleTimelineClip(TimelineClip timelineClipSelected, GameObject animationTrackGObject, string filePath = null)
             {
 
                 UnityEngine.Object[] exportArray = new UnityEngine.Object[] {
@@ -3640,7 +3639,7 @@ namespace FbxExporters
                 ExportModelEditorWindow.Init (exportArray, string.Format (AnimFbxFormat, animationTrackGObject.name, timelineClipSelected.displayName), isTimelineAnim: true);
             }
 
-            public static void ExportAllTimelineClips(GameObject objectWithPlayableDirector, string folderPath, IExportOptions exportOptions = null)
+            internal static void ExportAllTimelineClips(GameObject objectWithPlayableDirector, string folderPath, IExportOptions exportOptions = null)
             {
                 PlayableDirector pd = objectWithPlayableDirector.GetComponent<PlayableDirector>();
                 if (pd == null)
@@ -3684,12 +3683,12 @@ namespace FbxExporters
             /// Validate the menu item defined by the function OnContextItem.
             /// </summary>
             [MenuItem (MenuItemName, true, 30)]
-            public static bool OnValidateMenuItem ()
+            internal static bool OnValidateMenuItem ()
             {
                 return true;
             }
 
-            public static void DisplayNoSelectionDialog()
+            internal static void DisplayNoSelectionDialog()
             {
                 UnityEditor.EditorUtility.DisplayDialog (
                     string.Format("{0} Warning", PACKAGE_UI_NAME), 
@@ -3703,7 +3702,7 @@ namespace FbxExporters
             ///<summary>
             ///Information about the mesh that is important for exporting.
             ///</summary>
-            class MeshInfo
+            internal class MeshInfo
             {
                 public Mesh mesh;
 
@@ -3883,7 +3882,7 @@ namespace FbxExporters
             /// <summary>
             /// Get the GameObject
             /// </summary>
-            public static GameObject GetGameObject (Object obj)
+            internal static GameObject GetGameObject (Object obj)
             {
                 if (obj is UnityEngine.Transform) {
                     var xform = obj as UnityEngine.Transform;
@@ -3932,7 +3931,7 @@ namespace FbxExporters
             /// It's an error to register a callback for a component that
             /// already has one, unless 'replace' is set to true.
             /// </summary>
-            public static void RegisterMeshCallback<T>(GetMeshForComponent<T> callback, bool replace = false)
+            internal static void RegisterMeshCallback<T>(GetMeshForComponent<T> callback, bool replace = false)
                 where T: UnityEngine.MonoBehaviour
             {
                 // Under the hood we lose type safety, but don't let the user notice!
@@ -3951,7 +3950,7 @@ namespace FbxExporters
             /// Normally you'll want to use the generic form, but this one is
             /// easier to use with reflection.
             /// </summary>
-            public static void RegisterMeshCallback(System.Type t,
+            internal static void RegisterMeshCallback(System.Type t,
                     GetMeshForComponent callback,
                     bool replace = false)
             {
@@ -3987,7 +3986,7 @@ namespace FbxExporters
             /// Multiple GameObject-based callbacks can be registered; they are
             /// checked in order of registration.
             /// </summary>
-            public static void RegisterMeshObjectCallback(GetMeshForObject callback)
+            internal static void RegisterMeshObjectCallback(GetMeshForObject callback)
             {
                 MeshForObjectCallbacks.Add(callback);
             }
@@ -3995,7 +3994,7 @@ namespace FbxExporters
             /// <summary>
             /// Forget the callback linked to a component of type T.
             /// </summary>
-            public static void UnRegisterMeshCallback<T>()
+            internal static void UnRegisterMeshCallback<T>()
             {
                 MeshForComponentCallbacks.Remove(typeof(T));
             }
@@ -4003,7 +4002,7 @@ namespace FbxExporters
             /// <summary>
             /// Forget the callback linked to a component of type T.
             /// </summary>
-            public static void UnRegisterMeshCallback(System.Type t)
+            internal static void UnRegisterMeshCallback(System.Type t)
             {
                 MeshForComponentCallbacks.Remove(t);
             }
@@ -4011,7 +4010,7 @@ namespace FbxExporters
             /// <summary>
             /// Forget a GameObject-based callback.
             /// </summary>
-            public static void UnRegisterMeshCallback(GetMeshForObject callback)
+            internal static void UnRegisterMeshCallback(GetMeshForObject callback)
             {
                 MeshForObjectCallbacks.Remove(callback);
             }
@@ -4105,17 +4104,17 @@ namespace FbxExporters
             /// <summary>
             /// Number of nodes exported including siblings and decendents
             /// </summary>
-            public int NumNodes { get { return MapUnityObjectToFbxNode.Count; } }
+            internal int NumNodes { get { return MapUnityObjectToFbxNode.Count; } }
 
             /// <summary>
             /// Number of meshes exported
             /// </summary>
-            public int NumMeshes { private set; get; }
+            internal int NumMeshes { set; get; }
 
             /// <summary>
             /// Number of triangles exported
             /// </summary>
-            public int NumTriangles { private set; get; }
+            internal int NumTriangles { set; get; }
 
             /// <summary>
             /// Clean up this class on garbage collection
@@ -4124,7 +4123,7 @@ namespace FbxExporters
             {
             }
 
-            public bool Verbose { private set {;} get { return EditorTools.ExportSettings.instance.Verbose; } }
+            internal bool Verbose { set {;} get { return EditorTools.ExportSettings.instance.Verbose; } }
 
             /// <summary>
             /// manage the selection of a filename
@@ -4256,7 +4255,7 @@ namespace FbxExporters
                 return newName;
             }
 
-            public static string ConvertToValidFilename(string filename)
+            internal static string ConvertToValidFilename(string filename)
             {
                 return System.Text.RegularExpressions.Regex.Replace (filename, 
                     RegexCharStart + new string(Path.GetInvalidFileNameChars()) + RegexCharEnd,


### PR DESCRIPTION
Please review these changes. I only changed the ModelExporter class. See screenshots of the results in Visual Studio (intellisense?) when I type "ModelExporter." or "exporterInstance."

Still to do:
- Move what is still public (delegates and enum) in a different script (enums and delegates)
- Do the same for other scripts and classes. Should I spend time on this part or are we good with only the ModelExporter changes? In other words should we log something in Jira and move on?