### PR TITLE
FBX-142 Fix reset settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix warning about using absolute paths when overwriting an fbx file.
 - Fix exporting zero scale not importing correctly in 3ds Max.
 - Fix window size cutting off text in export window.
+- Fix settings reset button not working.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -871,11 +871,11 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             dccOptionPaths = new List<string>();
             dccOptionNames = new List<string>();
             BakeAnimationProperty = false;
-            ExportModelSettings = ScriptableObject.CreateInstance (typeof(ExportModelSettings)) as ExportModelSettings;
-            exportModelSettingsSerialize = ExportModelSettings.info;
+            exportModelSettingsSerialize = new ExportModelSettingsSerialize();
+            ExportModelSettings.info = exportModelSettingsSerialize;
             DisplayOptionsWindow = true;
-            ConvertToPrefabSettings = ScriptableObject.CreateInstance (typeof(ConvertToPrefabSettings)) as ConvertToPrefabSettings;
-            convertToPrefabSettingsSerialize = ConvertToPrefabSettings.info;
+            convertToPrefabSettingsSerialize = new ConvertToPrefabSettingsSerialize();
+            ConvertToPrefabSettings.info = convertToPrefabSettingsSerialize;
         }
 
         /// <summary>
@@ -1754,19 +1754,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         // Called on creation and whenever the reset button is clicked
         internal void Reset()
         {
-            // create presets if none exist
-            if (!m_defaultModelExportSettings) {
-                m_defaultModelExportSettings = new Preset(ExportModelSettings);
-            }
-
-            if (!m_defaultConvertPrefabSettings) {
-                m_defaultConvertPrefabSettings = new Preset(ConvertToPrefabSettings);
-            }
-
             // apply default settings
             LoadDefaults();
-            m_defaultModelExportSettings.ApplyTo(ExportModelSettings);
-            m_defaultConvertPrefabSettings.ApplyTo(ConvertToPrefabSettings);
         }
     }
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1748,9 +1748,23 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
         internal void Reset()
         {
-            Debug.Log("reset called");
-            // resets some but not all settings
+            // resets paths and general settings
             LoadDefaults();
+
+            // reset model export settings
+            exportModelSettingsSerialize.SetExportFormat(ExportFormat.ASCII);
+            exportModelSettingsSerialize.SetModelAnimIncludeOption(ExportSettings.Include.ModelAndAnim);
+            exportModelSettingsSerialize.SetLODExportType(ExportSettings.LODExportType.All);
+            exportModelSettingsSerialize.SetObjectPosition(ExportSettings.ObjectPosition.LocalCentered);
+            exportModelSettingsSerialize.SetAnimatedSkinnedMesh(false);
+            exportModelSettingsSerialize.SetUseMayaCompatibleNames(true);
+            exportModelSettingsSerialize.SetExportUnredererd(true);
+            exportModelSettingsSerialize.SetPreserveImportSettings(false);
+
+            // reset prefab export settings
+            convertToPrefabSettingsSerialize.SetExportFormat(ExportFormat.ASCII);
+            convertToPrefabSettingsSerialize.SetAnimatedSkinnedMesh(false);
+            convertToPrefabSettingsSerialize.SetUseMayaCompatibleNames(true);
         }
     }
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -880,12 +880,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // create presets if none exist
             if (!m_defaultModelExportSettings) {
                 m_defaultModelExportSettings = new Preset(ExportModelSettings);
-                Debug.Log("model default made");
             }
 
             if (!m_defaultConvertPrefabSettings) {
                 m_defaultConvertPrefabSettings = new Preset(ConvertToPrefabSettings);
-                Debug.Log("convert default made");
             }     
         }
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
+using UnityEditor.Presets;
 
 namespace UnityEditor.Formats.Fbx.Exporter {
     [System.Serializable]
@@ -476,6 +477,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
         public enum LODExportType { All = 0, Highest = 1, Lowest = 2 }
 
+        // presets for editor settings
+        private Preset m_defaultModelExportSettings;
+        private Preset m_defaultConvertPrefabSettings;
+
         internal const string kDefaultSavePath = ".";
         private static List<string> s_PreferenceList = new List<string>() {kMayaOptionName, kMayaLtOptionName, kMaxOptionName};
         //Any additional names require a space after the name
@@ -871,6 +876,17 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             DisplayOptionsWindow = true;
             ConvertToPrefabSettings = ScriptableObject.CreateInstance (typeof(ConvertToPrefabSettings)) as ConvertToPrefabSettings;
             convertToPrefabSettingsSerialize = ConvertToPrefabSettings.info;
+
+            // create presets if none exist
+            if (!m_defaultModelExportSettings) {
+                m_defaultModelExportSettings = new Preset(ExportModelSettings);
+                Debug.Log("model default made");
+            }
+
+            if (!m_defaultConvertPrefabSettings) {
+                m_defaultConvertPrefabSettings = new Preset(ConvertToPrefabSettings);
+                Debug.Log("convert default made");
+            }     
         }
 
         /// <summary>
