### PR TITLE
Fix FBX shape naming for blendshapes

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -498,7 +498,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var weight = umesh.GetBlendShapeFrameWeight(bi, fi);
                     umesh.GetBlendShapeFrameVertices(bi, fi, deltaPoints, deltaNormals, deltaTangents);
 
-                    var fbxShape = FbxShape.Create(fbxScene, "");
+                    var fbxShapeName = bsName;
+
+                    if (numFrames > 1)
+                    {
+                        fbxShapeName += "_" + fi;
+                    }
+
+                    var fbxShape = FbxShape.Create(fbxScene, fbxShapeName);
                     fbxChannel.AddTargetShape(fbxShape, weight);
 
                     // control points


### PR DESCRIPTION
If the name of a FbxShape backing a blendshape channel is left as an empty string, multiple blend shapes on the same object fail to export properly. Only the last blendshape modifier is used, regardless of which is enabled. This fixes it.