### PR TITLE
Add null material check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Fbx Exporter
 
+## [Unreleased] - 2021-05-31
+### Fixed
+- Fix NullReferenceException if materials are null.
+
 ## [Unreleased] - 2021-05-26
 ### Fixed
 - Fix Fbx Export Project Settings break if they are open when changing scenes.

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1416,7 +1416,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             if (materials != null)
             {
                 foreach (var mat in materials) {
-                    if (MaterialMap.TryGetValue(mat.GetInstanceID(), out newMaterial))
+                    if (mat != null && MaterialMap.TryGetValue(mat.GetInstanceID(), out newMaterial))
                     {
                         fbxNode.AddMaterial(newMaterial);
                     }


### PR DESCRIPTION
Fix null reference exception when materials are missing.
Default material is assigned if material is null.

Resulting fbx of gameobject will missing materials:

![Screen Shot 2021-05-31 at 3 38 55 PM](https://user-images.githubusercontent.com/85130337/120235221-912b9e00-c227-11eb-95f3-34c20ce3f16c.png)