### PR TITLE
FBX-139 Fix misaligned text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix NullReferenceException if materials are null.
 - Fix NullReferenceException if animation is missing.
 - Fix error when exporting object with empty name.
+- Fix misaligned text in export file name field.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -57,7 +57,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 if (m_nameTextFieldStyle == null)
                 {
                     m_nameTextFieldStyle = new GUIStyle(GUIStyle.none);
-                    m_nameTextFieldStyle.alignment = TextAnchor.LowerCenter;
+                    m_nameTextFieldStyle.alignment = TextAnchor.MiddleCenter;
                     m_nameTextFieldStyle.clipping = TextClipping.Clip;
                     m_nameTextFieldStyle.normal.textColor = EditorStyles.textField.normal.textColor;
                 }


### PR DESCRIPTION
Fix the misaligned text in export file name field.

![after](https://user-images.githubusercontent.com/85130337/120379195-673caf00-c2ed-11eb-94a5-b276d120c2f9.png)
