### PR TITLE
UT-3305 Export Outside Assets Folder

### DIFF
--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -371,13 +371,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
             ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup (ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
 
             // Set export setting for exporting outside the project on choosing a path
-            if (pathLabels[ExportSettings.instance.SelectedFbxPath].Contains("Assets"))
+            if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(ExportSettings.FbxAbsoluteSavePath)))
             {
-                ExportSettings.instance.ExportOutsideProject = false;
+                ExportSettings.instance.ExportOutsideProject = true;
             }
             else
             {
-                ExportSettings.instance.ExportOutsideProject = true;
+                ExportSettings.instance.ExportOutsideProject = false;
             }
 
             if (GUILayout.Button(new GUIContent("...", "Browse to a new location to export to"), EditorStyles.miniButton, GUILayout.Width(BrowseButtonWidth)))

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -366,7 +366,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 "Export Path",
                 "Relative path for saving Model Prefabs."),GUILayout.Width(LabelWidth - FieldOffset));
 
-            var pathLabels = ExportSettings.GetDisplayFbxSavePaths();
+            var pathLabels = ExportSettings.GetMixedFbxSavePaths();
 
             if (this is ConvertToPrefabEditorWindow)
             {

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -370,6 +370,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup (ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
 
+            // Set export setting for exporting outside the project on choosing a path
+            if (pathLabels[ExportSettings.instance.SelectedFbxPath].Contains("Assets"))
+            {
+                ExportSettings.instance.ExportOutsideProject = false;
+            }
+            else
+            {
+                ExportSettings.instance.ExportOutsideProject = true;
+            }
+
             if (GUILayout.Button(new GUIContent("...", "Browse to a new location to export to"), EditorStyles.miniButton, GUILayout.Width(BrowseButtonWidth)))
             {
                 string initialPath = Application.dataPath;
@@ -384,11 +394,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);
                     if (string.IsNullOrEmpty(relativePath))
                     {
-                        // Set a flag that we're exporting outside Assets folder
-                        ExportSettings.AddFbxSavePath(fullPath, true);
+                        // We're exporting outside Assets folder, so store the full path
+                        ExportSettings.AddFbxSavePath(fullPath);
                     }
                     else
                     {
+                        // Store the relative path
                         ExportSettings.AddFbxSavePath(relativePath);
                     }
                     // Make sure focus is removed from the selectable label

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -366,6 +366,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 "Export Path",
                 "Relative path for saving Model Prefabs."),GUILayout.Width(LabelWidth - FieldOffset));
 
+            // TODO change how displayed
             var pathLabels = ExportSettings.GetRelativeFbxSavePaths();
 
             ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup (ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
@@ -384,17 +385,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);
                     if (string.IsNullOrEmpty(relativePath))
                     {
-                        Debug.LogWarning("Please select a location in the Assets folder");
+                        // Set a flag that we're exporting outside Assets folder
+                        ExportSettings.AddFbxSavePath(fullPath, true);
                     }
                     else
                     {
                         ExportSettings.AddFbxSavePath(relativePath);
-
-                        // Make sure focus is removed from the selectable label
-                        // otherwise it won't update
-                        GUIUtility.hotControl = 0;
-                        GUIUtility.keyboardControl = 0;
                     }
+                    // Make sure focus is removed from the selectable label
+                    // otherwise it won't update
+                    GUIUtility.hotControl = 0;
+                    GUIUtility.keyboardControl = 0;
                 }
             }
             GUILayout.EndHorizontal();
@@ -633,6 +634,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Debug.LogError ("FbxExporter: Please specify an fbx filename");
                 return false;
             }
+            // TODO fix this
             var folderPath = ExportSettings.FbxAbsoluteSavePath;
             var filePath = System.IO.Path.Combine (folderPath, ExportFileName + ".fbx");
 

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -397,19 +397,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 if (!string.IsNullOrEmpty(fullPath))
                 {
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);
+
+                    // If exporting an fbx for a prefab, not allowed to export outside the Assets folder
                     if (this is ConvertToPrefabEditorWindow && string.IsNullOrEmpty(relativePath))
                     {
-                        // if exporting a prefab, not allowed to export outside project
                         Debug.LogWarning("Please select a location in the Assets folder");
                     }
+                    // We're exporting outside Assets folder, so store the absolute path
                     else if (string.IsNullOrEmpty(relativePath))
                     {
-                        // We're exporting outside Assets folder, so store the full path
                         ExportSettings.AddFbxSavePath(fullPath);
                     }