@@ -1746,25 +1762,15 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             this.SaveToFile ();
         }
 
+        // Called on creation and whenever the reset button is clicked
         internal void Reset()
         {
-            // resets paths and general settings
+            // loads some default settings and creates presets if none exist
             LoadDefaults();
 
-            // reset model export settings
-            exportModelSettingsSerialize.SetExportFormat(ExportFormat.ASCII);
-            exportModelSettingsSerialize.SetModelAnimIncludeOption(ExportSettings.Include.ModelAndAnim);
-            exportModelSettingsSerialize.SetLODExportType(ExportSettings.LODExportType.All);
-            exportModelSettingsSerialize.SetObjectPosition(ExportSettings.ObjectPosition.LocalCentered);
-            exportModelSettingsSerialize.SetAnimatedSkinnedMesh(false);
-            exportModelSettingsSerialize.SetUseMayaCompatibleNames(true);
-            exportModelSettingsSerialize.SetExportUnredererd(true);
-            exportModelSettingsSerialize.SetPreserveImportSettings(false);
-
-            // reset prefab export settings
-            convertToPrefabSettingsSerialize.SetExportFormat(ExportFormat.ASCII);
-            convertToPrefabSettingsSerialize.SetAnimatedSkinnedMesh(false);
-            convertToPrefabSettingsSerialize.SetUseMayaCompatibleNames(true);
+            // apply default settings
+            m_defaultModelExportSettings.ApplyTo(ExportModelSettings);
+            m_defaultConvertPrefabSettings.ApplyTo(ConvertToPrefabSettings);
         }
     }
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -868,8 +868,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             prefabSavePaths = new List<string>(){ kDefaultSavePath };
             fbxSavePaths = new List<string> (){ kDefaultSavePath };
             integrationSavePath = DefaultIntegrationSavePath;
-            dccOptionPaths = null;
-            dccOptionNames = null;
+            dccOptionPaths = new List<string>();
+            dccOptionNames = new List<string>();
             BakeAnimationProperty = false;
             ExportModelSettings = ScriptableObject.CreateInstance (typeof(ExportModelSettings)) as ExportModelSettings;
             exportModelSettingsSerialize = ExportModelSettings.info;
@@ -1764,7 +1764,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             }
 
             // apply default settings
-            //LoadDefaults();
+            LoadDefaults();
             m_defaultModelExportSettings.ApplyTo(ExportModelSettings);
             m_defaultConvertPrefabSettings.ApplyTo(ConvertToPrefabSettings);
         }

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -876,15 +876,6 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             DisplayOptionsWindow = true;
             ConvertToPrefabSettings = ScriptableObject.CreateInstance (typeof(ConvertToPrefabSettings)) as ConvertToPrefabSettings;
             convertToPrefabSettingsSerialize = ConvertToPrefabSettings.info;
-
-            // create presets if none exist
-            if (!m_defaultModelExportSettings) {
-                m_defaultModelExportSettings = new Preset(ExportModelSettings);
-            }
-
-            if (!m_defaultConvertPrefabSettings) {
-                m_defaultConvertPrefabSettings = new Preset(ConvertToPrefabSettings);
-            }     
         }
 
         /// <summary>
@@ -1763,10 +1754,17 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         // Called on creation and whenever the reset button is clicked
         internal void Reset()
         {
-            // loads some default settings and creates presets if none exist
-            LoadDefaults();
+            // create presets if none exist
+            if (!m_defaultModelExportSettings) {
+                m_defaultModelExportSettings = new Preset(ExportModelSettings);
+            }
+
+            if (!m_defaultConvertPrefabSettings) {
+                m_defaultConvertPrefabSettings = new Preset(ConvertToPrefabSettings);
+            }
 
             // apply default settings
+            //LoadDefaults();
             m_defaultModelExportSettings.ApplyTo(ExportModelSettings);
             m_defaultConvertPrefabSettings.ApplyTo(ConvertToPrefabSettings);
         }

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -477,10 +477,6 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
         public enum LODExportType { All = 0, Highest = 1, Lowest = 2 }
 
