### PR TITLE
UT-3407 run promotion test on 2018.4 instead of 2019.3

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -6,7 +6,7 @@
 # tests.
 #
 test_editors:
-  - version: 2019.3
+  - version: 2018.4
 test_platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -6,7 +6,7 @@
 # tests.
 #
 test_editors:
-  - version: 2018.4
+  - version: 2018.3
 test_platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -15,7 +15,7 @@ platforms:
     flavor: b1.medium
   - name: mac
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
 ---
 pack:

--- a/com.unity.formats.fbx/package.json
+++ b/com.unity.formats.fbx/package.json
@@ -4,7 +4,7 @@
   "version": "3.2.0-preview.2",
   "dependencies": {
     "com.unity.recorder": "2.2.0-preview.4",
-    "com.unity.timeline": "1.0.0",
+    "com.unity.timeline": "1.2.6",
     "com.autodesk.fbx": "3.0.1-preview.1"
   },
   "unity": "2018.3",


### PR DESCRIPTION
- to not hit an issue with the timeline not being on the production server