### PR TITLE
UT-3419 Duplicate meshes export as instances.

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1313,7 +1313,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         /// <summary>
-        /// if this game object is a model prefab then export with shared components
+        /// if this game object is a model prefab or the model has already been exported, then export with shared components
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
         private bool ExportInstance(GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
@@ -1322,27 +1322,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 return false;
             }
-            
-            /**
-            PrefabAssetType unityPrefabType = PrefabUtility.GetPrefabAssetType(unityGo);
-            // only export as an instance if the GameObject is part of a prefab instance
-            if (unityPrefabType == PrefabAssetType.MissingAsset ||
-                unityPrefabType == PrefabAssetType.NotAPrefab ||
-                PrefabUtility.GetPrefabInstanceStatus(unityGo) != PrefabInstanceStatus.Connected)
-            {
-                return false;
-            }
-            **/
 
             Object unityPrefabParent = PrefabUtility.GetCorrespondingObjectFromSource(unityGo);
-
-            if (Verbose)
-                Debug.Log (string.Format ("exporting instance {0}({1})", unityGo.name, unityPrefabParent.name));
 
             FbxMesh fbxMesh = null;
 
             if (unityPrefabParent != null && !SharedMeshes.TryGetValue (unityPrefabParent.GetInstanceID(), out fbxMesh))
             {
+                if (Verbose)
+                    Debug.Log (string.Format ("exporting instance {0}({1})", unityGo.name, unityPrefabParent.name));
+                
                 if (ExportMesh (unityGo, fbxNode) && fbxNode.GetMesh() != null) {
                     SharedMeshes [unityPrefabParent.GetInstanceID()] = fbxNode.GetMesh ();
                     return true;

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1344,8 +1344,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             else if (unityPrefabParent == null)
             {
                 // check if same mesh has already been exported
-                MeshFilter unityGoMesh;
-                if (unityGo.TryGetComponent<MeshFilter>(out unityGoMesh) && MeshToFbxNodeMap.ContainsKey(unityGoMesh.sharedMesh))
+                MeshFilter unityGoMesh = unityGo.GetComponent<MeshFilter>();
+                if (unityGoMesh != null && MeshToFbxNodeMap.ContainsKey(unityGoMesh.sharedMesh))
                 {
                     fbxMesh = MeshToFbxNodeMap[unityGoMesh.sharedMesh].GetMesh();
                 }

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1350,16 +1350,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     fbxMesh = MeshToFbxNodeMap[unityGoMesh.sharedMesh].GetMesh();
                 }
                 // export mesh as normal and add it to list
-                else if (unityGoMesh != null)
+                else
                 {
-                    MeshToFbxNodeMap.Add(unityGoMesh.sharedMesh, fbxNode);
+                    if (unityGoMesh != null)
+                    {
+                        MeshToFbxNodeMap.Add(unityGoMesh.sharedMesh, fbxNode);
+                    }
                     return false;
                 }
-            }
-
-            if (fbxMesh == null)
-            {
-                return false;
             }
 
             // We don't export the mesh because we already have it from the parent, but we still need to assign the material

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1360,6 +1360,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
 
+            if (fbxMesh == null)
+            {
+                return false;
+            }
+
             // We don't export the mesh because we already have it from the parent, but we still need to assign the material
             var renderer = unityGo.GetComponent<Renderer>();
             var materials = renderer ? renderer.sharedMaterials : null;

--- a/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
+++ b/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
@@ -15,7 +15,7 @@ namespace FbxExporter.UnitTests
         public override void Init()
         {
             base.Init();
-            m_toExport = new GameObject[] {CreateGameObjectToExport(), CreateGameObjectToExport()};
+            m_toExport = new GameObject[] {CreateGameObjectToExport(PrimitiveType.Cube), CreateGameObjectToExport(PrimitiveType.Sphere) };
         }
 
         [TearDown]
@@ -32,7 +32,7 @@ namespace FbxExporter.UnitTests
         /// Creates a GameObject to export.
         /// </summary>
         /// <returns>The game object to export.</returns>
-        private GameObject CreateGameObjectToExport ()
+        private GameObject CreateGameObjectToExport (PrimitiveType type = PrimitiveType.Sphere)
         {
             return GameObject.CreatePrimitive (PrimitiveType.Sphere);
         }

--- a/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
+++ b/com.unity.formats.fbx/Tests/FbxApiTests/PublicAPITest.cs
@@ -34,7 +34,7 @@ namespace FbxExporter.UnitTests
         /// <returns>The game object to export.</returns>
         private GameObject CreateGameObjectToExport (PrimitiveType type = PrimitiveType.Sphere)
         {
-            return GameObject.CreatePrimitive (PrimitiveType.Sphere);
+            return GameObject.CreatePrimitive (type);
         }
 
         [Test]

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -1085,13 +1085,14 @@ namespace FbxExporter.UnitTests
             GameObject child1 = CreateGameObject("child1", root.transform);
             GameObject child2 = CreateGameObject("child2", root.transform);
 
-            // export and check that there is 1 fbx file both objects reference
+            // check export was successful
             var result = ModelExporter.ExportObject(filename, root);
             Assert.That(result, Is.Not.Null);
             Assert.AreEqual(filename, result);
 
+            // check that both children reference the same mesh
             GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
-            Assert.AreEqual(fbxObj.transform.GetChild(0).GetComponent<Meshfilter>().sharedMesh.name, fbxObj.transform.GetChild(1).GetComponent<Meshfilter>().sharedMesh.name);
+            Assert.AreEqual(fbxObj.transform.GetChild(0).GetComponent<MeshFilter>().sharedMesh.name, fbxObj.transform.GetChild(1).GetComponent<MeshFilter>().sharedMesh.name);
         }
     }
 }

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -267,11 +267,11 @@ namespace FbxExporter.UnitTests
             // Unregister once => only one call per object, and no more for the prefab.
             ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
             ModelExporter.UnRegisterMeshObjectCallback(tester.CallbackForObject);
