### PR TITLE
FBX-6 Fix metafile warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fix NullReferenceException if animation is missing.
 - Fix error when exporting object with empty name.
 - Fix misaligned text in export file name field.
+- Fix warning about missing metafiles.
+- Fix warning about using absolute paths when overwriting an fbx file.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3863,7 +3863,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             try {
                 File.Delete (m_lastFilePath);
                 // delete meta file also
-                File.Delete("Assets" + m_lastFilePath.Substring(Application.dataPath.Length) + ".meta");
+                File.Delete(m_lastFilePath + ".meta");
             } catch (IOException) {
             }
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3846,6 +3846,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // delete old file
             try {
                 File.Delete (m_lastFilePath);
+                // delete meta file also
+                File.Delete("Assets" + m_lastFilePath.Substring(Application.dataPath.Length) + ".meta");
             } catch (IOException) {
             }
 

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3865,12 +3865,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             var tempMetafilePath = Path.GetTempFileName();
             
-            // Try as an absolute path
-            var fbxPath = m_lastFilePath;
+            // Try as a relative path
+            var fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
             if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
             {
-                // Try as a relative path
-                fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
+                // Try as an absolute path
+                fbxPath = m_lastFilePath;
                 if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
                 {
                     Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
@@ -3898,12 +3898,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private void ReplaceMetafile(string metafilePath)
         {
-            // Try as an absolute path
-            var fbxPath = m_lastFilePath;
+            // Try as a relative path
+            var fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
             if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
             {
-                // Try as a relative path
-                fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
+                // Try as an absolute path
+                fbxPath = m_lastFilePath;
                 if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
                 {
                     Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3883,17 +3883,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             var tempMetafilePath = Path.GetTempFileName();
             
-            // Try as a relative path
-            var fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
+            // get relative path
+            var fbxPath = "Assets/" + ExportSettings.ConvertToAssetRelativePath(m_lastFilePath);
             if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
             {
-                // Try as an absolute path
-                fbxPath = m_lastFilePath;
-                if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
-                {
-                    Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
-                    return "";
-                }
+                Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
+                return "";
             }
             
             // get metafile for original fbx file
@@ -3916,17 +3911,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private void ReplaceMetafile(string metafilePath)
         {
-            // Try as a relative path
-            var fbxPath = "Assets" + m_lastFilePath.Substring(Application.dataPath.Length);
+            // get relative path
+            var fbxPath = "Assets/" + ExportSettings.ConvertToAssetRelativePath(m_lastFilePath);
             if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
             {
-                // Try as an absolute path
-                fbxPath = m_lastFilePath;
-                if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
-                {
-                    Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
-                    return;
-                }
+                Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
+                return;
             }
             
             // get metafile for new fbx file

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3772,6 +3772,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 // delete old file, move temp file
                 ReplaceFile();
+
+                // refresh the database so Unity knows the file's been deleted
                 AssetDatabase.Refresh();
                 
                 // replace with original metafile if specified to
@@ -3846,9 +3848,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 File.Delete (m_lastFilePath);
             } catch (IOException) {
             }
-
-            // refresh the database so Unity knows the file's been deleted
-            AssetDatabase.Refresh();
 
             if (File.Exists (m_lastFilePath)) {
                 Debug.LogWarning ("Failed to delete file: " + m_lastFilePath);


### PR DESCRIPTION
Fix metafile warning when exporting an fbx.
Fix absolute path warning when overwriting an fbx.