### PR TITLE
FBX-2 Fix hdrp incandescence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix object name not being undone after undo convert to prefab.
 - Fix settings reset button not working.
 - Fix not being able to export to a new folder on Mac.
+- Fix hdrp materials being exported with max incandescence.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -702,6 +702,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // itself specular, Lambert otherwise.
             var shader = unityMaterial.shader;
             bool specular = shader.name.ToLower ().Contains ("specular");
+            bool hdrp = shader.name.ToLower().Contains("hdrp");
 
             var fbxMaterial = specular
                 ? FbxSurfacePhong.Create (fbxScene, fbxName)
@@ -710,6 +711,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Copy the flat colours over from Unity standard materials to FBX.
             fbxMaterial.Diffuse.Set (GetMaterialColor (unityMaterial, "_Color"));
             fbxMaterial.Emissive.Set (GetMaterialColor (unityMaterial, "_EmissionColor", 0));
+            // hdrp materials dont export emission properly, so default to 0
+            if (hdrp) {
+                fbxMaterial.Emissive.Set(0);
+            }
             fbxMaterial.Ambient.Set (new FbxDouble3 ());
 
             fbxMaterial.BumpFactor.Set (unityMaterial.HasProperty ("_BumpScale") ? unityMaterial.GetFloat ("_BumpScale") : 0);

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -713,7 +713,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             fbxMaterial.Emissive.Set (GetMaterialColor (unityMaterial, "_EmissionColor", 0));
             // hdrp materials dont export emission properly, so default to 0
             if (hdrp) {
-                fbxMaterial.Emissive.Set(0);
+                fbxMaterial.Emissive.Set(new FbxDouble3(0, 0, 0));
             }
             fbxMaterial.Ambient.Set (new FbxDouble3 ());
 


### PR DESCRIPTION
Fix hdrp materials being exported with maximum incandescence/emission in Maya and Unity.