### PR TITLE
UNI-48515 fix FBX SDK package validation errors

### DIFF
--- a/Packages/com.unity.formats.fbxsdk/CHANGELOG.md
+++ b/Packages/com.unity.formats.fbxsdk/CHANGELOG.md
@@ -1,53 +1,54 @@
 # Changes in FBX SDK C# Bindings
-**Version**: 1.6.0-preview
+
+## [1.6.0] - 2018-05-29
 
 * The fbxsdk package can now be used in standalone builds (runtime)
 
-**Version**: 1.5.0-preview
+## [1.5.0]
 
 * Added support for physical camera attributes
 
-**Version**: 1.4.0-preview
+## [1.4.0]
 
 * First version accessible via Package Manager
 * Update to FBX SDK 2018.1.1
 * Add bindings for constraints: `FbxConstraint`, `FbxConstraintParent`, `FbxConstraintAim`, and related functions
 * Reduced binary size on Mac (which also shrinks the package for everyone)
 
-**Version**: 1.3.0a1
+## [1.3.0a1]
 
 Fix Universal Windows Platform build error caused by UnityFbxSdk.dll being set as compatible with any platform instead of editor only.
 
-**Version**: sprint43
+## [sprint43]
 
 Add bindings for FbxAnimCurveFilterUnroll
 
 Add binding for FbxGlobalSettings SetTimeMode to set frame rate
 
-**Version**: 1.2.0b1
+## [1.2.0b1]
 
 Update version number
 
 Replace meta files with meta files from release 1.0.0b1 for backwards compatibility
 
-**Version**: sprint36
+## [sprint36]
 
 Expose bindings to set FbxNode's transformation inherit type
 
-**Version**: sprint35
+## [sprint35]
 
 Add binding for FbxCamera's FieldOfView property
 
-**Version**: 1.0.0b1
+## [1.0.0b1]
 
 Enforce FbxSdk DLL only works with Unity 2017.1+
 
-**Version**: 0.0.14a
+## [0.0.14a]
 Note: skipping some versions so that FbxSdk package version matches FbxExporter package version
 
 Added FbxObject::GetScene
 
-**Version**: 0.0.10a
+## [0.0.10a]
 
 Added documentation of vector classes.
 
@@ -55,7 +56,7 @@ Added test to check that the FbxSdk DLL cannot be used without the Unity Editor 
 
 Improve build process so it is more robust.
 
-**Version**: 0.0.9a
+## [0.0.9a]
 
 Set the Doxygen homepage to be README.txt instead of README.md
 
@@ -69,7 +70,7 @@ Package zip file containing Doxygen documentation
 
 Update license in README to Autodesk license
 
-**Version**: 0.0.8a
+## [0.0.8a]
 
 Updated LICENCSE.txt to include Autodesk license
 
@@ -77,7 +78,7 @@ Use .bundle on Mac instead of .so for shared libraries
 
 Ship bindings as binaries without source
 
-**Version**: 0.0.7a
+## [0.0.7a]
 Note: skipping version 0.0.6a so that FbxSdk package version matches FbxExporter package version
 
 Add bindings for FbxIOFileHeaderInfo. 
@@ -85,6 +86,6 @@ Add bindings for FbxIOFileHeaderInfo.
 
 Made it easier for performance tests to pass.
 
-**Version**: 0.0.5a
+## [0.0.5a]
 
 Added Doxygen documentation generation for C# bindings.

--- a/Packages/com.unity.formats.fbxsdk/package.json
+++ b/Packages/com.unity.formats.fbxsdk/package.json
@@ -1,7 +1,7 @@
 {
 "name": "com.unity.formats.fbxsdk",
-"displayName" : "FBX SDK C# bindings",
 "version" : "0.0.0-master",
+"displayName" : "FBX SDK CSharp bindings",
 "unity": "2018.2",
 "description" : "This package provides C# bindings to the Autodesk FBX SDK.",
 "keywords" : [ "fbx", "animation", "modeling", "maya", "max" ]


### PR DESCRIPTION
- changelog version expected format: ## [x.y.z] - YYYY-MM-DD
- remove preview from the version headers (if the package is called 1.6.0-preview, then the package validation suite expects an entry of ## [1.6.0] in the CHANGELOG
- also replace C# with CSharp as # is not allowed in the display name

NOTE: package validation will fail for the 0.0.0-master version number as it can't find the documentation for it and there is no entry for it in the changelog.