### PR TITLE
FBX-1 Fix null shared mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix not being able to export to a new folder on Mac.
 - Fix hdrp materials being exported with max incandescence.
 - Fix warning about ExportSettings not being in a file called ExportSettings.cs.
+- Fix exception when exporting a missing or null mesh.
 
 ## [4.1.0-pre.2] - 2021-05-05
 ### Known Issues

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1408,17 +1408,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
             else if (unityPrefabParent == null)
             {
                 // check if same mesh has already been exported
-                MeshFilter unityGoMesh = unityGo.GetComponent<MeshFilter>();
-                if (unityGoMesh != null && MeshToFbxNodeMap.ContainsKey(unityGoMesh.sharedMesh))
+                Mesh unityGoMesh = unityGo.GetComponent<MeshFilter>().sharedMesh;
+                if (unityGoMesh && MeshToFbxNodeMap.ContainsKey(unityGoMesh))
                 {
-                    fbxMesh = MeshToFbxNodeMap[unityGoMesh.sharedMesh].GetMesh();
+                    fbxMesh = MeshToFbxNodeMap[unityGoMesh].GetMesh();
                 }
                 // export mesh as normal and add it to list
                 else
                 {
                     if (unityGoMesh != null)
                     {
-                        MeshToFbxNodeMap.Add(unityGoMesh.sharedMesh, fbxNode);
+                        MeshToFbxNodeMap.Add(unityGoMesh, fbxNode);
                     }
                     return false;
                 }

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1400,7 +1400,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             if (!unityGoMesh)
             {
-                Debug.LogWarningFormat("Warning: Could not find a valid mesh for {0}.", unityGo.name);
                 return false;
             }
             // export mesh as an instance if it is a duplicate mesh or a prefab

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -182,7 +182,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         Dictionary<string, FbxTexture> TextureMap = new Dictionary<string, FbxTexture> ();
 
         /// <summary>
-        /// Map the ID of a prefab to an FbxMesh (for preserving instances) 
+        /// Map a Unity mesh to an fbx node (for preserving instances) 
         /// </summary>
         Dictionary<Mesh, FbxNode> SharedMeshes = new Dictionary<Mesh, FbxNode>();
 
@@ -1389,21 +1389,31 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // where the fbx mesh is stored on a successful export
             FbxMesh fbxMesh = null;
+            // store the shared mesh of the game object
             Mesh unityGoMesh = null;
+            
             // get the mesh of the game object
             if (unityGo.TryGetComponent<MeshFilter>(out MeshFilter meshFilter))
             {
                 unityGoMesh = meshFilter.sharedMesh;
             }
 
+            if (!unityGoMesh)
+            {
+                return false;
+            }
             // export mesh as an instance if it is a duplicate mesh or a prefab
-            if (unityGoMesh && SharedMeshes.ContainsKey(unityGoMesh))
+            else if (unityGoMesh && SharedMeshes.ContainsKey(unityGoMesh))
             {
                 if (Verbose)
                 {
                     Debug.Log (string.Format ("exporting instance {0}", unityGo.name));
                 }
-                fbxMesh = SharedMeshes[unityGoMesh].GetMesh();
+
+                if (SharedMeshes.TryGetValue(unityGoMesh, out FbxNode node))
+                {
+                    fbxMesh = node.GetMesh();
+                }
             }
             // unique mesh, so save it to find future duplicates
             else if (unityGoMesh)

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1396,25 +1396,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 unityGoMesh = meshFilter.sharedMesh;
             }
 
-            // mesh is a prefab instance, so export with a reference to its parent
+            // export mesh as an instance if it is a duplicate mesh or a prefab
             if (unityGoMesh && SharedMeshes.ContainsKey(unityGoMesh))
             {
                 if (Verbose)
                 {
                     Debug.Log (string.Format ("exporting instance {0}", unityGo.name));
                 }
-
-                // add mesh to shared prefab meshes if exported successfully
                 fbxMesh = SharedMeshes[unityGoMesh].GetMesh();
             }
-            // new mesh, so save reference
+            // unique mesh, so save it to find future duplicates
             else if (unityGoMesh)
             {
                 SharedMeshes.Add(unityGoMesh, fbxNode);
                 return false;
             }
+
             // mesh doesn't exist or wasn't exported successfully
-            else
+            if (fbxMesh == null)
             {
                 return false;
             }

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1400,6 +1400,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             if (!unityGoMesh)
             {
+                Debug.LogWarningFormat("Warning: Could not find a valid mesh for {0}.", unityGo.name);
                 return false;
             }
             // export mesh as an instance if it is a duplicate mesh or a prefab

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1403,20 +1403,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return false;
             }
             // export mesh as an instance if it is a duplicate mesh or a prefab
-            else if (unityGoMesh && SharedMeshes.ContainsKey(unityGoMesh))
+            else if (SharedMeshes.TryGetValue(unityGoMesh, out FbxNode node))
             {
                 if (Verbose)
                 {
                     Debug.Log (string.Format ("exporting instance {0}", unityGo.name));
                 }
-
-                if (SharedMeshes.TryGetValue(unityGoMesh, out FbxNode node))
-                {
-                    fbxMesh = node.GetMesh();
-                }
+                
+                fbxMesh = node.GetMesh();
             }
             // unique mesh, so save it to find future duplicates
-            else if (unityGoMesh)
+            else
             {
                 SharedMeshes.Add(unityGoMesh, fbxNode);
                 return false;

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -1192,5 +1192,16 @@ namespace FbxExporter.UnitTests
             Assert.That(AreEqual(fbxSphere2.position, sphere2.transform.position),
                 string.Format("Positions do not match.\nActual: {0}\nExpected: {1}", fbxSphere2.position, sphere2.transform.position));
         }
+        // Test that export does not fail if the mesh is missing or null
+        [Test]
+        public void TestMissingMeshExport()
+        {
+            var filename = GetRandomFbxFilePath();
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.GetComponent<MeshFilter>().sharedMesh = null;
+            Assert.IsNull(cube.GetComponent<MeshFilter>().sharedMesh);
+            ModelExporter.ExportObject(filename, cube);
+            Assert.IsNotNull(filename);
+        }
     }
 }


### PR DESCRIPTION
Fix error when exporting a game object with a missing mesh.
Reformat `ExportInstance` code and simplify instance export.