### PR TITLE
UNI-49696 fix prefab auto updater unit test

### DIFF
--- a/Assets/com.unity.formats.fbx.tests/FbxPrefabAutoUpdaterTest.cs
+++ b/Assets/com.unity.formats.fbx.tests/FbxPrefabAutoUpdaterTest.cs
@@ -55,15 +55,6 @@ namespace UnityEditor.Formats.Fbx.Exporter.UnitTests
             var imported = new HashSet<string> (new string [] { "Assets/path/to/foo.fbx", m_fbxPath });
             Assert.IsTrue (FbxPrefabAutoUpdater.MayHaveFbxPrefabToFbxAsset (m_prefabPath, fbxPrefabPath,
                         imported));
-
-            // Create an empty (and duplicate) FbxPrefab.cs to confuse the auto-updater. Make sure it's properly confused.
-            // This test only works in 2018.2 or later; 2018.1 hard-codes the path.
-#if UNITY_2018_2_OR_LATER
-            System.IO.File.WriteAllText(this.filePath + '/' + FbxPrefabAutoUpdater.FBX_PREFAB_FILE, "class CeciNestPasUnFbxPrefab : UnityEngine.MonoBehaviour {}\n");
-            AssetDatabase.Refresh(); // force refresh
-            // TODO: assert that we're getting a log warning, but this still works
-            Assert.IsTrue (FbxPrefabAutoUpdater.MayHaveFbxPrefabToFbxAsset (m_prefabPath, fbxPrefabPath, imported));
-#endif
         }
 
         [Test]

--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabAutoUpdater.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabAutoUpdater.cs
@@ -38,9 +38,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     {
         #if COM_UNITY_FORMATS_FBX_AS_ASSET
         public const string FbxPrefabFile = "/UnityFbxPrefab.dll";
-        #elif UNITY_2018_2_OR_NEWER
-        public const string FbxPrefabFile = "/FbxPrefab.cs";
-        #else // Unity 2018.1 and fbx installed as a package
+        #else
         public const string FbxPrefabFile = "Packages/com.unity.formats.fbx/Runtime/FbxPrefab.cs";
         #endif
 
@@ -51,7 +49,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         public static string FindFbxPrefabAssetPath()
         {
-        #if COM_UNITY_FORMATS_FBX_AS_ASSET || UNITY_2018_2_OR_NEWER
+#if COM_UNITY_FORMATS_FBX_AS_ASSET
             // Find guids that are scripts that look like FbxPrefab.
             // That catches FbxPrefabTest too, so we have to make sure.
             var allGuids = AssetDatabase.FindAssets("FbxPrefab t:MonoScript");
@@ -72,17 +70,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Debug.LogWarning(string.Format("{0} not found; are you trying to uninstall {1}?", FbxPrefabFile.Substring(1), ModelExporter.PACKAGE_UI_NAME));
             }
             return foundPath;
-        #else
-            // In Unity 2018.1, FindAssets can't find FbxPrefab.cs in a package.
+#else
+            // In Unity 2018.1 and 2018.2.0b7, FindAssets can't find FbxPrefab.cs in a package.
             // So we hardcode the path.
-            var path = FBX_PREFAB_FILE;
+            var path = FbxPrefabFile;
             if (System.IO.File.Exists(System.IO.Path.GetFullPath(path))) {
                 return path;
             } else {
-                Debug.LogWarning(string.Format("{0} not found; are you trying to uninstall {1}?", FBX_PREFAB_FILE, UnityEditor.Formats.Fbx.Exporter.ModelExporter.PACKAGE_UI_NAME));
+                Debug.LogWarningFormat("{0} not found; update FbxPrefabFile variable in FbxPrefabAutoUpdater.cs to point to FbxPrefab.cs path.", FbxPrefabFile);
                 return "";
             }
-        #endif
+#endif
         }
 
         public static bool IsFbxAsset(string assetPath) {


### PR DESCRIPTION
- in Unity 2018.2.0b7, the asset database can no longer find the file in the package with the filename alone.
- also add a different warning is the .cs file can't be found as it most likely isn't because of the user trying to uninstall
- remove test that no longer has a use case as it requred FbxPrefabFile to be "/FbxPrefab.cs"

This is the same as https://github.com/Unity-Technologies/FbxExporters/pull/425, except it is based off the master instead of v1.7 branch.