### PR TITLE
FBX-37: Export Blendshape Animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Fbx Exporter
 
+## [Unreleased]
+### Added
+- Added ability to export blendshape animations when the "Animated Skinned Mesh" Export Option is selected.
+
 ## [4.0.0-pre.4] - 2021-01-26
 ### Fixed
 - Fix ArgumentNullException on Linux when opening Export Options window.

--- a/com.unity.formats.fbx/Documentation~/exporting.md
+++ b/com.unity.formats.fbx/Documentation~/exporting.md
@@ -15,7 +15,7 @@ The FBX Exporter exports the following objects:
 * [Lights](#lights)
 * [Contraints](#constraints)
 * [Animation](#animation)
-* Blendshapes
+* Blendshapes if the "Animated Skinned Mesh" Export Option is selected
 
 
 

--- a/com.unity.formats.fbx/Documentation~/exporting.md
+++ b/com.unity.formats.fbx/Documentation~/exporting.md
@@ -15,7 +15,7 @@ The FBX Exporter exports the following objects:
 * [Lights](#lights)
 * [Contraints](#constraints)
 * [Animation](#animation)
-* Blendshapes if the "Animated Skinned Mesh" Export Option is selected
+* Blendshapes
 
 
 

--- a/com.unity.formats.fbx/Documentation~/exporting.md
+++ b/com.unity.formats.fbx/Documentation~/exporting.md
@@ -189,6 +189,7 @@ In addition, the FBX Exporter exports the following animated attributes:
   - World Up Vector (Aim Constraint)
   - Up Vector (Aim Constraint)
   - Aim Vector (Aim Constraint)
+- Blendshapes
 
 ### Animation curve tangents
 

--- a/com.unity.formats.fbx/Documentation~/exporting.md
+++ b/com.unity.formats.fbx/Documentation~/exporting.md
@@ -189,7 +189,7 @@ In addition, the FBX Exporter exports the following animated attributes:
   - World Up Vector (Aim Constraint)
   - Up Vector (Aim Constraint)
   - Aim Vector (Aim Constraint)
-- Blendshapes
+- Blendshapes (since version 4.1.0)
 
 ### Animation curve tangents
 

--- a/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
+++ b/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
@@ -118,6 +118,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 { @"m_RotationOffsets\.Array\.data\[(\d+)\]", "{0}.Offset R" }
             };
 
+        /// <summary>
+        /// Map of Unity constraint source transform property name as a regular expression to the FBX property as a string format.
+        /// This is necessary because the Unity and FBX properties contain the name of the source object.
+        /// </summary>
+        private static Dictionary<string, string> MapBlendshapesPropToFbxProp = new Dictionary<string, string>()
+            {
+                { @"blendShape\.(\S+)\.(\S+)", "DeformPercent" }
+            };
+
         // ================== Channel Maps ======================
 
         /// <summary>
@@ -147,6 +156,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private static PropertyChannelMap ColorPropertyMap = new PropertyChannelMap(MapColorPropToFbxProp, MapColorChannelToFbxChannel);
         private static PropertyChannelMap ConstraintSourcePropertyMap = new PropertyChannelMap(MapConstraintSourcePropToFbxProp, null);
         private static PropertyChannelMap ConstraintSourceTransformPropertyMap = new PropertyChannelMap(MapConstraintSourceTransformPropToFbxProp, MapTransformChannelToFbxChannel);
+
+        private static PropertyChannelMap BlendshapeMap = new PropertyChannelMap(MapBlendshapesPropToFbxProp, null);
         private static PropertyChannelMap OtherPropertyMap = new PropertyChannelMap(MapPropToFbxProp, null);
 
         /// <summary>
@@ -217,6 +228,29 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         /// <summary>
+        /// Get the Fbx property name for the given Unity constraint source property name from the given dictionary.
+        /// 
+        /// This is different from GetFbxProperty() because the Unity constraint source properties contain indices, and
+        /// the Fbx constraint source property contains the name of the source object.
+        /// </summary>
+        /// <param name="uniProperty"></param>
+        /// <param name="constraint"></param>
+        /// <param name="propertyMap"></param>
+        /// <returns>The Fbx property name or null if there was no match in the dictionary</returns>
+        private static string GetFbxBlendshapeProperty(string uniProperty, Dictionary<string, string> propertyMap)
+        {
+            foreach (var prop in propertyMap)
+            {
+                var match = System.Text.RegularExpressions.Regex.Match(uniProperty, prop.Key);
+                if (match.Success)
+                {
+                    return prop.Value;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Get the Fbx channel name for the given Unity channel from the given dictionary.
         /// </summary>
         /// <param name="uniChannel"></param>
@@ -256,11 +290,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 // try to match property
                 var fbxProperty = GetFbxProperty(uniPropChannelPair.property, propertyChannelMap.MapUnityPropToFbxProp);
-                if (string.IsNullOrEmpty(fbxProperty) && constraint != null)
+                if (string.IsNullOrEmpty(fbxProperty))
                 {
-                    // check if it's a constraint source property
-                    fbxProperty = GetFbxConstraintSourceProperty(uniPropChannelPair.property, constraint, propertyChannelMap.MapUnityPropToFbxProp);
+                    if (constraint != null)
+                    {
+                        // check if it's a constraint source property
+                        fbxProperty = GetFbxConstraintSourceProperty(uniPropChannelPair.property, constraint, propertyChannelMap.MapUnityPropToFbxProp);
+                    }
+                    else
+                    {
+                        // check if it's a blendshape property
+                        fbxProperty = GetFbxBlendshapeProperty(uniPropChannelPair.property, propertyChannelMap.MapUnityPropToFbxProp);
+                    }
                 }
+
                 if (string.IsNullOrEmpty(fbxProperty))
                 {
                     continue;
@@ -320,6 +363,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             propertyMaps.Add(TransformPropertyMap);
             propertyMaps.Add(ColorPropertyMap);
             propertyMaps.Add(OtherPropertyMap);
+            propertyMaps.Add(BlendshapeMap);
 
             foreach (var propMap in propertyMaps)
             {

--- a/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
+++ b/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
@@ -119,12 +119,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
             };
 
         /// <summary>
-        /// Map of Unity constraint source transform property name as a regular expression to the FBX property as a string format.
-        /// This is necessary because the Unity and FBX properties contain the name of the source object.
+        /// Map of Unity blendshape property name as a regular expression to the FBX property.
+        /// This is necessary because the Unity property contains the name of the target object.
         /// </summary>
         private static Dictionary<string, string> MapBlendshapesPropToFbxProp = new Dictionary<string, string>()
             {
-                { @"blendShape\.(\S+)\.(\S+)", "DeformPercent" }
+                { @"blendShape\.(\S+)", "DeformPercent" }
             };
 
         // ================== Channel Maps ======================
@@ -156,8 +156,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private static PropertyChannelMap ColorPropertyMap = new PropertyChannelMap(MapColorPropToFbxProp, MapColorChannelToFbxChannel);
         private static PropertyChannelMap ConstraintSourcePropertyMap = new PropertyChannelMap(MapConstraintSourcePropToFbxProp, null);
         private static PropertyChannelMap ConstraintSourceTransformPropertyMap = new PropertyChannelMap(MapConstraintSourceTransformPropToFbxProp, MapTransformChannelToFbxChannel);
-
         private static PropertyChannelMap BlendshapeMap = new PropertyChannelMap(MapBlendshapesPropToFbxProp, null);
+
         private static PropertyChannelMap OtherPropertyMap = new PropertyChannelMap(MapPropToFbxProp, null);
 
         /// <summary>
@@ -228,13 +228,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         /// <summary>
-        /// Get the Fbx property name for the given Unity constraint source property name from the given dictionary.
+        /// Get the Fbx property name for the given Unity blendshape property name from the given dictionary.
         /// 
-        /// This is different from GetFbxProperty() because the Unity constraint source properties contain indices, and
-        /// the Fbx constraint source property contains the name of the source object.
+        /// This is different from GetFbxProperty() because the Unity blendshape properties contain the name
+        /// of the target object.
         /// </summary>
         /// <param name="uniProperty"></param>
-        /// <param name="constraint"></param>
         /// <param name="propertyMap"></param>
         /// <returns>The Fbx property name or null if there was no match in the dictionary</returns>
         private static string GetFbxBlendshapeProperty(string uniProperty, Dictionary<string, string> propertyMap)


### PR DESCRIPTION
Adding support to export animations of blendshapes created in either Maya or Unity.
Requires the Animate Skinned Mesh export option to be selected.