### PR TITLE
FBX-97 Fix error when exporting object with empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changes in Fbx Exporter
 
-## [Unreleased] - 2021-05-31
-### Fixed
-- Fix NullReferenceException if materials are null.
-- Fix NullReferenceException if animation is missing.
-
 ## [Unreleased] - 2021-05-26
 ### Fixed
 - Fix Fbx Export Project Settings break if they are open when changing scenes.
 - Fix specular texture not being exported.
+- Fix NullReferenceException if materials are null.
+- Fix NullReferenceException if animation is missing.
+- Fix error when exporting object with empty name.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -4627,7 +4627,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private static string ConvertToMayaCompatibleName(string name)
         {
             if (string.IsNullOrEmpty(name)) {
-                name = InvalidCharReplacement.ToString();
+                return InvalidCharReplacement.ToString();
             }
             string newName = RemoveDiacritics (name);
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -4628,7 +4628,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             string newName = RemoveDiacritics (name);
 
-            if (char.IsDigit (newName [0])) {
+            if (newName.Length > 0 && char.IsDigit (newName [0])) {
                 newName = newName.Insert (0, InvalidCharReplacement.ToString());
             }
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -4626,9 +4626,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private static string ConvertToMayaCompatibleName(string name)
         {
+            if (string.IsNullOrEmpty(name)) {
+                name = InvalidCharReplacement.ToString();
+            }
             string newName = RemoveDiacritics (name);
 
-            if (newName.Length > 0 && char.IsDigit (newName [0])) {
+            if (char.IsDigit (newName [0])) {
                 newName = newName.Insert (0, InvalidCharReplacement.ToString());
             }
 


### PR DESCRIPTION
Fix ArrayOutOfBoundsException when trying to export a gameobject with no name.
Added to changelog and combined both unreleased sections into one.