### PR TITLE
UNI-53811 (packman) fix error when exporting bones that are not descandants of root

### DIFF
--- a/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
+++ b/Packages/com.unity.formats.fbx/Editor/Scripts/FbxExporter.cs
@@ -2667,7 +2667,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // first export all the animated bones that are in the export set
             // as only a subset of bones are exported, but we still need to make sure the bone transforms are correct
-            ExportAnimatedBones(unityGO, fbxScene, ref numObjectsExported, objectCount, exportData);
+            if(!ExportAnimatedBones(unityGO, fbxScene, ref numObjectsExported, objectCount, exportData))
+            {
+                // export cancelled
+                return -1;
+            }
 
             // export everything else and make sure all nodes are connected
             foreach (var go in exportSet) {


### PR DESCRIPTION
- only export bones that are specified as such on the skinned mesh as bones
- clean up redundant root bone specific code