### PR TITLE
FBX 67 Fix new folder button on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix warning about using absolute paths when overwriting an fbx file.
 - Fix exporting zero scale not importing correctly in 3ds Max.
 - Fix window size cutting off text in export window.
+- Fix export to new folder on Mac.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Fix warning about using absolute paths when overwriting an fbx file.
 - Fix exporting zero scale not importing correctly in 3ds Max.
 - Fix window size cutting off text in export window.
-- Fix export to new folder on Mac.
+- Fix not being able to export to a new folder on Mac.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/ConvertToPrefabEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToPrefabEditorWindow.cs
@@ -397,7 +397,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 string initialPath = Application.dataPath;
 
-                string fullPath = EditorUtility.OpenFolderPanel(
+                string fullPath = EditorUtility.SaveFolderPanel(
                     "Select FBX Prefab Variant Save Path", initialPath, null
                 );
 

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -523,7 +523,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 string initialPath = Application.dataPath;
 
-                string fullPath = EditorUtility.OpenFolderPanel(
+                string fullPath = EditorUtility.SaveFolderPanel(
                     "Select Export Model Path", initialPath, null
                 );
 

--- a/com.unity.formats.fbx/Editor/FbxExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportSettings.cs
@@ -142,7 +142,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             {
                 string initialPath = Application.dataPath;
 
-                string fullPath = EditorUtility.OpenFolderPanel(
+                string fullPath = EditorUtility.SaveFolderPanel(
                     openFolderPanelTitle, initialPath, null
                 );
                 


### PR DESCRIPTION
Change file selector so that the option to create a new folder is added.
Changed file selector window for fbx export, prefab export, and fbx export project settings.