+                    // Store the relative path to the Assets folder
                     else
                     {
-                        // Store the relative path
                         ExportSettings.AddFbxSavePath(relativePath);
                     }
                     // Make sure focus is removed from the selectable label

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -368,6 +368,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             var pathLabels = ExportSettings.GetDisplayFbxSavePaths();
 
+            if (this is ConvertToPrefabEditorWindow)
+            {
+                pathLabels = ExportSettings.GetRelativeFbxSavePaths();
+            }
+
             ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup (ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
 
             // Set export setting for exporting outside the project on choosing a path
@@ -392,7 +397,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 if (!string.IsNullOrEmpty(fullPath))
                 {
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);
-                    if (string.IsNullOrEmpty(relativePath))
+                    if (this is ConvertToPrefabEditorWindow && string.IsNullOrEmpty(relativePath))
+                    {
+                        // if exporting a prefab, not allowed to export outside project
+                        Debug.LogWarning("Please select a location in the Assets folder");
+                    }
+                    else if (string.IsNullOrEmpty(relativePath))
                     {
                         // We're exporting outside Assets folder, so store the full path
                         ExportSettings.AddFbxSavePath(fullPath);

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -364,7 +364,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent(
                 "Export Path",
-                "Relative path for saving Model Prefabs."),GUILayout.Width(LabelWidth - FieldOffset));
+                "Location where the FBX will be saved."),GUILayout.Width(LabelWidth - FieldOffset));
 
             var pathLabels = ExportSettings.GetMixedFbxSavePaths();
 

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -378,7 +378,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     "Select Export Model Path", initialPath, null
                 );
 
-                // Unless the user canceled, mark if they chose something in the Assets folder.
+                // Unless the user canceled, save path.
                 if (!string.IsNullOrEmpty(fullPath))
                 {
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -366,8 +366,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 "Export Path",
                 "Relative path for saving Model Prefabs."),GUILayout.Width(LabelWidth - FieldOffset));
 
-            // TODO change how displayed
-            var pathLabels = ExportSettings.GetRelativeFbxSavePaths();
+            var pathLabels = ExportSettings.GetDisplayFbxSavePaths();
 
             ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup (ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
 
@@ -379,7 +378,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     "Select Export Model Path", initialPath, null
                 );
 
-                // Unless the user canceled, make sure they chose something in the Assets folder.
+                // Unless the user canceled, mark if they chose something in the Assets folder.
                 if (!string.IsNullOrEmpty(fullPath))
                 {
                     var relativePath = ExportSettings.ConvertToAssetRelativePath(fullPath);
@@ -634,7 +633,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Debug.LogError ("FbxExporter: Please specify an fbx filename");
                 return false;
             }
-            // TODO fix this
             var folderPath = ExportSettings.FbxAbsoluteSavePath;
             var filePath = System.IO.Path.Combine (folderPath, ExportFileName + ".fbx");
 

--- a/com.unity.formats.fbx/Editor/ExportModelSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelSettings.cs
@@ -99,7 +99,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Preserve Import Settings for Existing FBX",
                 "If checked, the import settings from the overwritten FBX will be carried over to the new version."), GUILayout.Width(LabelWidth - FieldOffset));
+            // greyed out if exporting outside assets folder
+            EditorGUI.BeginDisabledGroup(ExportSettings.instance.ExportOutsideProject);
             exportSettings.SetPreserveImportSettings(EditorGUILayout.Toggle(exportSettings.PreserveImportSettings));
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
         }
     }
@@ -185,7 +188,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public override bool ExportUnrendered { get { return exportUnrendered; } }
         public void SetExportUnredererd(bool exportUnrendered){ this.exportUnrendered = exportUnrendered; }
         public override bool PreserveImportSettings { get { return preserveImportSettings; } }
-        public void SetPreserveImportSettings(bool preserveImportSettings){ this.preserveImportSettings = preserveImportSettings; }
+        public void SetPreserveImportSettings(bool preserveImportSettings){ this.preserveImportSettings = preserveImportSettings && !ExportSettings.instance.ExportOutsideProject; }
         public override bool AllowSceneModification { get { return false; } }
     }
 }

--- a/com.unity.formats.fbx/Editor/ExportModelSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelSettings.cs
@@ -177,7 +177,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private ExportSettings.ObjectPosition objectPosition = ExportSettings.ObjectPosition.LocalCentered;
         [SerializeField]
         private bool exportUnrendered = true;
