### PR TITLE
bug #1242332 - [Mac] Editor focus lockup when exporting an FBX using …

### DIFF
--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -281,7 +281,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
         internal static List<GameObject> GetSceneReferencesToObject(Object obj)
         {
             var sceneHierarchyWindowType = typeof(UnityEditor.SearchableEditorWindow).Assembly.GetType("UnityEditor.SceneHierarchyWindow");
-            var sceneHierarchyWindow = EditorWindow.GetWindow(sceneHierarchyWindowType);
+
+            // bug 1242332: don't grab the focus!
+            // The arguments aren't actually optional so they must all be named.
+            //
+            // todo: We should cache all the window-getting and reflection so it
+            // happens not once per object but once per convert.
+            var sceneHierarchyWindow = EditorWindow.GetWindow(
+                    t: sceneHierarchyWindowType,
+                    utility: false,
+                    title: null,
+                    focus: false);
             var instanceID = obj.GetInstanceID();
             var idFormat = "ref:{0}:";
 


### PR DESCRIPTION
…FBX Exporter

AKA UT-3571.

This is a quick-fix that fixes grabbing the focus of the hiearchy view.

This doesn't really improve the time, but it allows the user to surf the web
while waiting.