### PR TITLE
UT-3390 fix failing unit tests on 2018.3

### DIFF
--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -852,24 +852,15 @@ namespace FbxExporter.UnitTests
             SkinnedMeshRenderer originalSMR, exportedSMR;
             SetImportSettings setImportSettings = (importer) =>
             {
-#if UNITY_2019_1_OR_NEWER
                 importer.importBlendShapes = true;
+                importer.meshCompression = ModelImporterMeshCompression.Off;
+
+#if UNITY_2019_1_OR_NEWER
                 importer.optimizeMeshPolygons = false;
                 importer.optimizeMeshVertices = false;
-                importer.meshCompression = ModelImporterMeshCompression.Off;
-
-                importer.importNormals = ModelImporterNormals.Import;
-                importer.importTangents = ModelImporterTangents.CalculateMikk;
-
-                // If either blendshape normals are imported or weldVertices is turned off (or both),
-                // the vertex count between the original and exported meshes does not match.
-                // TODO (UT-3410): investigate why the original and exported blendshape normals split the vertices differently.
-                importer.importBlendShapeNormals = ModelImporterNormals.None;
-                importer.weldVertices = true;
 #else
-                importer.importBlendShapes = true;
                 importer.optimizeMesh = false;
-                importer.meshCompression = ModelImporterMeshCompression.Off;
+#endif // UNITY_2019_1_OR_NEWER
 
 #if UNITY_2018_4_OR_NEWER
                 importer.importNormals = ModelImporterNormals.Import;
@@ -879,13 +870,11 @@ namespace FbxExporter.UnitTests
                 // are imported.
                 importer.importNormals = ModelImporterNormals.None;
 #endif
-
                 // If either blendshape normals are imported or weldVertices is turned off (or both),
                 // the vertex count between the original and exported meshes does not match.
                 // TODO (UT-3410): investigate why the original and exported blendshape normals split the vertices differently.
                 importer.importBlendShapeNormals = ModelImporterNormals.None;
                 importer.weldVertices = true;
-#endif // UNITY_2019_1_OR_NEWER
             };
 
             var exportedFbxPath = ExportSkinnedMesh (fbxPath, out originalSMR, out exportedSMR, setImportSettings);

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -871,9 +871,14 @@ namespace FbxExporter.UnitTests
                 importer.optimizeMesh = false;
                 importer.meshCompression = ModelImporterMeshCompression.Off;
 
+#if UNITY_2018_4_OR_NEWER
+                importer.importNormals = ModelImporterNormals.Import;
+                importer.importTangents = ModelImporterTangents.CalculateMikk;
+#else
                 // In 2018.3, the vertices still do not match unless no normals
                 // are imported.
                 importer.importNormals = ModelImporterNormals.None;
+#endif
 
                 // If either blendshape normals are imported or weldVertices is turned off (or both),
                 // the vertex count between the original and exported meshes does not match.

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -542,10 +542,8 @@ namespace FbxExporter.UnitTests
         }
 
         private delegate void SetImportSettings(ModelImporter importer);
-        private string ExportSkinnedMesh(
+        private (string filename, SkinnedMeshRenderer originalSkinnedMesh, SkinnedMeshRenderer exportedSkinnedMesh) ExportSkinnedMesh(
             string fileToExport, 
-            out SkinnedMeshRenderer originalSkinnedMesh,
-            out SkinnedMeshRenderer exportedSkinnedMesh,
             SetImportSettings setImportSettings = null)
         {
             // change import settings of original FBX
@@ -577,13 +575,13 @@ namespace FbxExporter.UnitTests
             GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             Assert.IsTrue (fbxObj);
 
-            originalSkinnedMesh = originalGO.GetComponentInChildren<SkinnedMeshRenderer> ();
+            var originalSkinnedMesh = originalGO.GetComponentInChildren<SkinnedMeshRenderer> ();
             Assert.IsNotNull (originalSkinnedMesh);
 
-            exportedSkinnedMesh = fbxObj.GetComponentInChildren<SkinnedMeshRenderer> ();
+            var exportedSkinnedMesh = fbxObj.GetComponentInChildren<SkinnedMeshRenderer> ();
             Assert.IsNotNull (exportedSkinnedMesh);
 
-            return filename;
+            return (filename, originalSkinnedMesh, exportedSkinnedMesh);
         }
 
         public class SkinnedMeshTestDataClass
@@ -622,7 +620,9 @@ namespace FbxExporter.UnitTests
             Assert.That (fbxPath, Is.Not.Null);
 
             SkinnedMeshRenderer originalSkinnedMesh, exportedSkinnedMesh;
-            ExportSkinnedMesh (fbxPath, out originalSkinnedMesh, out exportedSkinnedMesh);
+            var exportResult = ExportSkinnedMesh (fbxPath);
+            originalSkinnedMesh = exportResult.originalSkinnedMesh;
+            exportedSkinnedMesh = exportResult.exportedSkinnedMesh;
 
             Assert.IsTrue (originalSkinnedMesh.name == exportedSkinnedMesh.name ||
                 (originalSkinnedMesh.transform.parent == null && exportedSkinnedMesh.transform.parent == null));
@@ -877,7 +877,11 @@ namespace FbxExporter.UnitTests
                 importer.weldVertices = true;
             };
 
-            var exportedFbxPath = ExportSkinnedMesh (fbxPath, out originalSMR, out exportedSMR, setImportSettings);
+            var exportResult = ExportSkinnedMesh (fbxPath, setImportSettings);
+            var exportedFbxPath = exportResult.filename;
+            originalSMR = exportResult.originalSkinnedMesh;
+            exportedSMR = exportResult.exportedSkinnedMesh;
+
 
             var originalMesh = originalSMR.sharedMesh;
             var exportedMesh = exportedSMR.sharedMesh;


### PR DESCRIPTION
- pass optional import settings to ExportSkinnedMesh
- change import settings for both original and exported mesh to make sure they match