-        private bool preserveImportSettings = true;
+        private bool preserveImportSettings = false;
 
         public override ExportSettings.Include ModelAnimIncludeOption { get { return include; } }
         public void SetModelAnimIncludeOption(ExportSettings.Include include) { this.include = include; }

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -285,6 +285,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
         public enum LODExportType { All = 0, Highest = 1, Lowest = 2 }
 
+        public bool ExportOutsideProject;
+
         internal const string kDefaultSavePath = ".";
         private static List<string> s_PreferenceList = new List<string>() {kMayaOptionName, kMayaLtOptionName, kMaxOptionName};
         //Any additional names require a space after the name
@@ -1168,13 +1170,13 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         /// <param name="savePath">Save path.</param>
         /// <param name="exportSavePaths">Export save paths.</param>
-        private static void AddSavePath(string savePath, ref List<string> exportSavePaths, bool absolute = false){
+        private static void AddSavePath(string savePath, ref List<string> exportSavePaths){
             if(exportSavePaths == null)
             {
                 return;
             }
 
-            if (absolute)
+            if (ExportSettings.instance.ExportOutsideProject)
             {
                 savePath = NormalizePath(savePath, isRelative: false);
             }
@@ -1199,8 +1201,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             exportSavePaths.Insert (0, savePath);
         }
 
-        internal static void AddFbxSavePath(string savePath, bool absolute = false){
-            AddSavePath (savePath, ref instance.fbxSavePaths, absolute);
+        internal static void AddFbxSavePath(string savePath){
+            AddSavePath (savePath, ref instance.fbxSavePaths);
             instance.SelectedFbxPath = 0;
         }
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1107,7 +1107,9 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
+                // TODO format better
+                //relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
+                relSavePaths[i] = exportSavePaths[i].Replace("/", forwardslash);
             }
             return relSavePaths;
         }
@@ -1135,13 +1137,21 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         /// <param name="savePath">Save path.</param>
         /// <param name="exportSavePaths">Export save paths.</param>
-        private static void AddSavePath(string savePath, ref List<string> exportSavePaths){
+        private static void AddSavePath(string savePath, ref List<string> exportSavePaths, bool absolute = false){
             if(exportSavePaths == null)
             {
                 return;
             }
 
-            savePath = NormalizePath (savePath, isRelative: true);
+            if (absolute)
+            {
+                savePath = NormalizePath(savePath, isRelative: false);
+            }
+            else
+            {
+                savePath = NormalizePath(savePath, isRelative: true);
+            }
+
             if (exportSavePaths.Contains (savePath)) {
                 // move to first place if it isn't already
                 if (exportSavePaths [0] == savePath) {
@@ -1158,8 +1168,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             exportSavePaths.Insert (0, savePath);
         }
 
-        internal static void AddFbxSavePath(string savePath){
-            AddSavePath (savePath, ref instance.fbxSavePaths);
+        internal static void AddFbxSavePath(string savePath, bool absolute = false){
+            AddSavePath (savePath, ref instance.fbxSavePaths, absolute);
             instance.SelectedFbxPath = 0;
         }
 
@@ -1168,10 +1178,18 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             instance.SelectedPrefabPath = 0;
         }
 
+        // TODO fix this
         internal static string GetAbsoluteSavePath(string relativePath){
             var absolutePath = Path.Combine(Application.dataPath, relativePath);
-            return NormalizePath(absolutePath, isRelative: false,
-                separator: Path.DirectorySeparatorChar);
+            absolutePath = NormalizePath(absolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);
+            
+            // check if path is actually absolute
+            if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(absolutePath)))
+            {
+                return relativePath;
+            }
+
+            return absolutePath;
         }
 
         internal static string FbxAbsoluteSavePath{

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1183,7 +1183,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             var absolutePath = Path.Combine(Application.dataPath, relativePath);
             absolutePath = NormalizePath(absolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);
             
-            // check if path is actually absolute
+            // check if path is outside Assets folder
             if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(absolutePath)))
             {
                 return relativePath;

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1109,10 +1109,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                if ((!Path.IsPathRooted(exportSavePaths[i])))
-                {
-                    relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
-                }
+                relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
             }
             return relSavePaths;
         }
@@ -1145,9 +1142,20 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// The path where Export model will save the new fbx.
         /// This is relative to the Application.dataPath ; it uses '/' as the
         /// separator on all platforms.
