### PR TITLE
FBX-63 Fix window width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix error when exporting object with empty name.
 - Fix misaligned text in export file name field.
 - Fix exporting zero scale not importing correctly in 3ds Max.
+- Fix window size cutting off text in export window.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -11,7 +11,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal abstract class ExportOptionsEditorWindow : EditorWindow
     {
         internal const string DefaultWindowTitle = "Export Options";
-        protected const float SelectableLabelMinWidth = 90;
+        protected const float SelectableLabelMinWidth = 150;
         protected const float BrowseButtonWidth = 25;
         protected const float LabelWidth = 175;
         protected const float FieldOffset = 18;

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -11,7 +11,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal abstract class ExportOptionsEditorWindow : EditorWindow
     {
         internal const string DefaultWindowTitle = "Export Options";
-        protected const float SelectableLabelMinWidth = 150;
+        protected const float SelectableLabelMinWidth = 120;
         protected const float BrowseButtonWidth = 25;
         protected const float LabelWidth = 175;
         protected const float FieldOffset = 18;
@@ -232,7 +232,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             InitializeReceiver ();
             #endif
             m_showOptions = true;
-            this.minSize = new Vector2 (SelectableLabelMinWidth + LabelWidth + BrowseButtonWidth, MinWindowHeight);
+            this.minSize = new Vector2 (SelectableLabelMinWidth + LabelWidth + BrowseButtonWidth + ExportButtonWidth, MinWindowHeight);
         }
 
         protected static T CreateWindow<T>() where T : EditorWindow {


### PR DESCRIPTION
Adjust SelectableLabelMinWidth to fit the names of game obejcts better.
Add ExportButtonWidth to window width so the export button is no longer cut off.

![Screen Shot 2021-06-03 at 11 22 09 AM](https://user-images.githubusercontent.com/85130337/120670967-ed2c3780-c45e-11eb-8019-a529cb7ef065.png)
