### PR TITLE
Feature: New export options to embed textures and export unique meshes

### DIFF
--- a/com.unity.formats.fbx/Editor/ExportModelSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelSettings.cs
@@ -113,6 +113,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             exportSettings.SetPreserveImportSettings(EditorGUILayout.Toggle(exportSettings.PreserveImportSettings));
             EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
+
+            exportSettings.SetKeepInstances(EditorGUILayout.Toggle(new GUIContent("Keep Instances", "If enabled, instances will be preserved as instances in the FBX file. This can cause issues with e.g. Blender if different instances have different materials assigned."), exportSettings.KeepInstances));
+            exportSettings.SetEmbedTextures(EditorGUILayout.Toggle(new GUIContent("Embed Textures", "If enabled, textures are embedded into the resulting FBX file instead of referenced."), exportSettings.EmbedTextures));
+
         }
     }
 
@@ -126,6 +130,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         bool AllowSceneModification { get; }
         bool ExportUnrendered { get; }
         bool PreserveImportSettings { get; }
+        bool KeepInstances { get; }
+        bool EmbedTextures { get; }
         Transform AnimationSource { get; }
         Transform AnimationDest { get; }
     }
@@ -190,6 +196,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public abstract bool ExportUnrendered { get; }
         public virtual bool PreserveImportSettings { get { return false; } }
         public abstract bool AllowSceneModification { get; }
+        public virtual bool KeepInstances { get { return true; } }
+        public virtual bool EmbedTextures { get { return false; } }
 
         public override bool Equals(object e)
         {
@@ -222,7 +230,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private bool exportUnrendered = true;
         [SerializeField]
         private bool preserveImportSettings = false;
-
+        [SerializeField]
+        private bool keepInstances = true;
+        [SerializeField]
+        private bool embedTextures = false;
+        
         public override ExportSettings.Include ModelAnimIncludeOption { get { return include; } }
         public void SetModelAnimIncludeOption(ExportSettings.Include include) { this.include = include; }
         public override ExportSettings.LODExportType LODExportType { get { return lodLevel; } }
@@ -234,6 +246,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public override bool PreserveImportSettings { get { return preserveImportSettings; } }
         public void SetPreserveImportSettings(bool preserveImportSettings){ this.preserveImportSettings = preserveImportSettings; }
         public override bool AllowSceneModification { get { return false; } }
+        public override bool KeepInstances { get { return keepInstances; } }
+        public void SetKeepInstances(bool keepInstances){ this.keepInstances = keepInstances; }
+        public override bool EmbedTextures { get { return embedTextures; } }
+        public void SetEmbedTextures(bool embedTextures){ this.embedTextures = embedTextures; }
 
         public override bool Equals(object e)
         {

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3385,7 +3385,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var fbxNode = entry.Value;
 
                 // try export mesh
-                bool exportedMesh = ExportInstance (unityGo, fbxScene, fbxNode);
+                bool exportedMesh = false;
+                if(ExportOptions.KeepInstances) {
+                    exportedMesh = ExportInstance (unityGo, fbxScene, fbxNode);
+                }
 
                 if (!exportedMesh) {
                     exportedMesh = ExportMesh (unityGo, fbxNode);
@@ -3592,7 +3595,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 // Create the FBX manager
                 using (var fbxManager = FbxManager.Create ()) {
                     // Configure fbx IO settings.
-                    fbxManager.SetIOSettings (FbxIOSettings.Create (fbxManager, Globals.IOSROOT));
+                    var settings = FbxIOSettings.Create (fbxManager, Globals.IOSROOT);
+                    if(ExportOptions.EmbedTextures)
+                        settings.SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
+                    fbxManager.SetIOSettings (settings);
 
                     // Create the exporter
                     var fbxExporter = FbxExporter.Create (fbxManager, "Exporter");


### PR DESCRIPTION
This PR includes two new export options:
![image](https://user-images.githubusercontent.com/2693840/134082883-066cd4cf-cf44-444f-bbaf-af0793aa8693.png)

1. **Embed Textures:** fixes a number of issues with the FBX exporter and interoperability, since relative/absolute texture paths don't matter anymore for external software. The resulting file is a monolithic FBX that contains all textures as embedded resources (very useful for interop). (Fixes Case 1201937)

2. **Keep Instances:** fixes issues with for example Blender and multimaterials on instances. Currently, when making a scene with 4 default Unity cubes with separate materials and exporting that to blender, the import result will be broken since a number of softwares don't properly support instances with individual materials. While this is clearly a bug somewhere else, this option allows to export all meshes as individual, unique ones and thus produces working files. (See https://developer.blender.org/T91288) (Fixes Case 1364212)