+        /// Only returns the paths within the Assets folder of the project.
         /// </summary>
         internal static string[] GetRelativeFbxSavePaths(){
-            return GetRelativeSavePaths(instance.fbxSavePaths);
+            // sort the list of paths, putting project paths first
+            instance.fbxSavePaths.Sort((x, y) => Path.IsPathRooted(x).CompareTo(Path.IsPathRooted(y)));
+            var relPathCount = instance.fbxSavePaths.FindAll(x => !Path.IsPathRooted(x)).Count;
+
+            // reset selected path if it's out of range
+            if (instance.SelectedFbxPath > relPathCount - 1)
+            {
+                instance.SelectedFbxPath = 0;
+            }
+
+            return GetRelativeSavePaths(instance.fbxSavePaths.GetRange(0, relPathCount));
         }
 
         /// <summary>

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1109,7 +1109,14 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
+                if ((!Path.IsPathRooted(exportSavePaths[i])))
+                {
+                    relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
+                }
+                else
+                {
+                    continue;
+                }
             }
             return relSavePaths;
         }

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1211,7 +1211,6 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             instance.SelectedPrefabPath = 0;
         }
 
-        // TODO fix this
         internal static string GetAbsoluteSavePath(string relativePath){
             var absolutePath = Path.Combine(Application.dataPath, relativePath);
             absolutePath = NormalizePath(absolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1154,6 +1154,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             return GetRelativeSavePaths(instance.prefabSavePaths);
         }
 
+        /// <summary>
+        /// The paths formatted for display in the menu.
+        /// Paths outside the Assets folder are kept as they are and ones inside are shortened. 
+        /// </summary>
         internal static string[] GetDisplayFbxSavePaths()
         {
             return GetDisplaySavePaths(instance.fbxSavePaths);

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1107,12 +1107,15 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                //relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
-                relSavePaths[i] = exportSavePaths[i].Replace("/", forwardslash);
+                relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
             }
             return relSavePaths;
         }
 
+        /// <summary>
+        /// Returns the paths for display in the menu.
+		/// Paths inside the Assets folder are relative, while those outside are kept absolute.
+        /// </summary>
         internal static string[] GetDisplaySavePaths(List<string> exportSavePaths)
         {
             string[] displayPaths = new string[exportSavePaths.Count];
@@ -1122,10 +1125,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 // if path is in Assets folder, shorten it
                 if (!Path.IsPathRooted(exportSavePaths[i]))
                 {
-                    displayPaths[i] = string.Format("Assets{0}{1}", forwardslash,
-                        exportSavePaths[i] == "."
-                            ? ""
-                            : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
+					displayPaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
                 }
                 else
                 {

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1107,11 +1107,33 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                // TODO format better
                 //relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
                 relSavePaths[i] = exportSavePaths[i].Replace("/", forwardslash);
             }
             return relSavePaths;
+        }
+
+        internal static string[] GetDisplaySavePaths(List<string> exportSavePaths)
+        {
+            string[] displayPaths = new string[exportSavePaths.Count];
+            string forwardslash = " \u2044 ";
+            for (int i = 0; i < displayPaths.Length; i++)
+            {
+                // if path is in Assets folder, shorten it
+                if (!Path.IsPathRooted(exportSavePaths[i]))
+                {
+                    displayPaths[i] = string.Format("Assets{0}{1}", forwardslash,
+                        exportSavePaths[i] == "."
+                            ? ""
+                            : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
+                }
+                else
+                {
+                    displayPaths[i] = exportSavePaths[i].Replace("/", forwardslash);
+                }
+            }
+
+            return displayPaths;
         }
 
         /// <summary>
@@ -1130,6 +1152,11 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         internal static string[] GetRelativePrefabSavePaths(){
             return GetRelativeSavePaths(instance.prefabSavePaths);
+        }
+
+        internal static string[] GetDisplayFbxSavePaths()
+        {
+            return GetDisplaySavePaths(instance.fbxSavePaths);
         }
 
         /// <summary>

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1109,14 +1109,14 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
             for (int i = 0; i < relSavePaths.Length; i++) {
-                relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
+                relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
             }
             return relSavePaths;
         }
 
         /// <summary>
         /// Returns the paths for display in the menu.
-		/// Paths inside the Assets folder are relative, while those outside are kept absolute.
+        /// Paths inside the Assets folder are relative, while those outside are kept absolute.
         /// </summary>
         internal static string[] GetMixedSavePaths(List<string> exportSavePaths)
         {
@@ -1222,17 +1222,17 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             instance.SelectedPrefabPath = 0;
         }
 
-        internal static string GetAbsoluteSavePath(string relativePath){
-            var absolutePath = Path.Combine(Application.dataPath, relativePath);
-            absolutePath = NormalizePath(absolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);
+        internal static string GetAbsoluteSavePath(string savePath){
+            var projectAbsolutePath = Path.Combine(Application.dataPath, savePath);
+            projectAbsolutePath = NormalizePath(projectAbsolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);
             
-            // check if path is outside Assets folder
-            if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(absolutePath)))
+            // if path is outside Assets folder, it's already absolute so return the original path
+            if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(projectAbsolutePath)))
             {
-                return relativePath;
+                return savePath;
             }
 