-            tester.Verify(0, nbTransforms);
+            tester.Verify(0, nbMeshCallbacks);
 
             // Legal to unregister if already unregistered.
             ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
-            tester.Verify(0, nbTransforms);
+            tester.Verify(0, nbMeshCallbacks);
 
             // Register same callback twice gets back to original state.
             ModelExporter.UnRegisterMeshObjectCallback(tester.CallbackForObject);
@@ -305,11 +305,12 @@ namespace FbxExporter.UnitTests
             ModelExporter.ExportObject(filename, tree);
             ModelExporter.UnRegisterMeshCallback<FbxPrefab>();
 
+            // UT-3419 Parent1 and Parent2 are instances the same mesh, so they should point to the same mesh
             asset = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             assetMesh = asset.transform.Find("Parent1").GetComponent<MeshFilter>().sharedMesh;
             Assert.AreEqual(sphereMesh.triangles.Length, assetMesh.triangles.Length);
             assetMesh = asset.transform.Find("Parent2").GetComponent<MeshFilter>().sharedMesh;
-            Assert.AreEqual(cubeMesh.triangles.Length, assetMesh.triangles.Length);
+            Assert.AreEqual(sphereMesh.triangles.Length, assetMesh.triangles.Length);
 
             // Try again, but this time pick on Parent2 by name (different just
             // to make sure we don't pass if the previous pass didn't
@@ -328,11 +329,12 @@ namespace FbxExporter.UnitTests
             ModelExporter.ExportObject(filename, tree);
             ModelExporter.UnRegisterMeshObjectCallback(callback);
 
+            // UT-3419 Parent1 and Parent2 are instances the same mesh, so they should point to the same mesh
             asset = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             assetMesh = asset.transform.Find("Parent1").GetComponent<MeshFilter>().sharedMesh;
             Assert.AreEqual(cubeMesh.triangles.Length, assetMesh.triangles.Length);
             assetMesh = asset.transform.Find("Parent2").GetComponent<MeshFilter>().sharedMesh;
-            Assert.AreEqual(sphereMesh.triangles.Length, assetMesh.triangles.Length);
+            Assert.AreEqual(cubeMesh.triangles.Length, assetMesh.triangles.Length);
         }
 
         [Test]

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -1075,5 +1075,23 @@ namespace FbxExporter.UnitTests
             newGuid = AssetDatabase.AssetPathToGUID(filename);
             Assert.AreEqual(originalGuid, newGuid);
         }
+
+        [Test]
+        public void TestInstanceExport()
+        {
+            // create root with 2 identical children
+            var filename = GetRandomFbxFilePath();
+            GameObject root = new GameObject("root");
+            GameObject child1 = CreateGameObject("child1", root.transform);
+            GameObject child2 = CreateGameObject("child2", root.transform);
+
+            // export and check that there is 1 fbx file both objects reference
+            var result = ModelExporter.ExportObject(filename, root);
+            Assert.That(result, Is.Not.Null);
+            Assert.AreEqual(filename, result);
+
+            GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
+            Assert.AreEqual(fbxObj.transform.GetChild(0).GetComponent<Meshfilter>().sharedMesh.name, fbxObj.transform.GetChild(1).GetComponent<Meshfilter>().sharedMesh.name);
+        }
     }
 }


### PR DESCRIPTION
When exporting a hierarchy of game objects, any objects with duplicate meshes now export as instances.
<img width="491" alt="Screen Shot 2020-08-03 at 1 57 12 PM" src="https://user-images.githubusercontent.com/33669880/89220806-36da9600-d5a0-11ea-9d8c-f33b0db7b675.png">
