### PR TITLE
UT-3313 don't reduce keyframes after recording and before exporting

### DIFF
--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -38,12 +38,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var absolutePath = FileNameGenerator.SanitizePath(settings.FileNameGenerator.BuildAbsolutePath(session));
                 var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
                 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2019_3_OR_NEWER
                 var options = new Animations.CurveFilterOptions();
                 options.keyframeReduction = false;
                 aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
 #else
-                aInput.gameObjectRecorder.SaveToClip(clip);
+                aInput.gameObjectRecorder.SaveToClip(clip, settings.FrameRate);
 #endif
                 var root = ((AnimationInputSettings)aInput.settings).gameObject;
                 clip.name = "recorded_clip";

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -43,7 +43,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 options.keyframeReduction = false;
                 aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
 #else
-                aInput.gameObjectRecorder.SaveToClip(clip, settings.FrameRate);
+                aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);
 #endif
                 var root = ((AnimationInputSettings)aInput.settings).gameObject;
                 clip.name = "recorded_clip";

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -39,7 +39,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
                 
 #if UNITY_2018_3_OR_NEWER
-                aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);
+                var options = new Animations.CurveFilterOptions();
+                options.keyframeReduction = false;
+                aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
 #else
                 aInput.gameObjectRecorder.SaveToClip(clip);
 #endif


### PR DESCRIPTION
- baking, reducing keyframes and baking again can create unnecessary errors/discrepancies in the exported curve.
- for the particular issue being fixed (UT-3313), the recorded curves originally had constant/linear tangents, which then became cubic after recording (as the recorder loses tangent information). This combined with keyframe reduction resulted in jitteryness where there should have been clean transitions between blocking positions.