### PR TITLE
FBX-328 - Doc tag/link/formatting fixes

### DIFF
--- a/com.unity.formats.fbx/Documentation~/troubleshooting.md
+++ b/com.unity.formats.fbx/Documentation~/troubleshooting.md
@@ -94,9 +94,9 @@ If you have already uninstalled the FBX Exporter package and are experiencing is
 
 ## Exporting camera animation only from Maya gives incorrect camera rotations
 
-When using the Unity FBX Exporter Maya plugin to export camera animation with the `File > Unity > Export Animation Only` menu option,
+When using the Unity FBX Exporter Maya plugin to export camera animation with the **File > Unity > Export Animation Only** menu option,
 the resulting exported camera animation may be incorrect.
 
-The reason for this is that using the `Export Animation Only` menu option will export only transform animation and not the camera or its animated properties.
+The reason for this is that using the **Export Animation Only** menu option will export only transform animation and not the camera or its animated properties.
 
-The workaround for this issue is to export the camera with the `File > Unity > Export` menu option, which will export the camera as well as its animation.
+The workaround for this issue is to export the camera with the **File > Unity > Export** menu option, which will export the camera as well as its animation.

--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -99,7 +99,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         /// <summary>
-        // Validate the menu items defined above.
+        /// Validate the menu items defined above.
         /// </summary>
         [MenuItem(GameObjectMenuItemName, true, 30)]
         [MenuItem(AssetsMenuItemName, true, 30)]

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -64,7 +64,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     /// Use the ExportObject and ExportObjects methods. The default export
     /// options are used when exporting the objects to the FBX file.
     /// </para>
-    /// <para>For information on using the ModelExporter class, see <a href="../manual/api_index.html">the Developer's Guide</a>.</para>
+    /// <para>For information on using the ModelExporter class, see <a href="index.html">the Developer's Guide</a>.</para>
     /// </summary>
     public sealed class ModelExporter : System.IDisposable
     {

--- a/com.unity.formats.fbx/Runtime/FbxPrefab.cs
+++ b/com.unity.formats.fbx/Runtime/FbxPrefab.cs
@@ -75,7 +75,7 @@ namespace UnityEngine.Formats.Fbx.Exporter
 
         /// <summary>
         /// Should we auto-update this prefab when the FBX file is updated?
-        /// <summary>
+        /// </summary>
         [Tooltip("Should we auto-update this prefab when the FBX file is updated?")]
         [SerializeField]
         bool m_autoUpdate = true;


### PR DESCRIPTION
## Purpose of the PR: 

[FBX-328](https://jira.unity3d.com/browse/FBX-328) - Documentation wrap-up before FBX Exporter 4.2.0 release
- API doc xml formatting issue fixes
- Bad link correction
- Small text formatting fix