### PR TITLE
UT-3125 Relative path of texture fix

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3448,7 +3448,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 // create a temp file in the same directory where the fbx will be exported
                 var exportDir = Path.GetDirectoryName(m_lastFilePath);
-                var tempFileName = Path.ChangeExtension(Path.GetRandomFileName(), ".fbx");
+                var lastFileName = Path.GetFileName(m_lastFilePath);
+                var tempFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + "_" + lastFileName;
                 m_tempFilePath = Path.Combine(new string[] { exportDir, tempFileName });
             }
             catch(IOException){

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3438,17 +3438,22 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<GameObject, IExportData> exportData)
         {
             exportCancelled = false;
+            
+            m_lastFilePath = LastFilePath;
 
             // Export first to a temporary file
             // in case the export is cancelled.
             // This way we won't overwrite existing files.
-            try{
-                m_tempFilePath = Path.GetTempFileName();
+            try
+            {
+                var exportDir = Path.GetDirectoryName(m_lastFilePath);
+                var tempFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
+                
+                m_tempFilePath = exportDir + "/" + tempFileName + ".fbx";
             }
             catch(IOException){
                 return 0;
             }
-            m_lastFilePath = LastFilePath;
 
             if (string.IsNullOrEmpty (m_tempFilePath)) {
                 return 0;

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3446,9 +3446,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // This way we won't overwrite existing files.
             try
             {
+                // create a temp file in the same directory where the fbx will be exported
                 var exportDir = Path.GetDirectoryName(m_lastFilePath);
                 var tempFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
-                
+                // have to add .fbx to the end or else the temp file path won't match the file name
                 m_tempFilePath = exportDir + "/" + tempFileName + ".fbx";
             }
             catch(IOException){

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3448,9 +3448,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 // create a temp file in the same directory where the fbx will be exported
                 var exportDir = Path.GetDirectoryName(m_lastFilePath);
-                var tempFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
-                // have to add .fbx to the end or else the temp file path won't match the file name
-                m_tempFilePath = exportDir + "/" + tempFileName + ".fbx";
+                var tempFileName = Path.ChangeExtension(Path.GetRandomFileName(), ".fbx");
+                m_tempFilePath = Path.Combine(new string[] { exportDir, tempFileName });
             }
             catch(IOException){
                 return 0;


### PR DESCRIPTION
Temp fbx file is now created in the directory where the exported fbx file will be created so that the relative path to textures is correct.