-            return absolutePath;
+            return projectAbsolutePath;
         }
 
         internal static string FbxAbsoluteSavePath{

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1113,10 +1113,6 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 {
                     relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
                 }
-                else
-                {
-                    continue;
-                }
             }
             return relSavePaths;
         }
@@ -1125,7 +1121,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// Returns the paths for display in the menu.
 		/// Paths inside the Assets folder are relative, while those outside are kept absolute.
         /// </summary>
-        internal static string[] GetDisplaySavePaths(List<string> exportSavePaths)
+        internal static string[] GetMixedSavePaths(List<string> exportSavePaths)
         {
             string[] displayPaths = new string[exportSavePaths.Count];
             string forwardslash = " \u2044 ";
@@ -1167,9 +1163,9 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// The paths formatted for display in the menu.
         /// Paths outside the Assets folder are kept as they are and ones inside are shortened. 
         /// </summary>
-        internal static string[] GetDisplayFbxSavePaths()
+        internal static string[] GetMixedFbxSavePaths()
         {
-            return GetDisplaySavePaths(instance.fbxSavePaths);
+            return GetMixedSavePaths(instance.fbxSavePaths);
         }
 
         /// <summary>

--- a/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
+++ b/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
@@ -77,6 +77,7 @@ namespace FbxExporter.UnitTests
             }
         }
 
+        // UT-3305 Test exporting an fbx outside the Assets folder of the project
         [Test]
         public void TestExportOutsideProject()
         {

--- a/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
+++ b/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
@@ -76,5 +76,18 @@ namespace FbxExporter.UnitTests
                 Assert.Greater(mesh.triangles.Length, 0);
             }
         }
+
+        [Test]
+        public void TestExportOutsideProject()
+        {
+            Assert.IsNotNull(m_toExport);
+            Assert.Greater(m_toExport.Length, 1);
+            var filename = GetTempOutsideFilePath();
+
+            var fbxFileName = ModelExporter.ExportObjects(filename, m_toExport);
+
+            Assert.IsNotNull(fbxFileName);
+            Assert.AreEqual(fbxFileName, filename);
+        }
     }
 }

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -1053,7 +1053,10 @@ namespace FbxExporter.UnitTests
             var originalImportBlendShapes = importer.importBlendShapes;
 
             // re-export with preserve import settings true and verify settings are the same
-            ModelExporter.ExportObjects(filename, new Object[] { cube });
+            var exportOptions = new ExportModelSettingsSerialize();
+            exportOptions.SetPreserveImportSettings(true);
+
+            ModelExporter.ExportObjects(filename, new Object[] { cube }, exportOptions);
             importer = AssetImporter.GetAtPath(filename) as ModelImporter;
             importer.SaveAndReimport();
             Assert.AreEqual(originalImportBlendShapes, importer.importBlendShapes);
@@ -1063,7 +1066,8 @@ namespace FbxExporter.UnitTests
             Assert.AreEqual(originalGuid, newGuid);
 
             // re-export with preserve import settings false and verify settings are different
-            var exportOptions = new ExportModelSettingsSerialize();
+            exportOptions = new ExportModelSettingsSerialize();
+            exportOptions.SetPreserveImportSettings(false);
 
             exportOptions.SetPreserveImportSettings(false);
             ModelExporter.ExportObjects(filename, new Object[] { cube }, exportOptions);

--- a/com.unity.formats.fbx/Tests/Scripts/ExporterTestBaseAPI.cs
+++ b/com.unity.formats.fbx/Tests/Scripts/ExporterTestBaseAPI.cs
@@ -123,6 +123,14 @@ namespace FbxExporter.UnitTests
         }
 
         /// <summary>
+        /// Returns a temp file path outside the Unity project.
+        /// </summary>
+        protected string GetTempOutsideFilePath()
+        {
+            return Path.GetTempFileName();
+        }
+
+        /// <summary>
         /// Creates a test hierarchy of cubes.
         ///      Root
         ///      -> Parent1


### PR DESCRIPTION
Can now export fbx models outside of the Assets folder in the Unity project.
Cannot export fbx models outside the project if converting to a prefab.
Preserve import settings checkbox greyed out if you're exporting outside the project.