### PR TITLE
UT-3484: When no objects are selected, exporting to Unity creates an empty FBX file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changes in Fbx Exporter
 
-## [3.2.1-preview.1] - 2020-07-16
-### Changed
-- Do not create an empty FBX file when user tries to export from 3ds Max with no object or export set selected.
-
 ## [3.2.0-preview.2] - 2020-05-19
 ### Added
 - Added an option to the Autodesk® Maya® integration Unity menu for creating an export set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Fbx Exporter
 
+## [3.2.1-preview.1] - 2020-07-16
+### Changed
+- Do not create an empty FBX file when user tries to export from 3ds Max with no object or export set selected.
+
 ## [3.2.0-preview.2] - 2020-05-19
 ### Added
 - Added an option to the Autodesk® Maya® integration Unity menu for creating an export set.

--- a/Integrations/Autodesk/max/scripts/UnityFbxForMaxPlugin.ms
+++ b/Integrations/Autodesk/max/scripts/UnityFbxForMaxPlugin.ms
@@ -298,43 +298,42 @@ struct UnityExportHelpers (
         )
         
         origSelection = getCurrentSelection()
-        
-        local origUnits = units.SystemType
-        units.SystemType = #Centimeters
-        
-        -- get all the unity export sets
-        local unityExportSets = UnityExportHelpers.getUnityExportSets()
-        
-        -- find all sets that contain at least one object from the current selection
-        local setsToExport = #()
-        for expSet in unityExportSets do (
-            for obj in origSelection do (
-                -- append export set as set to export if obj is in the set or obj is
-                -- dummy for this set
-                if (findItem expSet obj > 0) or (obj.name == expSet.name and (isProperty obj "modelFilePath")) do (
-                    appendIfUnique setsToExport expSet
-                    break
+
+        if origSelection != undefined and origSelection.count > 0 then (
+            local origUnits = units.SystemType
+            units.SystemType = #Centimeters
+            
+            -- get all the unity export sets
+            local unityExportSets = UnityExportHelpers.getUnityExportSets()
+            
+            -- find all sets that contain at least one object from the current selection
+            local setsToExport = #()
+            for expSet in unityExportSets do (
+                for obj in origSelection do (
+                    -- append export set as set to export if obj is in the set or obj is
+                    -- dummy for this set
+                    if (findItem expSet obj > 0) or (obj.name == expSet.name and (isProperty obj "modelFilePath")) do (
+                        appendIfUnique setsToExport expSet
+                        break
+                    )
                 )
             )
-        )
-        
-        -- if no sets are selected, then export selection, otherwise export each set to its corresponding file
-        if (setsToExport.count <= 0) then (
-            local unityProjectPath = getINISetting (GetMAXIniFile()) "Unity" "UnityProject"
-            local exportFileName = getSaveFileName caption:"Export FBX to Unity" filename:(unityProjectPath + "/Assets/") types:"FBX (*.fbx)|*.fbx|"
-            if exportFileName != undefined do (
-                exportFile exportFileName #noPrompt selectedOnly:true using:FBXEXP
+            
+            -- if no sets are selected, then export selection, otherwise export each set to its corresponding file
+            if (setsToExport.count <= 0) then (
+                local unityProjectPath = getINISetting (GetMAXIniFile()) "Unity" "UnityProject"
+                local exportFileName = getSaveFileName caption:"Export FBX to Unity" filename:(unityProjectPath + "/Assets/") types:"FBX (*.fbx)|*.fbx|"
+                if exportFileName != undefined do (
+                    exportFile exportFileName #noPrompt selectedOnly:true using:FBXEXP
+                )
             )
-        )
-        else (
-            for expSet in setsToExport do (
-                UnityExportHelpers.exportUnitySet expSet
+            else (
+                for expSet in setsToExport do (
+                    UnityExportHelpers.exportUnitySet expSet
+                )
             )
-        )
-        
-        units.SystemType = origUnits
-        
-        if origSelection != undefined then (
+            
+            units.SystemType = origUnits
             select origSelection
         )
     )


### PR DESCRIPTION
Previously, when no objects are selected, exporting to Unity creates an empty FBX file:
![image](https://user-images.githubusercontent.com/6233749/87708768-3acd8200-c771-11ea-93ea-b950d6c2258c.png)


In 3ds Max, export should only be possible if an object or export set is selected.

Selecting "Export to Unity" or "Export to Unity (Model Only)" with no selection now does nothing. This is to match the current behavior in Maya.

Updating ChangeLog.

