### PR TITLE
FBX-30: FbxRecorderSettings uses reflection but doesn't need to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Added
 - Added ability to export blendshape animations when the "Animated Skinned Mesh" Export Option is selected.
 
+## [Unreleased]
+### Changed
+- Updating the minimum required version of the Unity Recorder package to 2.5.5.
+
 ## [4.0.0-pre.4] - 2021-01-26
 ### Fixed
 - Fix ArgumentNullException on Linux when opening Export Options window.

--- a/com.unity.formats.fbx/Documentation~/recorder.md
+++ b/com.unity.formats.fbx/Documentation~/recorder.md
@@ -4,7 +4,7 @@ With the FBX Exporter and the [Unity Recorder](https://docs.unity3d.com/Packages
 
 ## Requirements
 
-* To use the FBX Recorder, you must install the [Unity Recorder](https://docs.unity3d.com/Packages/com.unity.recorder@latest/) package.
+* To use the FBX Recorder, you must install the [Unity Recorder](https://docs.unity3d.com/Packages/com.unity.recorder@latest/) package (version 2.5.5 or higher).
 
 
 ## Using the FBX Recorder from the Recorder window

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
@@ -91,12 +91,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns>Transform associated with binding ID</returns>
         static Transform GetBinding(string id)
         {
-#if UNITY_2020_1_OR_NEWER
             return BindingManager.Get(id) as Transform;
-#else
-            var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Get", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
-            return method.Invoke(null, new object[] { id }) as Transform;
-#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>
@@ -108,12 +103,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="obj">Unity Object</param>
         static void SetBinding(string id, UnityEngine.Object obj)
         {
-#if UNITY_2020_1_OR_NEWER
             BindingManager.Set(id, obj);
-#else
-            var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Set", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
-            method.Invoke(null, new object[] { id, obj });
-#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
@@ -91,9 +91,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns>Transform associated with binding ID</returns>
         static Transform GetBinding(string id)
         {
-            // return BindingManager.Get(m_BindingId) as GameObject;
+#if UNITY_2020_1_OR_NEWER
+            return BindingManager.Get(m_BindingId) as Transform;
+#else
             var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Get", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
             return method.Invoke(null, new object[] { id }) as Transform;
+#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>
@@ -105,9 +108,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="obj">Unity Object</param>
         static void SetBinding(string id, UnityEngine.Object obj)
         {
-            // BindingManager.Set(m_BindingId, value);
+#if UNITY_2020_1_OR_NEWER
+            BindingManager.Set(m_BindingId, value);
+#else
             var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Set", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
             method.Invoke(null, new object[] { id, obj });
+#endif // UNITY_2020_1_OR_NEWER
         }
 
         /// <summary>

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
@@ -92,7 +92,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         static Transform GetBinding(string id)
         {
 #if UNITY_2020_1_OR_NEWER
-            return BindingManager.Get(m_BindingId) as Transform;
+            return BindingManager.Get(id) as Transform;
 #else
             var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Get", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
             return method.Invoke(null, new object[] { id }) as Transform;
@@ -109,7 +109,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         static void SetBinding(string id, UnityEngine.Object obj)
         {
 #if UNITY_2020_1_OR_NEWER
-            BindingManager.Set(m_BindingId, value);
+            BindingManager.Set(id, obj);
 #else
             var method = Type.GetType("UnityEditor.Recorder.BindingManager,Unity.Recorder.Editor").GetMethod("Set", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
             method.Invoke(null, new object[] { id, obj });

--- a/com.unity.formats.fbx/Editor/Unity.Formats.Fbx.Editor.asmdef
+++ b/com.unity.formats.fbx/Editor/Unity.Formats.Fbx.Editor.asmdef
@@ -20,7 +20,7 @@
     "versionDefines": [
         {
             "name": "com.unity.recorder",
-            "expression": "2.2.0-preview.4",
+            "expression": "2.5.5",
             "define": "ENABLE_FBX_RECORDER"
         }
     ],

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
@@ -15,7 +15,7 @@ namespace FbxExporter.UnitTests
         };
 
         [Test, TestCaseSource(typeof(FbxRecorderTest), "RecorderTestCases")]
-    	public void TransferAnimationTest(string prefabPath) 
+        public void TransferAnimationTest(string prefabPath) 
         {
             prefabPath = FindPathInUnitTests(prefabPath);
             Assert.That(prefabPath, Is.Not.Null);

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
@@ -1,0 +1,18 @@
+#if ENABLE_FBX_RECORDER
+using UnityEngine;
+using NUnit.Framework;
+using UnityEditor.Formats.Fbx.Exporter;
+using UnityEditor.Recorder;
+
+namespace FbxExporter.UnitTests
+{
+    public class FbxRecorderTest : ExporterTestBase
+    {
+        [Test]
+    	public void TestBindings() 
+        {
+
+        }
+    }
+}
+#endif // ENABLE_FBX_RECORDER

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
@@ -3,15 +3,39 @@ using UnityEngine;
 using NUnit.Framework;
 using UnityEditor.Formats.Fbx.Exporter;
 using UnityEditor.Recorder;
+using UnityEditor.Recorder.Input;
 
 namespace FbxExporter.UnitTests
 {
     public class FbxRecorderTest : ExporterTestBase
     {
-        [Test]
-    	public void TestBindings() 
+        public static string[] RecorderTestCases = new string[]
         {
+            "Models/Player/Player.prefab"
+        };
 
+        [Test, TestCaseSource(typeof(FbxRecorderTest), "RecorderTestCases")]
+    	public void TransferAnimationTest(string prefabPath) 
+        {
+            prefabPath = FindPathInUnitTests(prefabPath);
+            Assert.That(prefabPath, Is.Not.Null);
+
+            var go = AddAssetToScene(prefabPath);
+            Assert.That(go);
+
+            AnimationInputSettings animationInputSettings = new AnimationInputSettings();
+            animationInputSettings.gameObject = go;
+
+            FbxRecorderSettings settings = ScriptableObject.CreateInstance(typeof(FbxRecorderSettings)) as FbxRecorderSettings;
+            settings.animationInputSettings = animationInputSettings;
+
+            settings.TransferAnimationSource = go.transform;
+
+            Transform skeletonNode = go.transform.GetChild(2);
+            settings.TransferAnimationDest = skeletonNode;
+
+            Assert.That(settings.TransferAnimationSource, Is.Not.Null);
+            Assert.That(settings.TransferAnimationDest, Is.Not.Null);
         }
     }
 }

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
@@ -34,8 +34,13 @@ namespace FbxExporter.UnitTests
             Transform skeletonNode = go.transform.GetChild(2);
             settings.TransferAnimationDest = skeletonNode;
 
+            // Assignment of the AnimationSource and AnimationDest transforms also tests the GetBinding and SetBinding methods
+            // of the FbxRecorderSettings class which previously used a private API.
             Assert.That(settings.TransferAnimationSource, Is.Not.Null);
+            Assert.That(settings.TransferAnimationSource, Is.EqualTo(go.transform));
+
             Assert.That(settings.TransferAnimationDest, Is.Not.Null);
+            Assert.That(settings.TransferAnimationDest, Is.EqualTo(skeletonNode));
         }
     }
 }

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs.meta
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38f0f8b9eff81574c866acecb17c3c6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
+++ b/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
@@ -28,7 +28,7 @@
     "versionDefines": [
         {
             "name": "com.unity.recorder",
-            "expression": "2.2.0-preview.4",
+            "expression": "2.5.5",
             "define": "ENABLE_FBX_RECORDER"
         }
     ],

--- a/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
+++ b/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
@@ -1,22 +1,36 @@
 {
     "name": "Unity.Formats.Fbx.Editor.Tests",
+    "rootNamespace": "",
     "references": [
         "Unity.Timeline",
         "Autodesk.Fbx",
         "Unity.Formats.Fbx.Editor",
         "Unity.Formats.Fbx.Runtime",
-        "Unity.Formats.Fbx.Editor.Tests.Prefabs"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Unity.Formats.Fbx.Editor.Tests.Prefabs",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Unity.Recorder",
+        "Unity.Recorder.Editor"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
-    "autoReferenced": true,
-    "defineConstraints": []
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.unity.recorder",
+            "expression": "2.2.0-preview.4",
+            "define": "ENABLE_FBX_RECORDER"
+        }
+    ],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
* Adding public API call to ifdef
* Adding automated test file (TODO: currently only testing get/set binding functionality but eventually the entire Recorder workflow should be tested)
* Modifying the test assembly definition file to reference the Unity.Recorder assembly and set the `#if ENABLE_FBX_RECORDER` pre-processor definition