### PR TITLE
FBX-76: fix invocation of Get/SetIconForObject when methods are public

### DIFF
--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -756,7 +756,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 GameObjectUtility.SetStaticEditorFlags(destGO, GameObjectUtility.GetStaticEditorFlags(sourceGO));
 
                 // set icon
-                System.Reflection.BindingFlags bindingFlags = System.Reflection.BindingFlags.InvokeMethod | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic;
+                System.Reflection.BindingFlags bindingFlags = System.Reflection.BindingFlags.InvokeMethod | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public;
                 var sourceIcon = typeof(EditorGUIUtility).InvokeMember("GetIconForObject", bindingFlags, null, null, new object[] { sourceGO });
                 object[] args = new object[] { destGO, sourceIcon };
                 typeof(EditorGUIUtility).InvokeMember("SetIconForObject", bindingFlags, null, null, args);


### PR DESCRIPTION
These methods (in trunk) will become public soon. Change the bindingFlags for InvokeMethod to search for both public and non-public methods so the method won't fail. This is temporary until the API change lands, after which we can remove reflection for Unity > 2021.2.?.

Tested locally against `branch editor/public-api-for-getting-and-setting-icons`