### PR TITLE
UT-3389 export bones in original position instead of bindpose

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -957,11 +957,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     fbxPreRotationQuaternion.Inverse();
 
                     // Multiply LclRotation by pre-rotation inverse to get the LclRotation without pre-rotation applied
-                    var fbxFinalQuat = fbxPreRotationQuaternion * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
+                    var finalLclRotationQuat = fbxPreRotationQuaternion * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
 
-                    var quatToEulerMatrix = new FbxAMatrix();
-                    quatToEulerMatrix.SetQ(fbxFinalQuat);
-                    fbxBone.LclRotation.Set(ToFbxDouble3(quatToEulerMatrix.GetR()));
+                    // Convert to Euler without axis conversion (Pre-rotation and LclRotation were already in Maya axis)
+                    // and update LclRotation
+                    fbxBone.LclRotation.Set(ToFbxDouble3(QuaternionToEuler(finalLclRotationQuat)));
                 }
             }
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -947,18 +947,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
                     ExportTransform(bone, fbxBone, newCenter: Vector3.zero, TransformExportType.Local);
 
-                    // cancel out the pre-rotation from the exported rotation
+                    // Cancel out the pre-rotation from the exported rotation
+
+                    // Get prerotation
                     var fbxPreRotationEuler = fbxBone.GetPreRotation(FbxNode.EPivotSet.eSourcePivot);
-                    // Get the inverse of the prerotation
+                    // Convert the prerotation to a Quaternion (so that it can be inverted)
                     var fbxPreRotationInverse = ModelExporter.EulerToQuaternion(fbxPreRotationEuler);
+                    // Get the inverse of the prerotation
                     fbxPreRotationInverse.Inverse();
 
+                    // Multiply LclRotation by pre-rotation inverse to get the LclRotation without pre-rotation applied
                     var fbxFinalQuat = fbxPreRotationInverse * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
 
-                    var finalUnityQuat = new FbxQuaternion((float)fbxFinalQuat.X, (float)fbxFinalQuat.Y, (float)fbxFinalQuat.Z, (float)fbxFinalQuat.W);
-
                     var quatToEulerMatrix = new FbxAMatrix();
-                    quatToEulerMatrix.SetQ(finalUnityQuat);
+                    quatToEulerMatrix.SetQ(fbxFinalQuat);
                     fbxBone.LclRotation.Set(ToFbxDouble3(quatToEulerMatrix.GetR()));
                 }
             }

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -952,7 +952,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     // Get prerotation
                     var fbxPreRotationEuler = fbxBone.GetPreRotation(FbxNode.EPivotSet.eSourcePivot);
                     // Convert the prerotation to a Quaternion
-                    var fbxPreRotationQuaternion = ModelExporter.EulerToQuaternion(fbxPreRotationEuler);
+                    var fbxPreRotationQuaternion = EulerToQuaternion(fbxPreRotationEuler);
                     // Inverse of the prerotation
                     fbxPreRotationQuaternion.Inverse();
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -951,13 +951,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                     // Get prerotation
                     var fbxPreRotationEuler = fbxBone.GetPreRotation(FbxNode.EPivotSet.eSourcePivot);
-                    // Convert the prerotation to a Quaternion (so that it can be inverted)
-                    var fbxPreRotationInverse = ModelExporter.EulerToQuaternion(fbxPreRotationEuler);
-                    // Get the inverse of the prerotation
-                    fbxPreRotationInverse.Inverse();
+                    // Convert the prerotation to a Quaternion
+                    var fbxPreRotationQuaternion = ModelExporter.EulerToQuaternion(fbxPreRotationEuler);
+                    // Inverse of the prerotation
+                    fbxPreRotationQuaternion.Inverse();
 
                     // Multiply LclRotation by pre-rotation inverse to get the LclRotation without pre-rotation applied
-                    var fbxFinalQuat = fbxPreRotationInverse * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
+                    var fbxFinalQuat = fbxPreRotationQuaternion * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
 
                     var quatToEulerMatrix = new FbxAMatrix();
                     quatToEulerMatrix.SetQ(fbxFinalQuat);


### PR DESCRIPTION
When exporting bones of skinned meshes, their transform values are first set to the bindpose, so that the skin and bindpose are exported properly.

However, afterwards we need to set the bones back to their original transform values so that if the character is not in the bindpose on export, the same pose is maintained in the FBX.

This fixes fogbug: https://fogbugz.unity3d.com/f/cases/1185725/