### PR TITLE
FBX-31 CameraVisitor.cs no longer using Reflection

### DIFF
--- a/com.unity.formats.fbx/Editor/CameraVisitor.cs
+++ b/com.unity.formats.fbx/Editor/CameraVisitor.cs
@@ -68,10 +68,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             public static Vector2 GetSizeOfMainGameView()
             {
+#if UNITY_2019_4_OR_NEWER
+                return Handles.GetMainGameViewSize();
+#else
                 System.Type T = System.Type.GetType("UnityEditor.GameView,UnityEditor");
                 System.Reflection.MethodInfo GetSizeOfMainGameView = T.GetMethod("GetSizeOfMainGameView", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
                 System.Object Res = GetSizeOfMainGameView.Invoke(null, null);
                 return (Vector2)Res;
+#endif // UNITY_2019_4_OR_NEWER
             }
 
             /// <summary>

--- a/com.unity.formats.fbx/Editor/CameraVisitor.cs
+++ b/com.unity.formats.fbx/Editor/CameraVisitor.cs
@@ -68,14 +68,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             public static Vector2 GetSizeOfMainGameView()
             {
-#if UNITY_2019_4_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
                 return Handles.GetMainGameViewSize();
 #else
                 System.Type T = System.Type.GetType("UnityEditor.GameView,UnityEditor");
                 System.Reflection.MethodInfo GetSizeOfMainGameView = T.GetMethod("GetSizeOfMainGameView", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
                 System.Object Res = GetSizeOfMainGameView.Invoke(null, null);
                 return (Vector2)Res;
-#endif // UNITY_2019_4_OR_NEWER
+#endif // UNITY_2020_1_OR_NEWER
             }
 
             /// <summary>

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxCameraTests.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxCameraTests.cs
@@ -102,6 +102,7 @@ namespace FbxExporter.UnitTests
 
             Assert.That( srcCam.fieldOfView, Is.EqualTo(origCam.fieldOfView).Within(EPSILON));
             Assert.That( srcCam.focalLength, Is.EqualTo(origCam.focalLength));
+            Assert.That( srcCam.aspect, Is.EqualTo(origCam.aspect));
             Assert.That( srcCam.sensorSize.x, Is.EqualTo(origCam.sensorSize.x).Within(EPSILON));
             Assert.That( srcCam.sensorSize.y, Is.EqualTo(origCam.sensorSize.y).Within(EPSILON));
             Assert.That( srcCam.usePhysicalProperties, Is.EqualTo(origCam.usePhysicalProperties));


### PR DESCRIPTION
- `Handles.GetMainGameViewSize();` (public API) now used
- Modifying unit test to check for aspect ratio (set using the value returned by `GetSizeOfMainView()`)