### PR TITLE
UT-3401 fix failing blendshape unit tests

### DIFF
--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -564,7 +564,13 @@ namespace FbxExporter.UnitTests
             importer.importBlendShapeNormals = ModelImporterNormals.None;
             importer.weldVertices = true;
 #else
+            importer.importBlendShapes = true;
             importer.optimizeMesh = false;
+            importer.meshCompression = ModelImporterMeshCompression.Off;
+            // If either blendshape normals are imported or weldVertices is turned off (or both),
+            // the vertex count between the original and exported meshes does not match.
+            importer.importBlendShapeNormals = ModelImporterNormals.None;
+            importer.weldVertices = true;
 #endif // UNITY_2019_1_OR_NEWER
             importer.SaveAndReimport();
 

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -561,6 +561,7 @@ namespace FbxExporter.UnitTests
             importer.meshCompression = ModelImporterMeshCompression.Off;
             // If either blendshape normals are imported or weldVertices is turned off (or both),
             // the vertex count between the original and exported meshes does not match.
+            // TODO (UT-3410): investigate why the original and exported blendshape normals split the vertices differently.
             importer.importBlendShapeNormals = ModelImporterNormals.None;
             importer.weldVertices = true;
 #else
@@ -569,6 +570,7 @@ namespace FbxExporter.UnitTests
             importer.meshCompression = ModelImporterMeshCompression.Off;
             // If either blendshape normals are imported or weldVertices is turned off (or both),
             // the vertex count between the original and exported meshes does not match.
+            // TODO (UT-3410): investigate why the original and exported blendshape normals split the vertices differently.
             importer.importBlendShapeNormals = ModelImporterNormals.None;
             importer.weldVertices = true;
 #endif // UNITY_2019_1_OR_NEWER

--- a/com.unity.formats.fbx/Tests/Models/blendshape.fbx.meta
+++ b/com.unity.formats.fbx/Tests/Models/blendshape.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: b705ecb2a64d54064b278c16d1926bee
 ModelImporter:
-  serializedVersion: 26
+  serializedVersion: 19300
   internalIDToNameTable:
   - first:
       1: 100000
@@ -26,7 +26,7 @@ ModelImporter:
     second: ImportLogs
   externalObjects: {}
   materials:
-    importMaterials: 1
+    materialImportMode: 1
     materialName: 0
     materialSearch: 1
     materialLocation: 1
@@ -59,6 +59,7 @@ ModelImporter:
     meshCompression: 0
     addColliders: 0
     useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -85,11 +86,10 @@ ModelImporter:
     tangentImportMode: 3
     normalCalculationMode: 4
     legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
-    blendShapeNormalImportMode: 1
+    blendShapeNormalImportMode: 2
     normalSmoothingSource: 0
   referencedClips: []
   importAnimation: 1
-  copyAvatar: 0
   humanDescription:
     serializedVersion: 3
     human: []
@@ -107,8 +107,10 @@ ModelImporter:
     hasExtraRoot: 0
     skeletonHasParents: 1
   lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
   animationType: 2
   humanoidOversampling: 1
+  avatarSetup: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/com.unity.formats.fbx/Tests/Models/blendshape.fbx.meta
+++ b/com.unity.formats.fbx/Tests/Models/blendshape.fbx.meta
@@ -67,6 +67,7 @@ ModelImporter:
     swapUVChannels: 0
     generateSecondaryUV: 0
     useFileUnits: 1
+    optimizeMeshForGPU: 0
     keepQuads: 0
     weldVertices: 1
     preserveHierarchy: 0

--- a/com.unity.formats.fbx/Tests/Models/blendshape_with_skinning.fbx.meta
+++ b/com.unity.formats.fbx/Tests/Models/blendshape_with_skinning.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 00d7679ab4124488a95ff1f947bc82cc
 ModelImporter:
-  serializedVersion: 26
+  serializedVersion: 19300
   internalIDToNameTable:
   - first:
       1: 100000
@@ -68,7 +68,7 @@ ModelImporter:
     second: ImportLogs
   externalObjects: {}
   materials:
-    importMaterials: 1
+    materialImportMode: 1
     materialName: 0
     materialSearch: 1
     materialLocation: 1
@@ -101,6 +101,7 @@ ModelImporter:
     meshCompression: 0
     addColliders: 0
     useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -127,11 +128,10 @@ ModelImporter:
     tangentImportMode: 3
     normalCalculationMode: 4
     legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
-    blendShapeNormalImportMode: 1
+    blendShapeNormalImportMode: 2
     normalSmoothingSource: 0
   referencedClips: []
   importAnimation: 1
-  copyAvatar: 0
   humanDescription:
     serializedVersion: 3
     human: []
@@ -149,8 +149,10 @@ ModelImporter:
     hasExtraRoot: 0
     skeletonHasParents: 1
   lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
   animationType: 2
   humanoidOversampling: 1
+  avatarSetup: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/com.unity.formats.fbx/Tests/Models/blendshape_with_skinning.fbx.meta
+++ b/com.unity.formats.fbx/Tests/Models/blendshape_with_skinning.fbx.meta
@@ -109,6 +109,7 @@ ModelImporter:
     swapUVChannels: 0
     generateSecondaryUV: 0
     useFileUnits: 1
+    optimizeMeshForGPU: 0
     keepQuads: 0
     weldVertices: 1
     preserveHierarchy: 0

--- a/com.unity.formats.fbx/package.json
+++ b/com.unity.formats.fbx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.formats.fbx",
   "displayName": "FBX Exporter",
-  "version": "3.1.0-preview.1",
+  "version": "3.2.0-preview.1",
   "dependencies": {
     "com.unity.recorder": "2.1.0-preview.1",
     "com.unity.timeline": "1.0.0",


### PR DESCRIPTION
make sure blendshape normals aren't imported on the original FBX files

If blendshape normals are imported the vertex count between the original and exported meshes won't match. They can't be imported for either the exported file or the original one.