### PR TITLE
Add null checks when accessing bones.

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -983,6 +983,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         // and update LclRotation
                         fbxBone.LclRotation.Set(ToFbxDouble3(QuaternionToEuler(finalLclRotationQuat)));
                     }
+                    else
+                    {
+                        Debug.Log("Warning: One or more bones are null. Skeleton may not export correctly.");
+                    }
                 }
             }
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -961,6 +961,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var bones = unitySkin.bones;
                 foreach (var bone in bones)
                 {
+                    // ignore null bones
                     if (bone != null)
                     {
                         var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
@@ -1044,6 +1045,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<Transform, int> index = new Dictionary<Transform, int>();
             for (int boneIndex = 0; boneIndex < bones.Length; boneIndex++) {
                 Transform unityBoneTransform = bones [boneIndex];
+
+                // ignore null bones
                 if (unityBoneTransform != null)
                 {
                     index[unityBoneTransform] = boneIndex;
@@ -1055,6 +1058,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Step 1: Set transforms
             var boneInfo = new SkinnedMeshBoneInfo (skinnedMesh, index);
             foreach (var bone in bones) {
+                // ignore null bones
                 if (bone != null)
                 {
                     var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
@@ -1079,6 +1083,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<int, FbxCluster> boneCluster = new Dictionary<int, FbxCluster> ();
 
             for(int i = 0; i < skinnedMesh.bones.Length; i++) {
+                // ignore null bones
                 if (skinnedMesh.bones[i] != null)
                 {
                     FbxNode fbxBoneNode = MapUnityObjectToFbxNode[skinnedMesh.bones[i].gameObject];
@@ -1176,6 +1181,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return false;
             }
             for (int i = 0; i < bones.Length; i++) {
+                // ignore null bones
                 if (bones[i] != null)
                 {
                     FbxNode fbxBoneNode = MapUnityObjectToFbxNode[bones[i].gameObject];

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -961,24 +961,27 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var bones = unitySkin.bones;
                 foreach (var bone in bones)
                 {
-                    var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
-                    ExportTransform(bone, fbxBone, newCenter: Vector3.zero, TransformExportType.Local);
+                    if (bone != null)
+                    {
+                        var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
+                        ExportTransform(bone, fbxBone, newCenter: Vector3.zero, TransformExportType.Local);
 
-                    // Cancel out the pre-rotation from the exported rotation
+                        // Cancel out the pre-rotation from the exported rotation
 
-                    // Get prerotation
-                    var fbxPreRotationEuler = fbxBone.GetPreRotation(FbxNode.EPivotSet.eSourcePivot);
-                    // Convert the prerotation to a Quaternion
-                    var fbxPreRotationQuaternion = EulerToQuaternion(fbxPreRotationEuler);
-                    // Inverse of the prerotation
-                    fbxPreRotationQuaternion.Inverse();
+                        // Get prerotation
+                        var fbxPreRotationEuler = fbxBone.GetPreRotation(FbxNode.EPivotSet.eSourcePivot);
+                        // Convert the prerotation to a Quaternion
+                        var fbxPreRotationQuaternion = EulerToQuaternion(fbxPreRotationEuler);
+                        // Inverse of the prerotation
+                        fbxPreRotationQuaternion.Inverse();
 
-                    // Multiply LclRotation by pre-rotation inverse to get the LclRotation without pre-rotation applied
-                    var finalLclRotationQuat = fbxPreRotationQuaternion * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
+                        // Multiply LclRotation by pre-rotation inverse to get the LclRotation without pre-rotation applied
+                        var finalLclRotationQuat = fbxPreRotationQuaternion * EulerToQuaternion(new FbxVector4(fbxBone.LclRotation.Get()));
 
-                    // Convert to Euler without axis conversion (Pre-rotation and LclRotation were already in Maya axis)
-                    // and update LclRotation
-                    fbxBone.LclRotation.Set(ToFbxDouble3(QuaternionToEuler(finalLclRotationQuat)));
+                        // Convert to Euler without axis conversion (Pre-rotation and LclRotation were already in Maya axis)
+                        // and update LclRotation
+                        fbxBone.LclRotation.Set(ToFbxDouble3(QuaternionToEuler(finalLclRotationQuat)));
+                    }
                 }
             }
 
@@ -1041,7 +1044,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<Transform, int> index = new Dictionary<Transform, int>();
             for (int boneIndex = 0; boneIndex < bones.Length; boneIndex++) {
                 Transform unityBoneTransform = bones [boneIndex];
-                index[unityBoneTransform] = boneIndex;
+                if (unityBoneTransform != null)
+                {
+                    index[unityBoneTransform] = boneIndex;
+                }
             }
 
             skinnedMeshToBonesMap.Add (skinnedMesh, bones);
@@ -1049,8 +1055,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Step 1: Set transforms
             var boneInfo = new SkinnedMeshBoneInfo (skinnedMesh, index);
             foreach (var bone in bones) {
-                var fbxBone = MapUnityObjectToFbxNode [bone.gameObject];
-                ExportBoneTransform (fbxBone, fbxScene, bone, boneInfo);
+                if (bone != null)
+                {
+                    var fbxBone = MapUnityObjectToFbxNode[bone.gameObject];
+                    ExportBoneTransform(fbxBone, fbxScene, bone, boneInfo);
+                }
             }
             return true;
         }
@@ -1070,24 +1079,27 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<int, FbxCluster> boneCluster = new Dictionary<int, FbxCluster> ();
 
             for(int i = 0; i < skinnedMesh.bones.Length; i++) {
-                FbxNode fbxBoneNode = MapUnityObjectToFbxNode [skinnedMesh.bones[i].gameObject];
+                if (skinnedMesh.bones[i] != null)
+                {
+                    FbxNode fbxBoneNode = MapUnityObjectToFbxNode[skinnedMesh.bones[i].gameObject];
 
-                // Create the deforming cluster
-                FbxCluster fbxCluster = FbxCluster.Create (fbxScene, "BoneWeightCluster");
+                    // Create the deforming cluster
+                    FbxCluster fbxCluster = FbxCluster.Create(fbxScene, "BoneWeightCluster");
 
-                fbxCluster.SetLink (fbxBoneNode);
-                fbxCluster.SetLinkMode (FbxCluster.ELinkMode.eNormalize);
+                    fbxCluster.SetLink(fbxBoneNode);
+                    fbxCluster.SetLinkMode(FbxCluster.ELinkMode.eNormalize);
 
-                boneCluster.Add (i, fbxCluster);
+                    boneCluster.Add(i, fbxCluster);
 
-                // set the Transform and TransformLink matrix
-                fbxCluster.SetTransformMatrix (fbxMeshMatrix);
+                    // set the Transform and TransformLink matrix
+                    fbxCluster.SetTransformMatrix(fbxMeshMatrix);
 
-                FbxAMatrix fbxLinkMatrix = fbxBoneNode.EvaluateGlobalTransform ();
-                fbxCluster.SetTransformLinkMatrix (fbxLinkMatrix);
+                    FbxAMatrix fbxLinkMatrix = fbxBoneNode.EvaluateGlobalTransform();
+                    fbxCluster.SetTransformLinkMatrix(fbxLinkMatrix);
 
-                // add the cluster to the skin
-                fbxSkin.AddCluster (fbxCluster);
+                    // add the cluster to the skin
+                    fbxSkin.AddCluster(fbxCluster);
+                }
             }
 
             // set the vertex weights for each bone
@@ -1164,21 +1176,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return false;
             }
             for (int i = 0; i < bones.Length; i++) {
-                FbxNode fbxBoneNode = MapUnityObjectToFbxNode [bones[i].gameObject];
+                if (bones[i] != null)
+                {
+                    FbxNode fbxBoneNode = MapUnityObjectToFbxNode[bones[i].gameObject];
 
-                // EvaluateGlobalTransform returns an FbxAMatrix (affine matrix)
-                // which has to be converted to an FbxMatrix so that it can be passed to fbxPose.Add().
-                // The hierarchy for FbxMatrix and FbxAMatrix is as follows:
-                //
-                //      FbxDouble4x4
-                //      /           \
-                // FbxMatrix     FbxAMatrix
-                //
-                // Therefore we can't convert directly from FbxAMatrix to FbxMatrix,
-                // however FbxMatrix has a constructor that takes an FbxAMatrix.
-                FbxMatrix fbxBindMatrix = new FbxMatrix(fbxBoneNode.EvaluateGlobalTransform ());
+                    // EvaluateGlobalTransform returns an FbxAMatrix (affine matrix)
+                    // which has to be converted to an FbxMatrix so that it can be passed to fbxPose.Add().
+                    // The hierarchy for FbxMatrix and FbxAMatrix is as follows:
+                    //
+                    //      FbxDouble4x4
+                    //      /           \
+                    // FbxMatrix     FbxAMatrix
+                    //
+                    // Therefore we can't convert directly from FbxAMatrix to FbxMatrix,
+                    // however FbxMatrix has a constructor that takes an FbxAMatrix.
+                    FbxMatrix fbxBindMatrix = new FbxMatrix(fbxBoneNode.EvaluateGlobalTransform());
 
-                fbxPose.Add (fbxBoneNode, fbxBindMatrix);
+                    fbxPose.Add(fbxBoneNode, fbxBindMatrix);
+                }
             }
 
             fbxPose.Add (fbxMeshNode, new FbxMatrix (fbxMeshNode.EvaluateGlobalTransform ()));


### PR DESCRIPTION
Add null checks whenever accessing a bone, so that export doesn't fail with a broken rig.