### PR TITLE
Update to 2019.3

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -6,7 +6,7 @@
 # tests.
 #
 test_editors:
-  - version: 2019.1
+  - version: 2019.3
 test_platforms:
   - name: win
     type: Unity::VM
@@ -35,26 +35,6 @@ promotion_test_{{ platform.name }}_{{ editor.version }}:
         - "upm-ci~/packages/**/*"
   dependencies:
     - .yamato/upm-ci.yml#pack
-{% endfor %}
-{% endfor %}
-
-promotion_test_trigger:
-  name: Promotion Tests Trigger
-  agent:
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.small
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-    packages:
-      paths:
-        - "upm-ci~/packages/**/*"
-  dependencies:
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-    - .yamato/promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
 {% endfor %}
 {% endfor %}
 

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -3,6 +3,7 @@ editors:
   - version: 2018.4
   - version: 2019.1
   - version: 2019.2
+  - version: 2019.3
 platforms:
   - name: win
     type: Unity::VM
@@ -54,12 +55,6 @@ test_{{ platform.name }}_{{ editor.version }}:
 
 test_trigger:
   name: Tests Trigger
-  agent:
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.small
-  commands:
-    - dir
   triggers:
     branches:
       only:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -61,13 +61,6 @@ test_trigger:
         - "/.*/"
       except:
         - master
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-    packages:
-      paths:
-        - "upm-ci~/packages/**/*"
   dependencies:
     - .yamato/upm-ci.yml#pack
 {% for editor in editors %}


### PR DESCRIPTION
Also remove a job we weren't using, and make a virtual job from a job that was
doing nothing on its machine (fixing a warning, speeding up builds).

This is stuff I saw while working on the soft dependence.