### PR TITLE
UT-1846 fix duplicate dccs in integration dropdown

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -346,7 +346,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                     }
                 }
             }
-            return result;
+            return NormalizePath(result, false);
         }
 
         /// <summary>
@@ -367,7 +367,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 {
                     if (Directory.Exists(location))
                     {
-                        result.Add(location);
+                        result.Add(NormalizePath(location, false));
                     }
                 }
             }


### PR DESCRIPTION
normalize paths before adding them so that we don't end up with the same path twice but slightly different (e.g. one with backslashes, one with forward slashes)