### PR TITLE
UNI-51219 make sure every UI occurence of FBX is all caps

### DIFF
--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExportSettings.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExportSettings.cs
@@ -1321,10 +1321,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             }
         }
 
-        [MenuItem("Edit/Project Settings/Fbx Export", priority = 300)]
+        [MenuItem("Edit/Project Settings/FBX Export", priority = 300)]
         static void ShowManager()
         {
-            instance.name = "Fbx Export Settings";
+            instance.name = "FBX Export Settings";
             Selection.activeObject = instance;
             instance.Load();
         }

--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
@@ -88,7 +88,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         const string TimelineClipMenuItemName = "GameObject/Export Selected Timeline Clip...";
 
-        const string ProgressBarTitle = "Fbx Export";
+        const string ProgressBarTitle = "FBX Export";
 
         const char MayaNamespaceSeparator = ':';
 

--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabInspector.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabInspector.cs
@@ -24,10 +24,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             EditorGUI.BeginDisabledGroup(isDisabled);
             FbxPrefabUtility fbxPrefabUtility = new FbxPrefabUtility (fbxPrefab);
             var oldFbxAsset = fbxPrefabUtility.FbxAsset;
-            var newFbxAsset = EditorGUILayout.ObjectField(new GUIContent("Source Fbx Asset", "The FBX file that is linked to this Prefab"), oldFbxAsset,
+            var newFbxAsset = EditorGUILayout.ObjectField(new GUIContent("Source FBX Asset", "The FBX file that is linked to this Prefab"), oldFbxAsset,
                     typeof(GameObject), allowSceneObjects: false) as GameObject;
             if (newFbxAsset && !FbxPrefabAutoUpdater.IsFbxAsset(UnityEditor.AssetDatabase.GetAssetPath(newFbxAsset))) {
-                Debug.LogError("FbxPrefab must point to an Fbx asset (or none).");
+                Debug.LogError("FbxPrefab must point to an FBX asset (or none).");
             } else if (newFbxAsset != oldFbxAsset) {
                 fbxPrefabUtility.SetSourceModel(newFbxAsset);
             }

--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabUtility.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxPrefabUtility.cs
@@ -114,7 +114,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         [System.Diagnostics.Conditional("FBXEXPORTER_DEBUG")]
         public static void Log(string message)
         {
-            Debug.Log("Fbx prefab update: " + message);
+            Debug.Log("FBX prefab update: " + message);
         }
 
         [System.Diagnostics.Conditional("FBXEXPORTER_DEBUG")]


### PR DESCRIPTION
It does fix the "Fbx Export Settings" title capitalization, but the title is save in the .asset file so it will only be visible in projects that don't already have the settings file.