### PR TITLE
Fix label getting cut off.

### DIFF
--- a/com.unity.formats.fbx/Editor/ExportModelSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelSettings.cs
@@ -97,7 +97,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             GUILayout.EndHorizontal ();
             
             GUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField(new GUIContent("Preserve Import Settings for Existing FBX",
+            EditorGUILayout.LabelField(new GUIContent("Preserve Import Settings",
                 "If checked, the import settings from the overwritten FBX will be carried over to the new version."), GUILayout.Width(LabelWidth - FieldOffset));
             // greyed out if exporting outside assets folder
             EditorGUI.BeginDisabledGroup(ExportSettings.instance.ExportOutsideProject);


### PR DESCRIPTION
Label Preserve Import Settings checkbox was getting cut off in a bad spot on Mac.
<img width="183" alt="Screen Shot 2020-08-06 at 3 57 30 PM" src="https://user-images.githubusercontent.com/33669880/89576806-c5981e80-d7fd-11ea-98e3-fcd82cd3353c.png">
