### PR TITLE
FBX-168 update version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [4.1.0-pre.3] - 2021-06-28
 ### Changed
-- Updated the FBX SDK bindings to 4.1.0-pre.2.
+- Updated the FBX SDK bindings to 4.1.0-pre.3.
 
 ### Fixed
 - Fix Fbx Export Project Settings break if they are open when changing scenes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changes in Fbx Exporter
 
-## [Unreleased] - 2021-05-26
+## [4.1.0-pre.3] - 2021-06-28
+### Changed
+- Updated the FBX SDK bindings to 4.1.0-pre.2.
+
 ### Fixed
 - Fix Fbx Export Project Settings break if they are open when changing scenes.
 - Fix specular texture not being exported.

--- a/com.unity.formats.fbx/package.json
+++ b/com.unity.formats.fbx/package.json
@@ -4,7 +4,7 @@
   "version": "4.1.0-pre.3",
   "dependencies": {
     "com.unity.timeline": "1.5.2",
-    "com.autodesk.fbx": "4.1.0-pre.2"
+    "com.autodesk.fbx": "4.1.0-pre.3"
   },
   "unity": "2019.4",
   "unityRelease": "0f1",

--- a/com.unity.formats.fbx/package.json
+++ b/com.unity.formats.fbx/package.json
@@ -1,10 +1,10 @@
 {
   "name": "com.unity.formats.fbx",
   "displayName": "FBX Exporter",
-  "version": "4.1.0-pre.2",
+  "version": "4.1.0-pre.3",
   "dependencies": {
     "com.unity.timeline": "1.5.2",
-    "com.autodesk.fbx": "4.1.0-pre.1"
+    "com.autodesk.fbx": "4.1.0-pre.2"
   },
   "unity": "2019.4",
   "unityRelease": "0f1",


### PR DESCRIPTION
errors are due to updating the com.autodesk.fbx version (not yet published)