-        // presets for editor settings
-        private Preset m_defaultModelExportSettings;
-        private Preset m_defaultConvertPrefabSettings;
-
         internal const string kDefaultSavePath = ".";
         private static List<string> s_PreferenceList = new List<string>() {kMayaOptionName, kMayaLtOptionName, kMaxOptionName};
         //Any additional names require a space after the name

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -1745,6 +1745,13 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             convertToPrefabSettingsSerialize = ConvertToPrefabSettings.info;
             this.SaveToFile ();
         }
+
+        internal void Reset()
+        {
+            Debug.Log("reset called");
+            // resets some but not all settings
+            LoadDefaults();
+        }
     }
 
     [AttributeUsage(AttributeTargets.Class)]

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
@@ -753,5 +753,43 @@ namespace FbxExporter.UnitTests
 
             exportWindow.Close();
         }
+        [Test]
+        public void TestExportOptionsReset()
+        {
+            var instance = ExportSettings.instance;
+            var exportSettings = instance.ExportModelSettings.info;
+            var prefabSettings = instance.ConvertToPrefabSettings.info;
+            var go = new GameObject("temp");
+            var exportWindow = ExportModelEditorWindow.Init(new Object[] { go }, isTimelineAnim: false);
+            var convertWindow = ConvertToPrefabEditorWindow.Init(new GameObject[] { go });
+
+            // test export window reset
+            // change one setting from default
+            exportSettings.SetExportFormat(ExportSettings.ExportFormat.Binary);
+            Assert.That(exportSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
+
+            // reset export settings
+            instance.Reset();
+
+            // check that setting was reverted to default
+            Assert.That(exportSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
+
+            exportWindow.ResetSessionSettings();
+            exportWindow.Close();
+
+            // test convert prefab window reset
+            // change one setting from default
+            prefabSettings.SetExportFormat(ExportSettings.ExportFormat.Binary);
+            Assert.That(prefabSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
+
+            // reset export settings
+            instance.Reset();
+
+            // check that setting was reverted to default
+            Assert.That(prefabSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
+
+            convertWindow.ResetSessionSettings();
+            convertWindow.Close();
+        }
     }
 }

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
@@ -757,36 +757,34 @@ namespace FbxExporter.UnitTests
         public void TestExportOptionsReset()
         {
             var instance = ExportSettings.instance;
-            var exportSettings = instance.ExportModelSettings.info;
-            var prefabSettings = instance.ConvertToPrefabSettings.info;
             var go = new GameObject("temp");
             var exportWindow = ExportModelEditorWindow.Init(new Object[] { go }, isTimelineAnim: false);
             var convertWindow = ConvertToPrefabEditorWindow.Init(new GameObject[] { go });
 
             // test export window reset
             // change one setting from default
-            exportSettings.SetExportFormat(ExportSettings.ExportFormat.Binary);
-            Assert.That(exportSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
+            instance.ExportModelSettings.info.SetExportFormat(ExportSettings.ExportFormat.Binary);
+            Assert.That(instance.ExportModelSettings.info.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
 
             // reset export settings
             instance.Reset();
 
             // check that setting was reverted to default
-            Assert.That(exportSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
+            Assert.That(instance.ExportModelSettings.info.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
 
             exportWindow.ResetSessionSettings();
             exportWindow.Close();
 
             // test convert prefab window reset
             // change one setting from default
-            prefabSettings.SetExportFormat(ExportSettings.ExportFormat.Binary);
-            Assert.That(prefabSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
+            instance.ConvertToPrefabSettings.info.SetExportFormat(ExportSettings.ExportFormat.Binary);
+            Assert.That(instance.ConvertToPrefabSettings.info.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.Binary));
 
             // reset export settings
             instance.Reset();
 
             // check that setting was reverted to default
-            Assert.That(prefabSettings.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
+            Assert.That(instance.ConvertToPrefabSettings.info.ExportFormat, Is.EqualTo(ExportSettings.ExportFormat.ASCII));
 
             convertWindow.ResetSessionSettings();
             convertWindow.Close();


### PR DESCRIPTION
Add reset functionality for FBX export project settings menu.
Add `Reset()` to `FbxExportSettings`.
Fix `dccOptionNames` being reset to null instead of empty list.