### PR TITLE
FbxExporter.cs improvement

### DIFF
--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
@@ -56,6 +56,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             OnContextItem(command, SelectionMode.Editable | SelectionMode.TopLevel);
         }
+
         [MenuItem(AssetsMenuItemName, false, 30)]
         static void OnAssetsContextItem(MenuCommand command)
         {
@@ -159,7 +160,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var go = toExport.First();
                     if (PrefabUtility.IsPartOfNonAssetPrefabInstance(go) && !PrefabUtility.IsOutermostPrefabInstanceRoot(go))
                     {
-                        DisplayInvalidSelectionDialog(go, 
+                        DisplayInvalidSelectionDialog(go,
                             "Children of a Prefab instance cannot be converted.\nYou can open the Prefab in Prefab Mode or unpack the Prefab instance to convert it's children");
                         return null;
                     }
@@ -213,7 +214,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         /// <summary>
         /// For sceneObj, replace references of objects that are keys in fixSceneRefsMap, to the value.
-        /// 
+        ///
         /// If the scene object is toConvertRoot or a child of it, then do not fix its references as it
         /// will be deleted after conversion.
         /// </summary>
@@ -257,7 +258,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         if (property.propertyPath == "m_Father") continue;
                         if (!property.objectReferenceValue) continue;
 
-                        if(fixSceneRefsMap.TryGetValue(property.objectReferenceValue, out Object newVal))
+                        if (fixSceneRefsMap.TryGetValue(property.objectReferenceValue, out Object newVal))
                         {
                             property.objectReferenceValue = newVal;
                         }
@@ -279,6 +280,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return items.ConvertAll(x => x.ToObject());
             }
         }
+
 #endif // UNITY_2021_2_OR_NEWER
 
         /// <summary>
@@ -307,10 +309,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     // bug 1242332: don't grab the focus!
                     // The arguments aren't actually optional so they must all be named.
                     s_sceneHierarchyWindow = EditorWindow.GetWindow(
-                            t: sceneHierarchyWindowType,
-                            utility: false,
-                            title: null,
-                            focus: false);
+                        t: sceneHierarchyWindowType,
+                        utility: false,
+                        title: null,
+                        focus: false);
                 }
                 return s_sceneHierarchyWindow;
             }
@@ -370,6 +372,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             setSearchFilterMethod.Invoke(sceneHierarchyWindow, new object[] { previousSearchFilter, SearchableEditorWindow.SearchMode.Name, true, false });
             return sceneObjects;
         }
+
 #endif // UNITY_2021_2_OR_NEWER
 
         /// <summary>
@@ -439,7 +442,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // so that we can unpack it and avoid issues with nested prefab references.
             bool isPrefabAsset = false;
             UnityEngine.SceneManagement.Scene? previewScene = null;
-            if(PrefabUtility.IsPartOfPrefabAsset(toConvert) && PrefabUtility.GetPrefabInstanceStatus(toConvert) == PrefabInstanceStatus.NotAPrefab)
+            if (PrefabUtility.IsPartOfPrefabAsset(toConvert) && PrefabUtility.GetPrefabInstanceStatus(toConvert) == PrefabInstanceStatus.NotAPrefab)
             {
                 previewScene = SceneManagement.EditorSceneManager.NewPreviewScene();
                 toConvert = PrefabUtility.InstantiatePrefab(toConvert, previewScene.Value) as GameObject;
@@ -516,7 +519,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Undo.DestroyObjectImmediate(toConvert);
                 Undo.RegisterCreatedObjectUndo(fbxInstance, UndoConversionCreateObject);
                 SceneManagement.EditorSceneManager.MarkSceneDirty(fbxInstance.scene);
-                
+
                 Undo.IncrementCurrentGroup();
                 return fbxInstance;
             }
@@ -547,7 +550,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// A list of scene objects that reference this
             /// object or one of its components. Populated before traversing the
             /// components to speed up the search time of finding/replacing references.
-            /// 
+            ///
             /// Note: In older versions of Unity (without the Search API), searching
             /// for references by GameObject ID will not return objects that reference
             /// the components of the same GameObject. Therefore in older versions still need
@@ -560,10 +563,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 destGO = dest;
 #if UNITY_2021_2_OR_NEWER
-               sceneObjectsWithReference = new List<Object>();
+                sceneObjectsWithReference = new List<Object>();
 #endif // UNITY_2021_2_OR_NEWER
+            }
         }
-    }
 
         /// <summary>
         /// Dictionary from name of source object (in toConvert hierarchy) to info.
@@ -638,9 +641,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// fbx asset or an instance of an fbx.</param>
         /// <returns>The root of a model prefab asset.</returns>
         internal static GameObject GetOrCreateFbxAsset(GameObject toConvert,
-                string fbxDirectoryFullPath = null,
-                string fbxFullPath = null,
-                ConvertToPrefabSettingsSerialize exportOptions = null)
+            string fbxDirectoryFullPath = null,
+            string fbxFullPath = null,
+            ConvertToPrefabSettingsSerialize exportOptions = null)
         {
             if (toConvert == null)
             {
@@ -683,9 +686,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Export to FBX. It refreshes the database.
             {
                 var fbxActualPath = ModelExporter.ExportObject(
-                                        fbxFullPath, toConvert,
-                                        exportOptions != null ? exportOptions : new ConvertToPrefabSettingsSerialize()
-                                    );
+                    fbxFullPath, toConvert,
+                    exportOptions != null ? exportOptions : new ConvertToPrefabSettingsSerialize()
+                );
                 if (fbxActualPath != fbxFullPath)
                 {
                     throw new ConvertToNestedPrefabException("Failed to convert " + toConvert.name);
@@ -717,7 +720,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Children of model prefab instances will also have "model prefab instance"
             // as their prefab type, so it is important that it is the root that is selected.
             //
-            // e.g. If I have the following hierarchy: 
+            // e.g. If I have the following hierarchy:
             //      Cube
             //      -- Sphere
             //
@@ -744,7 +747,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     }
                 case PrefabInstanceStatus.NotAPrefab:
                     // a prefab asset
-                    if(go.transform.root.gameObject == go)
+                    if (go.transform.root.gameObject == go)
                     {
                         return go;
                     }
@@ -797,7 +800,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 file = string.Format(format, fileWithoutExt, index, ext);
                 file = Path.Combine(path, file);
                 index++;
-            } while (File.Exists(file));
+            }
+            while (File.Exists(file));
 
             return file;
         }
@@ -881,7 +885,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 // Fix references of other objects in the scene
 #if UNITY_2021_2_OR_NEWER
-                if(info.sceneObjectsWithReference != null)
+                if (info.sceneObjectsWithReference != null)
                 {
                     var items = info.sceneObjectsWithReference;
                     foreach (var item in items)
@@ -915,7 +919,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 // set icon
 #if UNITY_2021_2_OR_NEWER
                 var sourceIcon = EditorGUIUtility.GetIconForObject(sourceGO);
-                EditorGUIUtility.SetIconForObject(destGO, sourceIcon);   
+                EditorGUIUtility.SetIconForObject(destGO, sourceIcon);
 #else // UNITY_2021_2_OR_NEWER
                 System.Reflection.BindingFlags bindingFlags = System.Reflection.BindingFlags.InvokeMethod | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public;
                 var sourceIcon = typeof(EditorGUIUtility).InvokeMember("GetIconForObject", bindingFlags, null, null, new object[] { sourceGO });
@@ -932,7 +936,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         /// <summary>
         /// Gets a dictionary linking dest GameObject name to source game object.
-        /// 
+        ///
         /// Before export we ensure that the hierarchy has unique names, so that we can map by name afterwards.
         /// </summary>
         /// <returns>Dictionary containing the name to source game object.</returns>
@@ -968,7 +972,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
         }
-        
+
         /// <summary>
         /// Copy the object reference from fromProperty to the matching property on serializedObject.
         /// Use nameMap to find the correct object reference to use.
@@ -1009,9 +1013,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// are already in the FBX.
         ///
         /// The 'from' hierarchy is not modified.
-        /// 
+        ///
         /// Note: 'root' is the root object that is being converted
-        /// 
+        ///
         /// For each component, add to fixSceneRefsMap a mapping from the original component on "from"
         /// to the new component on "to". In order to be able to fix scene references that were
         /// pointing to the original component.
@@ -1021,7 +1025,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // copy components on "from" to "to". Don't want to copy over meshes and materials that were exported
             var originalComponents = new List<Component>(from.GetComponents<Component>());
             var destinationComponents = new List<Component>(to.GetComponents<Component>());
-            foreach(var fromComponent in originalComponents)
+            foreach (var fromComponent in originalComponents)
             {
                 // ignore missing components
                 if (fromComponent == null)
@@ -1081,7 +1085,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 // been added when adding the particle system.
                 // An object can have only one ParticleSystem so there shouldn't be an issue of the renderer
                 // belonging to a different ParticleSystem.
-                if(!toComponent && fromComponent is ParticleSystemRenderer)
+                if (!toComponent && fromComponent is ParticleSystemRenderer)
                 {
                     toComponent = to.GetComponent<ParticleSystemRenderer>();
                 }
@@ -1099,7 +1103,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
 
                 fixSceneRefsMap.Add(fromComponent, toComponent);
-                
+
                 // SkinnedMeshRenderer also stores the mesh.
                 // Make sure this is not copied over when the SkinnedMeshRenderer is updated,
                 // as we want to keep the mesh from the FBX not the scene.
@@ -1115,7 +1119,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     EditorJsonUtility.FromJsonOverwrite(json, toComponent);
                 }
 
-                if(fromComponent is MeshCollider)
+                if (fromComponent is MeshCollider)
                 {
                     // UNI-27534: This fixes the issue where the mesh collider would not update to point to the mesh in the fbx after export
                     // Point the mesh included in the mesh collider to the mesh in the FBX file, which is the same as the one in mesh filter
@@ -1142,7 +1146,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 // For everything else, filtering by visible children in the while loop and then copying properties that don't have visible children,
                 // ensures that only the leaf properties are copied over. Copying other properties is not usually necessary and may break references that
                 // were not meant to be copied.
-                while (fromProperty.Next((fromComponent is SkinnedMeshRenderer)? fromProperty.hasChildren : fromProperty.hasVisibleChildren))
+                while (fromProperty.Next((fromComponent is SkinnedMeshRenderer) ? fromProperty.hasChildren : fromProperty.hasVisibleChildren))
                 {
                     if (!fromProperty.hasVisibleChildren)
                     {

--- a/com.unity.formats.fbx/Editor/ConvertToPrefabSettings.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToPrefabSettings.cs
@@ -1,8 +1,8 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
-    [CustomEditor (typeof(ConvertToPrefabSettings))]
+    [CustomEditor(typeof(ConvertToPrefabSettings))]
     internal class ConvertToPrefabSettingsEditor : UnityEditor.Editor
     {
         private const float DefaultLabelWidth = 175;
@@ -11,13 +11,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public float LabelWidth { get; set; } = DefaultLabelWidth;
         public float FieldOffset { get; set; } = DefaultFieldOffset;
 
-        private string[] exportFormatOptions = new string[]{ "ASCII", "Binary" };
-        private string[] includeOptions = new string[]{"Model(s) + Animation"};
-        private string[] lodOptions = new string[]{"All Levels"};
+        private string[] exportFormatOptions = new string[] { "ASCII", "Binary" };
+        private string[] includeOptions = new string[] {"Model(s) + Animation"};
+        private string[] lodOptions = new string[] {"All Levels"};
 
-        private string[] objPositionOptions { get { return new string[]{"Local Pivot"}; }}
+        private string[] objPositionOptions { get { return new string[] {"Local Pivot"}; }}
 
-        public override void OnInspectorGUI ()
+        public override void OnInspectorGUI()
         {
             var exportSettings = ((ConvertToPrefabSettings)target).info;
 
@@ -34,7 +34,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // always greyed out, show only to let user know what will happen
             EditorGUI.BeginDisabledGroup(true);
             EditorGUILayout.Popup(0, includeOptions);
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -42,7 +42,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // always greyed out, show only to let user know what will happen
             EditorGUI.BeginDisabledGroup(true);
             EditorGUILayout.Popup(0, lodOptions);
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -50,24 +50,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // always greyed out, show only to let user know what will happen
             EditorGUI.BeginDisabledGroup(true);
             EditorGUILayout.Popup(0, objPositionOptions);
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Animated Skinned Mesh"), GUILayout.Width(LabelWidth - FieldOffset));
-            exportSettings.SetAnimatedSkinnedMesh(EditorGUILayout.Toggle (exportSettings.AnimateSkinnedMesh));
+            exportSettings.SetAnimatedSkinnedMesh(EditorGUILayout.Toggle(exportSettings.AnimateSkinnedMesh));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Compatible Naming",
-                    "In Maya some symbols such as spaces and accents get replaced when importing an FBX " +
-                    "(e.g. \"foo bar\" becomes \"fooFBXASC032bar\"). " +
-                    "On export, convert the names of GameObjects so they are Maya compatible." +
-                    (exportSettings.UseMayaCompatibleNames ? "" :
-                        "\n\nWARNING: Disabling this feature may result in lost material connections," +
-                        " and unexpected character replacements in Maya.")),
-                    GUILayout.Width(LabelWidth - FieldOffset));
-            exportSettings.SetUseMayaCompatibleNames(EditorGUILayout.Toggle (exportSettings.UseMayaCompatibleNames));
+                "In Maya some symbols such as spaces and accents get replaced when importing an FBX " +
+                "(e.g. \"foo bar\" becomes \"fooFBXASC032bar\"). " +
+                "On export, convert the names of GameObjects so they are Maya compatible." +
+                (exportSettings.UseMayaCompatibleNames ? "" :
+                    "\n\nWARNING: Disabling this feature may result in lost material connections," +
+                    " and unexpected character replacements in Maya.")),
+                GUILayout.Width(LabelWidth - FieldOffset));
+            exportSettings.SetUseMayaCompatibleNames(EditorGUILayout.Toggle(exportSettings.UseMayaCompatibleNames));
             GUILayout.EndHorizontal();
         }
     }

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -56,7 +56,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private GUIStyle m_nameTextFieldStyle;
         protected GUIStyle NameTextFieldStyle
         {
-            get {
+            get
+            {
                 if (m_nameTextFieldStyle == null)
                 {
                     m_nameTextFieldStyle = new GUIStyle(GUIStyle.none);
@@ -72,7 +73,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private GUIStyle m_fbxExtLabelStyle;
         protected GUIStyle FbxExtLabelStyle
         {
-            get {
+            get
+            {
                 if (m_fbxExtLabelStyle == null)
                 {
                     m_fbxExtLabelStyle = new GUIStyle(GUIStyle.none);
@@ -233,7 +235,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private bool m_exportSetContainsPrefabInstanceWithAddedObjects;
 
         private Object[] m_toExport;
-        protected Object[] ToExport { 
+        protected Object[] ToExport
+        {
             get
             {
                 return m_toExport;
@@ -245,39 +248,47 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
         }
 
-        protected virtual void OnEnable(){
+        protected virtual void OnEnable()
+        {
             #if UNITY_2018_1_OR_NEWER
-            InitializeReceiver ();
+            InitializeReceiver();
             #endif
             m_showOptions = true;
-            this.minSize = new Vector2 (SelectableLabelMinWidth + LabelWidth + BrowseButtonWidth + ExportButtonWidth, MinWindowHeight);
+            this.minSize = new Vector2(SelectableLabelMinWidth + LabelWidth + BrowseButtonWidth + ExportButtonWidth, MinWindowHeight);
         }
 
-        protected static T CreateWindow<T>() where T : EditorWindow {
-            return (T)EditorWindow.GetWindow <T>(DefaultWindowTitle, focus:true);
+        protected static T CreateWindow<T>() where T : EditorWindow
+        {
+            return (T)EditorWindow.GetWindow<T>(DefaultWindowTitle, focus: true);
         }
 
-        protected virtual void InitializeWindow(string filename = ""){
+        protected virtual void InitializeWindow(string filename = "")
+        {
             this.titleContent = WindowTitle;
-            this.SetFilename (filename);
+            this.SetFilename(filename);
         }
 
         #if UNITY_2018_1_OR_NEWER
-        protected void InitializeReceiver(){
-            if (!Receiver) {
-                Receiver = ScriptableObject.CreateInstance<FbxExportPresetSelectorReceiver> () as FbxExportPresetSelectorReceiver;
+        protected void InitializeReceiver()
+        {
+            if (!Receiver)
+            {
+                Receiver = ScriptableObject.CreateInstance<FbxExportPresetSelectorReceiver>() as FbxExportPresetSelectorReceiver;
                 Receiver.SelectionChanged -= OnPresetSelectionChanged;
                 Receiver.SelectionChanged += OnPresetSelectionChanged;
                 Receiver.DialogClosed -= SaveExportSettings;
                 Receiver.DialogClosed += SaveExportSettings;
             }
         }
+
         #endif
 
-        internal void SetFilename(string filename){
+        internal void SetFilename(string filename)
+        {
             // remove .fbx from end of filename
             int extIndex = filename.LastIndexOf(".fbx");
-            if (extIndex < 0) {
+            if (extIndex < 0)
+            {
                 ExportFileName = filename;
                 return;
             }
@@ -288,7 +299,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         public void OnPresetSelectionChanged()
         {
-            this.Repaint ();
+            this.Repaint();
         }
 
         protected bool SelectionContainsPrefabInstanceWithAddedObjects()
@@ -315,7 +326,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     continue;
                 }
 
-                if(PrefabUtility.IsAnyPrefabInstanceRoot(go) && PrefabUtility.GetAddedGameObjects(go).Count > 0)
+                if (PrefabUtility.IsAnyPrefabInstanceRoot(go) && PrefabUtility.GetAddedGameObjects(go).Count > 0)
                 {
                     return true;
                 }
@@ -328,45 +339,55 @@ namespace UnityEditor.Formats.Fbx.Exporter
             return false;
         }
 
-        protected abstract bool Export ();
+        protected abstract bool Export();
 
         /// <summary>
         /// Function to be used by derived classes to add custom UI between the file path selector and export options.
         /// </summary>
-        protected virtual void CreateCustomUI(){}
+        protected virtual void CreateCustomUI() {}
 
-        #if UNITY_2018_1_OR_NEWER  
-        protected abstract void ShowPresetReceiver ();
+        #if UNITY_2018_1_OR_NEWER
+        protected abstract void ShowPresetReceiver();
 
-        protected void ShowPresetReceiver(UnityEngine.Object target){
-            InitializeReceiver ();
+        protected void ShowPresetReceiver(UnityEngine.Object target)
+        {
+            InitializeReceiver();
             Receiver.SetTarget(target);
-            Receiver.SetInitialValue (new Preset (target));
+            Receiver.SetInitialValue(new Preset(target));
             UnityEditor.Presets.PresetSelector.ShowSelector(target, null, true, Receiver);
         }
+
         #endif
 
-        protected Transform TransferAnimationSource {
-            get {
+        protected Transform TransferAnimationSource
+        {
+            get
+            {
                 return SettingsObject.AnimationSource;
             }
-            set {
-                if (!TransferAnimationSourceIsValid (value)) {
+            set
+            {
+                if (!TransferAnimationSourceIsValid(value))
+                {
                     return;
                 }
-                SettingsObject.SetAnimationSource (value);
+                SettingsObject.SetAnimationSource(value);
             }
         }
 
-        protected Transform TransferAnimationDest {
-            get {
+        protected Transform TransferAnimationDest
+        {
+            get
+            {
                 return SettingsObject.AnimationDest;
             }
-            set {
-                if (!TransferAnimationDestIsValid (value)) {
+            set
+            {
+                if (!TransferAnimationDestIsValid(value))
+                {
                     return;
                 }
-                SettingsObject.SetAnimationDest (value);
+                SettingsObject.SetAnimationDest(value);
             }
         }
 
@@ -378,10 +399,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns><c>true</c> if p is ancestor to t; otherwise, <c>false</c>.</returns>
         /// <param name="p">P.</param>
         /// <param name="t">T.</param>
-        protected bool IsAncestor(Transform p, Transform t){
+        protected bool IsAncestor(Transform p, Transform t)
+        {
             var curr = t;
-            while (curr != null) {
-                if (curr == p) {
+            while (curr != null)
+            {
+                if (curr == p)
+                {
                     return true;
                 }
                 curr = curr.parent;
@@ -395,15 +419,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns><c>true</c> if t1 is in same hierarchy as t2; otherwise, <c>false</c>.</returns>
         /// <param name="t1">T1.</param>
         /// <param name="t2">T2.</param>
-        protected bool IsInSameHierarchy(Transform t1, Transform t2){
-            return (IsAncestor (t1, t2) || IsAncestor (t2, t1));
+        protected bool IsInSameHierarchy(Transform t1, Transform t2)
+        {
+            return (IsAncestor(t1, t2) || IsAncestor(t2, t1));
         }
-
 
         protected GameObject m_firstGameObjectToExport;
         protected virtual GameObject FirstGameObjectToExport
         {
-            get {
+            get
+            {
                 if (!m_firstGameObjectToExport)
                 {
                     if (ToExport == null || ToExport.Length == 0)
@@ -416,8 +441,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
         }
 
-        protected bool TransferAnimationSourceIsValid(Transform newValue){
-            if (!newValue) {
+        protected bool TransferAnimationSourceIsValid(Transform newValue)
+        {
+            if (!newValue)
+            {
                 return true;
             }
 
@@ -429,20 +456,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             // source must be ancestor to dest
-            if (TransferAnimationDest && !IsAncestor(newValue, TransferAnimationDest)) {
+            if (TransferAnimationDest && !IsAncestor(newValue, TransferAnimationDest))
+            {
                 Debug.LogWarningFormat("FbxExportSettings: Source {0} must be an ancestor of {1}", newValue.name, TransferAnimationDest.name);
                 return false;
             }
             // must be in same hierarchy as selected GO
-            if (!selectedGO || !IsInSameHierarchy(newValue, selectedGO.transform)) {
-                Debug.LogWarningFormat("FbxExportSettings: Source {0} must be in the same hierarchy as {1}", newValue.name, selectedGO? selectedGO.name : "the selected object");
+            if (!selectedGO || !IsInSameHierarchy(newValue, selectedGO.transform))
+            {
+                Debug.LogWarningFormat("FbxExportSettings: Source {0} must be in the same hierarchy as {1}", newValue.name, selectedGO ? selectedGO.name : "the selected object");
                 return false;
             }
             return true;
         }
 
-        protected bool TransferAnimationDestIsValid(Transform newValue){
-            if (!newValue) {
+        protected bool TransferAnimationDestIsValid(Transform newValue)
+        {
+            if (!newValue)
+            {
                 return true;
             }
 
@@ -454,13 +485,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             // source must be ancestor to dest
-            if (TransferAnimationSource && !IsAncestor(TransferAnimationSource, newValue)) {
+            if (TransferAnimationSource && !IsAncestor(TransferAnimationSource, newValue))
+            {
                 Debug.LogWarningFormat("FbxExportSettings: Destination {0} must be a descendant of {1}", newValue.name, TransferAnimationSource.name);
                 return false;
             }
             // must be in same hierarchy as selected GO
-            if (!selectedGO || !IsInSameHierarchy(newValue, selectedGO.transform)) {
-                Debug.LogWarningFormat("FbxExportSettings: Destination {0} must be in the same hierarchy as {1}", newValue.name, selectedGO? selectedGO.name : "the selected object");
+            if (!selectedGO || !IsInSameHierarchy(newValue, selectedGO.transform))
+            {
+                Debug.LogWarningFormat("FbxExportSettings: Destination {0} must be in the same hierarchy as {1}", newValue.name, selectedGO ? selectedGO.name : "the selected object");
                 return false;
             }
             return true;
@@ -480,17 +513,18 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         // -------------------------------------------------------------------------------------
 
-        protected void OnGUI ()
+        protected void OnGUI()
         {
             // Increasing the label width so that none of the text gets cut off
             EditorGUIUtility.labelWidth = LabelWidth;
 
-            GUILayout.BeginHorizontal ();
-            GUILayout.FlexibleSpace ();
-                
-            #if UNITY_2018_1_OR_NEWER  
-            if(EditorGUILayout.DropdownButton(presetIcon, FocusType.Keyboard, presetIconButton)){
-                ShowPresetReceiver ();
+            GUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+
+            #if UNITY_2018_1_OR_NEWER
+            if (EditorGUILayout.DropdownButton(presetIcon, FocusType.Keyboard, presetIconButton))
+            {
+                ShowPresetReceiver();
             }
             #endif
 
@@ -499,35 +533,35 @@ namespace UnityEditor.Formats.Fbx.Exporter
             EditorGUILayout.LabelField("Naming");
             EditorGUI.indentLevel++;
 
-            GUILayout.BeginHorizontal ();
+            GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent(
                 "Export Name",
-                "Filename to save model to."),GUILayout.Width(LabelWidth-TextFieldAlignOffset));
+                "Filename to save model to."), GUILayout.Width(LabelWidth - TextFieldAlignOffset));
 
-            EditorGUI.BeginDisabledGroup (DisableNameSelection);
+            EditorGUI.BeginDisabledGroup(DisableNameSelection);
             // Show the export name with an uneditable ".fbx" at the end
             //-------------------------------------
-            EditorGUILayout.BeginVertical ();
+            EditorGUILayout.BeginVertical();
             EditorGUILayout.BeginHorizontal(EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
             EditorGUI.indentLevel--;
             // continually resize to contents
-            var textFieldSize = NameTextFieldStyle.CalcSize (new GUIContent(ExportFileName));
-            ExportFileName = EditorGUILayout.TextField (ExportFileName, NameTextFieldStyle, GUILayout.Width(textFieldSize.x + 5), GUILayout.MinWidth(5));
-            ExportFileName = ModelExporter.ConvertToValidFilename (ExportFileName);
+            var textFieldSize = NameTextFieldStyle.CalcSize(new GUIContent(ExportFileName));
+            ExportFileName = EditorGUILayout.TextField(ExportFileName, NameTextFieldStyle, GUILayout.Width(textFieldSize.x + 5), GUILayout.MinWidth(5));
+            ExportFileName = ModelExporter.ConvertToValidFilename(ExportFileName);
 
-            EditorGUILayout.LabelField ("<color=#808080ff>.fbx</color>", FbxExtLabelStyle, GUILayout.Width(FbxExtLabelWidth));
+            EditorGUILayout.LabelField("<color=#808080ff>.fbx</color>", FbxExtLabelStyle, GUILayout.Width(FbxExtLabelWidth));
             EditorGUI.indentLevel++;
 
             EditorGUILayout.EndHorizontal();
-            EditorGUILayout.EndVertical ();
+            EditorGUILayout.EndVertical();
             //-----------------------------------
-            EditorGUI.EndDisabledGroup ();
-            GUILayout.EndHorizontal ();
+            EditorGUI.EndDisabledGroup();
+            GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent(
                 "Export Path",
-                "Location where the FBX will be saved."),GUILayout.Width(LabelWidth - FieldOffset));
+                "Location where the FBX will be saved."), GUILayout.Width(LabelWidth - FieldOffset));
 
             var pathLabels = ExportSettings.GetMixedSavePaths(FbxSavePaths);
 
@@ -536,7 +570,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 pathLabels = ExportSettings.GetRelativeFbxSavePaths(FbxSavePaths, ref m_selectedFbxPath);
             }
 
-            SelectedFbxPath = EditorGUILayout.Popup (SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
+            SelectedFbxPath = EditorGUILayout.Popup(SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
 
             if (!(this is ConvertToPrefabEditorWindow))
             {
@@ -586,27 +620,28 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             CreateCustomUI();
 
-            EditorGUILayout.Space ();
+            EditorGUILayout.Space();
 
-            EditorGUI.BeginDisabledGroup (DisableTransferAnim);
+            EditorGUI.BeginDisabledGroup(DisableTransferAnim);
             EditorGUI.indentLevel--;
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent(
                 "Transfer Animation",
                 "Transfer transform animation from source to destination. Animation on objects between source and destination will also be transferred to destination."
-            ), GUILayout.Width(LabelWidth - FieldOffset));
+                ), GUILayout.Width(LabelWidth - FieldOffset));
             GUILayout.EndHorizontal();
             EditorGUI.indentLevel++;
-            TransferAnimationSource = EditorGUILayout.ObjectField ("Source", TransferAnimationSource, typeof(Transform), allowSceneObjects: true) as Transform;
-            TransferAnimationDest = EditorGUILayout.ObjectField ("Destination", TransferAnimationDest, typeof(Transform), allowSceneObjects: true) as Transform;
-            EditorGUILayout.Space ();
-            EditorGUI.EndDisabledGroup ();
+            TransferAnimationSource = EditorGUILayout.ObjectField("Source", TransferAnimationSource, typeof(Transform), allowSceneObjects: true) as Transform;
+            TransferAnimationDest = EditorGUILayout.ObjectField("Destination", TransferAnimationDest, typeof(Transform), allowSceneObjects: true) as Transform;
+            EditorGUILayout.Space();
+            EditorGUI.EndDisabledGroup();
 
             EditorGUI.indentLevel--;
-            m_showOptions = EditorGUILayout.Foldout (m_showOptions, "Options");
+            m_showOptions = EditorGUILayout.Foldout(m_showOptions, "Options");
             EditorGUI.indentLevel++;
-            if (m_showOptions) {
-                InnerEditor.OnInspectorGUI ();
+            if (m_showOptions)
+            {
+                InnerEditor.OnInspectorGUI();
             }
 
             // if we are exporting or converting a prefab with overrides, then show a warning
@@ -616,21 +651,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 EditorGUILayout.HelpBox("Prefab instance overrides will be exported", MessageType.Warning, true);
             }
 
-            GUILayout.FlexibleSpace ();
+            GUILayout.FlexibleSpace();
 
-            GUILayout.BeginHorizontal ();
+            GUILayout.BeginHorizontal();
             DoNotShowDialogUI();
-            GUILayout.FlexibleSpace ();
-            if (GUILayout.Button ("Cancel", GUILayout.Width(ExportButtonWidth))) {
-                this.Close ();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Cancel", GUILayout.Width(ExportButtonWidth)))
+            {
+                this.Close();
             }
 
-            if (GUILayout.Button (ExportButtonName, GUILayout.Width(ExportButtonWidth))) {
-                if (Export ()) {
-                    this.Close ();
+            if (GUILayout.Button(ExportButtonName, GUILayout.Width(ExportButtonWidth)))
+            {
+                if (Export())
+                {
+                    this.Close();
                 }
             }
-            GUILayout.EndHorizontal ();
+            GUILayout.EndHorizontal();
             EditorGUILayout.Space(); // adding a space at bottom of dialog so buttons aren't right at the edge
 
             if (GUI.changed)
@@ -644,14 +682,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         /// <returns><c>true</c>, if file should be overwritten, <c>false</c> otherwise.</returns>
         /// <param name="filePath">File path.</param>
-        protected bool OverwriteExistingFile(string filePath){
+        protected bool OverwriteExistingFile(string filePath)
+        {
             // check if file already exists, give a warning if it does
-            if (System.IO.File.Exists (filePath)) {
-                bool overwrite = UnityEditor.EditorUtility.DisplayDialog (
-                    string.Format("{0} Warning", ModelExporter.PACKAGE_UI_NAME), 
-                    string.Format("File {0} already exists.\nOverwrite cannot be undone.", filePath), 
+            if (System.IO.File.Exists(filePath))
+            {
+                bool overwrite = UnityEditor.EditorUtility.DisplayDialog(
+                    string.Format("{0} Warning", ModelExporter.PACKAGE_UI_NAME),
+                    string.Format("File {0} already exists.\nOverwrite cannot be undone.", filePath),
                     "Overwrite", "Cancel");
-                if (!overwrite) {
+                if (!overwrite)
+                {
                     if (GUI.changed)
                     {
                         SaveExportSettings();
@@ -669,8 +710,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
         protected override string SessionStoragePrefix { get { return k_SessionStoragePrefix; } }
 
         protected override float MinWindowHeight { get { return 310; } } // determined by trial and error
-        protected override bool DisableNameSelection {
-            get {
+        protected override bool DisableNameSelection
+        {
+            get
+            {
                 return false;
             }
         }
@@ -694,8 +737,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
         }
 
-        protected override bool DisableTransferAnim {
-            get {
+        protected override bool DisableTransferAnim
+        {
+            get
+            {
                 // don't transfer animation if we are exporting more than one hierarchy, the timeline clips from
                 // a playable director, or if only the model is being exported
                 // if we are on the timeline then export length can be more than 1
@@ -707,17 +752,22 @@ namespace UnityEditor.Formats.Fbx.Exporter
         protected PlayableDirector PlayableDirector { get; set; }
 
         private bool m_isTimelineAnim = false;
-        protected bool IsTimelineAnim {
+        protected bool IsTimelineAnim
+        {
             get { return m_isTimelineAnim; }
-            set{
+            set
+            {
                 m_isTimelineAnim = value;
-                if (m_isTimelineAnim) {
+                if (m_isTimelineAnim)
+                {
                     m_previousInclude = ExportModelSettingsInstance.info.ModelAnimIncludeOption;
                     ExportModelSettingsInstance.info.SetModelAnimIncludeOption(ExportSettings.Include.Anim);
                 }
-                if (InnerEditor) {
+                if (InnerEditor)
+                {
                     var exportModelSettingsEditor = InnerEditor as ExportModelSettingsEditor;
-                    if (exportModelSettingsEditor) {
+                    if (exportModelSettingsEditor)
+                    {
                         exportModelSettingsEditor.DisableIncludeDropdown(m_isTimelineAnim);
                     }
                 }
@@ -725,15 +775,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         private bool m_singleHierarchyExport = true;
-        protected bool SingleHierarchyExport {
+        protected bool SingleHierarchyExport
+        {
             get { return m_singleHierarchyExport; }
-            set {
+            set
+            {
                 m_singleHierarchyExport = value;
 
-                if (InnerEditor) {
+                if (InnerEditor)
+                {
                     var exportModelSettingsEditor = InnerEditor as ExportModelSettingsEditor;
-                    if (exportModelSettingsEditor) {
-                        exportModelSettingsEditor.SetIsSingleHierarchy (m_singleHierarchyExport);
+                    if (exportModelSettingsEditor)
+                    {
+                        exportModelSettingsEditor.SetIsSingleHierarchy(m_singleHierarchyExport);
                     }
                 }
             }
@@ -758,7 +812,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             get
             {
-                if(m_exportModelSettingsInstance == null)
+                if (m_exportModelSettingsInstance == null)
                 {
                     // make a copy of the settings
                     m_exportModelSettingsInstance = ScriptableObject.CreateInstance(typeof(ExportModelSettings)) as ExportModelSettings;
@@ -802,27 +856,29 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private ExportSettings.Include m_previousInclude = ExportSettings.Include.ModelAndAnim;
 
-        public static ExportModelEditorWindow Init (IEnumerable<UnityEngine.Object> toExport, string filename = "", TimelineClip timelineClip = null, PlayableDirector director = null)
+        public static ExportModelEditorWindow Init(IEnumerable<UnityEngine.Object> toExport, string filename = "", TimelineClip timelineClip = null, PlayableDirector director = null)
         {
-            ExportModelEditorWindow window = CreateWindow<ExportModelEditorWindow> ();
+            ExportModelEditorWindow window = CreateWindow<ExportModelEditorWindow>();
             window.IsTimelineAnim = (timelineClip != null);
             window.TimelineClipToExport = timelineClip;
-            window.PlayableDirector = director? director : TimelineEditor.inspectedDirector;
+            window.PlayableDirector = director ? director : TimelineEditor.inspectedDirector;
 
 
-            int numObjects = window.SetGameObjectsToExport (toExport);
-            if (string.IsNullOrEmpty (filename)) {
+            int numObjects = window.SetGameObjectsToExport(toExport);
+            if (string.IsNullOrEmpty(filename))
+            {
                 filename = window.DefaultFilename;
             }
-            window.InitializeWindow (filename);
+            window.InitializeWindow(filename);
             window.SingleHierarchyExport = (numObjects == 1);
-            window.Show ();
+            window.Show();
             return window;
         }
 
-        protected int SetGameObjectsToExport(IEnumerable<UnityEngine.Object> toExport) {
+        protected int SetGameObjectsToExport(IEnumerable<UnityEngine.Object> toExport)
+        {
             ToExport = toExport?.ToArray();
-            if (!IsTimelineAnim && (ToExport == null || ToExport.Length==0)) return 0;
+            if (!IsTimelineAnim && (ToExport == null || ToExport.Length == 0)) return 0;
 
             TransferAnimationSource = null;
             TransferAnimationDest = null;
@@ -838,7 +894,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
 
-            return IsTimelineAnim? 1 : ToExport.Length;
+            return IsTimelineAnim ? 1 : ToExport.Length;
         }
 
         /// <summary>
@@ -846,7 +902,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         /// <returns>The object's name if one object selected, "Untitled" if multiple
         /// objects selected for export.</returns>
-        protected string DefaultFilename {
+        protected string DefaultFilename
+        {
             get
             {
                 string filename;
@@ -862,11 +919,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
         }
 
-        protected override void OnEnable ()
+        protected override void OnEnable()
         {
-            base.OnEnable ();
-            if (!InnerEditor) {
-                InnerEditor = UnityEditor.Editor.CreateEditor (ExportModelSettingsInstance);
+            base.OnEnable();
+            if (!InnerEditor)
+            {
+                InnerEditor = UnityEditor.Editor.CreateEditor(ExportModelSettingsInstance);
                 this.SingleHierarchyExport = m_singleHierarchyExport;
                 this.IsTimelineAnim = m_isTimelineAnim;
             }
@@ -874,7 +932,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         protected void OnDisable()
         {
-            RestoreSettings ();
+            RestoreSettings();
         }
 
         /// <summary>
@@ -882,22 +940,25 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         protected virtual void RestoreSettings()
         {
-            if (IsTimelineAnim) {
+            if (IsTimelineAnim)
+            {
                 ExportModelSettingsInstance.info.SetModelAnimIncludeOption(m_previousInclude);
             }
         }
 
-
         [SecurityPermission(SecurityAction.LinkDemand)]
-        protected override bool Export(){
-            if (string.IsNullOrEmpty (ExportFileName)) {
-                Debug.LogError ("FbxExporter: Please specify an fbx filename");
+        protected override bool Export()
+        {
+            if (string.IsNullOrEmpty(ExportFileName))
+            {
+                Debug.LogError("FbxExporter: Please specify an fbx filename");
                 return false;
             }
             var folderPath = ExportSettings.GetAbsoluteSavePath(FbxSavePaths[SelectedFbxPath]);
-            var filePath = System.IO.Path.Combine (folderPath, ExportFileName + ".fbx");
+            var filePath = System.IO.Path.Combine(folderPath, ExportFileName + ".fbx");
 
-            if (!OverwriteExistingFile (filePath)) {
+            if (!OverwriteExistingFile(filePath))
+            {
                 return false;
             }
 
@@ -920,11 +981,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
             return true;
         }
 
-        #if UNITY_2018_1_OR_NEWER  
-        protected override void ShowPresetReceiver ()
+        #if UNITY_2018_1_OR_NEWER
+        protected override void ShowPresetReceiver()
         {
-            ShowPresetReceiver (ExportModelSettingsInstance);
+            ShowPresetReceiver(ExportModelSettingsInstance);
         }
+
         #endif
     }
 }

--- a/com.unity.formats.fbx/Editor/ExportModelSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelSettings.cs
@@ -1,8 +1,8 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
-    [CustomEditor (typeof(ExportModelSettings))]
+    [CustomEditor(typeof(ExportModelSettings))]
     internal class ExportModelSettingsEditor : UnityEditor.Editor
     {
         private const float DefaultLabelWidth = 175;
@@ -11,14 +11,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public float LabelWidth { get; set; } = DefaultLabelWidth;
         public float FieldOffset { get; set; } = DefaultFieldOffset;
 
-        private string[] exportFormatOptions = new string[]{ "ASCII", "Binary" };
-        private string[] includeOptions = new string[]{"Model(s) Only", "Animation Only", "Model(s) + Animation"};
-        private string[] lodOptions = new string[]{"All Levels", "Highest", "Lowest"};
+        private string[] exportFormatOptions = new string[] { "ASCII", "Binary" };
+        private string[] includeOptions = new string[] {"Model(s) Only", "Animation Only", "Model(s) + Animation"};
+        private string[] lodOptions = new string[] {"All Levels", "Highest", "Lowest"};
 
         public const string singleHierarchyOption = "Local Pivot";
         public const string multiHerarchyOption = "Local Centered";
         private string hierarchyDepOption = singleHierarchyOption;
-        private string[] objPositionOptions { get { return new string[]{hierarchyDepOption, "World Absolute"}; }}
+        private string[] objPositionOptions { get { return new string[] {hierarchyDepOption, "World Absolute"}; }}
 
         private bool disableIncludeDropdown = false;
 
@@ -28,19 +28,22 @@ namespace UnityEditor.Formats.Fbx.Exporter
             m_exportingOutsideProject = val;
         }
 
-        public void SetIsSingleHierarchy(bool singleHierarchy){
-            if (singleHierarchy) {
+        public void SetIsSingleHierarchy(bool singleHierarchy)
+        {
+            if (singleHierarchy)
+            {
                 hierarchyDepOption = singleHierarchyOption;
                 return;
             }
             hierarchyDepOption = multiHerarchyOption;
         }
 
-        public void DisableIncludeDropdown(bool disable){
+        public void DisableIncludeDropdown(bool disable)
+        {
             disableIncludeDropdown = disable;
         }
 
-        public override void OnInspectorGUI ()
+        public override void OnInspectorGUI()
         {
             var exportSettings = ((ExportModelSettings)target).info;
 
@@ -49,14 +52,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Export Format", "Export the FBX file in the standard binary format." +
                 " Select ASCII to export the FBX file in ASCII format."), GUILayout.Width(LabelWidth - FieldOffset));
-            exportSettings.SetExportFormat((ExportSettings.ExportFormat)EditorGUILayout.Popup((int)exportSettings.ExportFormat, exportFormatOptions) );
+            exportSettings.SetExportFormat((ExportSettings.ExportFormat)EditorGUILayout.Popup((int)exportSettings.ExportFormat, exportFormatOptions));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Include", "Select whether to export models, animation or both."), GUILayout.Width(LabelWidth - FieldOffset));
             EditorGUI.BeginDisabledGroup(disableIncludeDropdown);
             exportSettings.SetModelAnimIncludeOption((ExportSettings.Include)EditorGUILayout.Popup((int)exportSettings.ModelAnimIncludeOption, includeOptions));
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -64,7 +67,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // greyed out if animation only
             EditorGUI.BeginDisabledGroup(exportSettings.ModelAnimIncludeOption == ExportSettings.Include.Anim);
             exportSettings.SetLODExportType((ExportSettings.LODExportType)EditorGUILayout.Popup((int)exportSettings.LODExportType, lodOptions));
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -72,7 +75,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // greyed out if animation only
             EditorGUI.BeginDisabledGroup(exportSettings.ModelAnimIncludeOption == ExportSettings.Include.Anim);
             exportSettings.SetObjectPosition((ExportSettings.ObjectPosition)EditorGUILayout.Popup((int)exportSettings.ObjectPosition, objPositionOptions));
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -81,19 +84,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // greyed out if model
             EditorGUI.BeginDisabledGroup(exportSettings.ModelAnimIncludeOption == ExportSettings.Include.Model);
             exportSettings.SetAnimatedSkinnedMesh(EditorGUILayout.Toggle(exportSettings.AnimateSkinnedMesh));
-            EditorGUI.EndDisabledGroup ();
-            GUILayout.EndHorizontal ();
+            EditorGUI.EndDisabledGroup();
+            GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Compatible Naming",
-                    "In Maya some symbols such as spaces and accents get replaced when importing an FBX " +
-                    "(e.g. \"foo bar\" becomes \"fooFBXASC032bar\"). " +
-                    "On export, convert the names of GameObjects so they are Maya compatible." +
-                    (exportSettings.UseMayaCompatibleNames ? "" :
-                        "\n\nWARNING: Disabling this feature may result in lost material connections," +
-                        " and unexpected character replacements in Maya.")),
-                    GUILayout.Width(LabelWidth - FieldOffset));
-            exportSettings.SetUseMayaCompatibleNames(EditorGUILayout.Toggle (exportSettings.UseMayaCompatibleNames));
+                "In Maya some symbols such as spaces and accents get replaced when importing an FBX " +
+                "(e.g. \"foo bar\" becomes \"fooFBXASC032bar\"). " +
+                "On export, convert the names of GameObjects so they are Maya compatible." +
+                (exportSettings.UseMayaCompatibleNames ? "" :
+                    "\n\nWARNING: Disabling this feature may result in lost material connections," +
+                    " and unexpected character replacements in Maya.")),
+                GUILayout.Width(LabelWidth - FieldOffset));
+            exportSettings.SetUseMayaCompatibleNames(EditorGUILayout.Toggle(exportSettings.UseMayaCompatibleNames));
             GUILayout.EndHorizontal();
 
             GUILayout.BeginHorizontal();
@@ -102,9 +105,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // greyed out if animation only
             EditorGUI.BeginDisabledGroup(exportSettings.ModelAnimIncludeOption == ExportSettings.Include.Anim);
             exportSettings.SetExportUnredererd(EditorGUILayout.Toggle(exportSettings.ExportUnrendered));
-            EditorGUI.EndDisabledGroup ();
-            GUILayout.EndHorizontal ();
-            
+            EditorGUI.EndDisabledGroup();
+            GUILayout.EndHorizontal();
+
             GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(new GUIContent("Preserve Import Settings",
                 "If checked, the import settings from the overwritten FBX will be carried over to the new version."), GUILayout.Width(LabelWidth - FieldOffset));
@@ -129,7 +132,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
     }
 
-    internal interface IExportOptions {
+    internal interface IExportOptions
+    {
         ExportSettings.ExportFormat ExportFormat { get; }
         ExportSettings.Include ModelAnimIncludeOption { get; }
         ExportSettings.LODExportType LODExportType { get; }
@@ -158,7 +162,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         public override bool Equals(object e)
         {
             var expOptions = e as ExportOptionsSettingsBase<T>;
-            if(expOptions == null)
+            if (expOptions == null)
             {
                 return false;
             }
@@ -190,11 +194,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private Transform animDest;
 
         public ExportSettings.ExportFormat ExportFormat { get { return exportFormat; } }
-        public void SetExportFormat(ExportSettings.ExportFormat format){ this.exportFormat = format; }
+        public void SetExportFormat(ExportSettings.ExportFormat format) { this.exportFormat = format; }
         public bool AnimateSkinnedMesh { get { return animatedSkinnedMesh; } }
-        public void SetAnimatedSkinnedMesh(bool animatedSkinnedMesh){ this.animatedSkinnedMesh = animatedSkinnedMesh; }
+        public void SetAnimatedSkinnedMesh(bool animatedSkinnedMesh) { this.animatedSkinnedMesh = animatedSkinnedMesh; }
         public bool UseMayaCompatibleNames { get { return mayaCompatibleNaming; } }
-        public void SetUseMayaCompatibleNames(bool useMayaCompNames){ this.mayaCompatibleNaming = useMayaCompNames; }
+        public void SetUseMayaCompatibleNames(bool useMayaCompNames) { this.mayaCompatibleNaming = useMayaCompNames; }
         public Transform AnimationSource { get { return animSource; } }
         public void SetAnimationSource(Transform source) { this.animSource = source; }
         public Transform AnimationDest { get { return animDest; } }
@@ -243,22 +247,22 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private bool keepInstances = true;
         [SerializeField]
         private bool embedTextures = false;
-        
+
         public override ExportSettings.Include ModelAnimIncludeOption { get { return include; } }
         public void SetModelAnimIncludeOption(ExportSettings.Include include) { this.include = include; }
         public override ExportSettings.LODExportType LODExportType { get { return lodLevel; } }
-        public void SetLODExportType(ExportSettings.LODExportType lodLevel){ this.lodLevel = lodLevel; }
+        public void SetLODExportType(ExportSettings.LODExportType lodLevel) { this.lodLevel = lodLevel; }
         public override ExportSettings.ObjectPosition ObjectPosition { get { return objectPosition; } }
-        public void SetObjectPosition(ExportSettings.ObjectPosition objPos){ this.objectPosition = objPos; }
+        public void SetObjectPosition(ExportSettings.ObjectPosition objPos) { this.objectPosition = objPos; }
         public override bool ExportUnrendered { get { return exportUnrendered; } }
-        public void SetExportUnredererd(bool exportUnrendered){ this.exportUnrendered = exportUnrendered; }
+        public void SetExportUnredererd(bool exportUnrendered) { this.exportUnrendered = exportUnrendered; }
         public override bool PreserveImportSettings { get { return preserveImportSettings; } }
-        public void SetPreserveImportSettings(bool preserveImportSettings){ this.preserveImportSettings = preserveImportSettings; }
+        public void SetPreserveImportSettings(bool preserveImportSettings) { this.preserveImportSettings = preserveImportSettings; }
         public override bool AllowSceneModification { get { return false; } }
         public override bool KeepInstances { get { return keepInstances; } }
-        public void SetKeepInstances(bool keepInstances){ this.keepInstances = keepInstances; }
+        public void SetKeepInstances(bool keepInstances) { this.keepInstances = keepInstances; }
         public override bool EmbedTextures { get { return embedTextures; } }
-        public void SetEmbedTextures(bool embedTextures){ this.embedTextures = embedTextures; }
+        public void SetEmbedTextures(bool embedTextures) { this.embedTextures = embedTextures; }
 
         public override bool Equals(object e)
         {
@@ -267,7 +271,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 return false;
             }
-            return base.Equals(e) && 
+            return base.Equals(e) &&
                 include == expOptions.include &&
                 lodLevel == expOptions.lodLevel &&
                 objectPosition == expOptions.objectPosition &&

--- a/com.unity.formats.fbx/Editor/ExportSettings.cs
+++ b/com.unity.formats.fbx/Editor/ExportSettings.cs
@@ -9,24 +9,26 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 using UnityEditor.Presets;
 
-namespace UnityEditor.Formats.Fbx.Exporter {
+namespace UnityEditor.Formats.Fbx.Exporter
+{
     [System.Serializable]
     internal class FbxExportSettingsException : System.Exception
     {
-        public FbxExportSettingsException() { }
+        public FbxExportSettingsException() {}
 
         public FbxExportSettingsException(string message)
-            : base(message) { }
+            : base(message) {}
 
         public FbxExportSettingsException(string message, System.Exception inner)
-            : base(message, inner) { }
+            : base(message, inner) {}
 
         protected FbxExportSettingsException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+            : base(info, context) {}
     }
 
     [CustomEditor(typeof(ExportSettings))]
-    internal class ExportSettingsEditor : UnityEditor.Editor {
+    internal class ExportSettingsEditor : UnityEditor.Editor
+    {
         Vector2 scrollPos = Vector2.zero;
         const float LabelWidth = 180;
         const float SelectableLabelMinWidth = 90;
@@ -114,10 +116,12 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             {
                 ExportSettings.instance.SelectedPrefabPath = EditorGUILayout.Popup(ExportSettings.instance.SelectedPrefabPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
             }
-            else {
+            else
+            {
                 ExportSettings.instance.SelectedFbxPath = EditorGUILayout.Popup(ExportSettings.instance.SelectedFbxPath, pathLabels, GUILayout.MinWidth(SelectableLabelMinWidth));
             }
-            if(EditorGUI.EndChangeCheck() && isSingletonInstance){
+            if (EditorGUI.EndChangeCheck() && isSingletonInstance)
+            {
                 if (isConvertToPrefabOptions)
                 {
                     ClearExportWindowSettings<ConvertToPrefabEditorWindow>(ConvertToPrefabEditorWindow.k_SessionStoragePrefix);
@@ -146,7 +150,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 string fullPath = EditorUtility.SaveFolderPanel(
                     openFolderPanelTitle, initialPath, null
                 );
-                
+
                 // Unless the user canceled, save path.
                 if (!string.IsNullOrEmpty(fullPath))
                 {
@@ -190,19 +194,21 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         }
 
         [SecurityPermission(SecurityAction.LinkDemand)]
-        public override void OnInspectorGUI() {
+        public override void OnInspectorGUI()
+        {
             ExportSettings exportSettings = (ExportSettings)target;
             bool isSingletonInstance = this.targets.Length == 1 && this.target == ExportSettings.instance;
 
             // Increasing the label width so that none of the text gets cut off
             EditorGUIUtility.labelWidth = LabelWidth;
 
-            scrollPos = GUILayout.BeginScrollView (scrollPos);
+            scrollPos = GUILayout.BeginScrollView(scrollPos);
 
-            var version = UnityEditor.Formats.Fbx.Exporter.ModelExporter.GetVersionFromReadme ();
-            if (!string.IsNullOrEmpty(version)) {
-                GUILayout.Label ("Version: " + version, EditorStyles.centeredGreyMiniLabel);
-                EditorGUILayout.Space ();
+            var version = UnityEditor.Formats.Fbx.Exporter.ModelExporter.GetVersionFromReadme();
+            if (!string.IsNullOrEmpty(version))
+            {
+                GUILayout.Label("Version: " + version, EditorStyles.centeredGreyMiniLabel);
+                EditorGUILayout.Space();
             }
 
             GUILayout.BeginVertical();
@@ -260,49 +266,56 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             EditorGUILayout.LabelField("Integration", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
 
-            GUILayout.BeginHorizontal ();
+            GUILayout.BeginHorizontal();
             EditorGUILayout.LabelField(Style.Application3D, GUILayout.Width(LabelWidth));
-            
+
             // dropdown to select Maya version to use
             var options = ExportSettings.GetDCCOptions();
 
             exportSettings.SelectedDCCApp = EditorGUILayout.Popup(exportSettings.SelectedDCCApp, options);
 
             EditorGUI.BeginDisabledGroup(!isSingletonInstance);
-            if (GUILayout.Button(new GUIContent("...", "Browse to a 3D application in a non-default location"), EditorStyles.miniButton, GUILayout.Width(BrowseButtonWidth))) {
+            if (GUILayout.Button(new GUIContent("...", "Browse to a 3D application in a non-default location"), EditorStyles.miniButton, GUILayout.Width(BrowseButtonWidth)))
+            {
                 var ext = "";
-                switch (Application.platform) {
-                case RuntimePlatform.WindowsEditor:
-                    ext = "exe";
-                    break;
-                case RuntimePlatform.OSXEditor:
-                    ext = "app";
-                    break;
-                default:
-                    throw new System.NotImplementedException ();
+                switch (Application.platform)
+                {
+                    case RuntimePlatform.WindowsEditor:
+                        ext = "exe";
+                        break;
+                    case RuntimePlatform.OSXEditor:
+                        ext = "app";
+                        break;
+                    default:
+                        throw new System.NotImplementedException();
                 }
 
-                string dccPath = EditorUtility.OpenFilePanel ("Select Digital Content Creation Application", ExportSettings.FirstValidVendorLocation, ext);
+                string dccPath = EditorUtility.OpenFilePanel("Select Digital Content Creation Application", ExportSettings.FirstValidVendorLocation, ext);
 
                 // check that the path is valid and references the maya executable
-                if (!string.IsNullOrEmpty (dccPath)) {
+                if (!string.IsNullOrEmpty(dccPath))
+                {
                     ExportSettings.DCCType foundDCC = ExportSettings.DCCType.Maya;
-                    var foundDCCPath = TryFindDCC (dccPath, ext, ExportSettings.DCCType.Maya);
-                    if (foundDCCPath == null && Application.platform == RuntimePlatform.WindowsEditor) {
-                        foundDCCPath = TryFindDCC (dccPath, ext, ExportSettings.DCCType.Max);
+                    var foundDCCPath = TryFindDCC(dccPath, ext, ExportSettings.DCCType.Maya);
+                    if (foundDCCPath == null && Application.platform == RuntimePlatform.WindowsEditor)
+                    {
+                        foundDCCPath = TryFindDCC(dccPath, ext, ExportSettings.DCCType.Max);
                         foundDCC = ExportSettings.DCCType.Max;
                     }
-                    if (foundDCCPath == null) {
-                        Debug.LogError (string.Format ("Could not find supported 3D application at: \"{0}\"", Path.GetDirectoryName (dccPath)));
-                    } else {
-                        dccPath = foundDCCPath;
-                        ExportSettings.AddDCCOption (dccPath, foundDCC);
+                    if (foundDCCPath == null)
+                    {
+                        Debug.LogError(string.Format("Could not find supported 3D application at: \"{0}\"", Path.GetDirectoryName(dccPath)));
                     }
-                    Repaint ();
+                    else
+                    {
+                        dccPath = foundDCCPath;
+                        ExportSettings.AddDCCOption(dccPath, foundDCC);
+                    }
+                    Repaint();
                 }
             }
             EditorGUI.EndDisabledGroup();
-            GUILayout.EndHorizontal ();
+            GUILayout.EndHorizontal();
 
             EditorGUILayout.Space();
 
@@ -323,37 +336,43 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             EditorGUILayout.Space();
 
             // disable button if no 3D application is available
-            EditorGUI.BeginDisabledGroup (!isSingletonInstance || !ExportSettings.CanInstall());
-            if (GUILayout.Button (Style.InstallIntegrationContent)) {
+            EditorGUI.BeginDisabledGroup(!isSingletonInstance || !ExportSettings.CanInstall());
+            if (GUILayout.Button(Style.InstallIntegrationContent))
+            {
                 EditorApplication.delayCall += UnityEditor.Formats.Fbx.Exporter.IntegrationsUI.InstallDCCIntegration;
             }
-            EditorGUI.EndDisabledGroup ();
+            EditorGUI.EndDisabledGroup();
 
-            EditorGUILayout.Space ();
+            EditorGUILayout.Space();
 
             EditorGUI.indentLevel--;
-            EditorGUILayout.LabelField ("FBX Prefab Component Updater", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("FBX Prefab Component Updater", EditorStyles.boldLabel);
             EditorGUI.indentLevel++;
 
-            EditorGUILayout.Space ();
+            EditorGUILayout.Space();
 
             EditorGUI.BeginDisabledGroup(!isSingletonInstance);
-            if (GUILayout.Button (Style.RepairMissingScripts)) {
-                var componentUpdater = new UnityEditor.Formats.Fbx.Exporter.RepairMissingScripts ();
+            if (GUILayout.Button(Style.RepairMissingScripts))
+            {
+                var componentUpdater = new UnityEditor.Formats.Fbx.Exporter.RepairMissingScripts();
                 var filesToRepairCount = componentUpdater.AssetsToRepairCount;
                 var dialogTitle = "FBX Prefab Component Updater";
-                if (filesToRepairCount > 0) {
-                    bool result = UnityEditor.EditorUtility.DisplayDialog (dialogTitle,
+                if (filesToRepairCount > 0)
+                {
+                    bool result = UnityEditor.EditorUtility.DisplayDialog(dialogTitle,
                         string.Format("Found {0} prefab(s) and/or scene(s) with components requiring update.\n\n" +
-                        "If you choose 'Go Ahead', the FbxPrefab components in these assets " +
-                        "will be automatically updated to work with the latest FBX exporter.\n" +
+                            "If you choose 'Go Ahead', the FbxPrefab components in these assets " +
+                            "will be automatically updated to work with the latest FBX exporter.\n" +
                             "You should make a backup before proceeding.", filesToRepairCount),
                         "I Made a Backup. Go Ahead!", "No Thanks");
-                    if (result) {
-                        componentUpdater.ReplaceGUIDInTextAssets ();
-                    } else {
-                        var assetsToRepair = componentUpdater.GetAssetsToRepair ();
-                        Debug.LogFormat ("Failed to update the FbxPrefab components in the following files:\n{0}", string.Join ("\n", assetsToRepair));
+                    if (result)
+                    {
+                        componentUpdater.ReplaceGUIDInTextAssets();
+                    }
+                    else
+                    {
+                        var assetsToRepair = componentUpdater.GetAssetsToRepair();
+                        Debug.LogFormat("Failed to update the FbxPrefab components in the following files:\n{0}", string.Join("\n", assetsToRepair));
                     }
                 }
                 else
@@ -365,11 +384,12 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             EditorGUI.EndDisabledGroup();
             EditorGUI.indentLevel--;
 
-            GUILayout.FlexibleSpace ();
+            GUILayout.FlexibleSpace();
             GUILayout.EndVertical();
-            GUILayout.EndScrollView ();
+            GUILayout.EndScrollView();
 
-            if (GUI.changed) {
+            if (GUI.changed)
+            {
                 // Only save the settings if we are in the Singleton instance.
                 // Otherwise, the user is editing a preset and we don't need to save.
                 if (isSingletonInstance)
@@ -379,20 +399,23 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             }
         }
 
-        private static string TryFindDCC(string dccPath, string ext, ExportSettings.DCCType dccType){
+        private static string TryFindDCC(string dccPath, string ext, ExportSettings.DCCType dccType)
+        {
             string dccName = "";
-            switch (dccType) {
-            case ExportSettings.DCCType.Maya:
-                dccName = "maya";
-                break;
-            case ExportSettings.DCCType.Max:
-                dccName = "3dsmax";
-                break;
-            default:
-                throw new System.NotImplementedException ();
+            switch (dccType)
+            {
+                case ExportSettings.DCCType.Maya:
+                    dccName = "maya";
+                    break;
+                case ExportSettings.DCCType.Max:
+                    dccName = "3dsmax";
+                    break;
+                default:
+                    throw new System.NotImplementedException();
             }
 
-            if (Path.GetFileNameWithoutExtension (dccPath).ToLower ().Equals (dccName)) {
+            if (Path.GetFileNameWithoutExtension(dccPath).ToLower().Equals(dccName))
+            {
                 return dccPath;
             }
 
@@ -400,22 +423,25 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // a dcc in this directory.
             var dccDir = new DirectoryInfo(Path.GetDirectoryName(dccPath));
             FileSystemInfo[] files = {};
-            switch(Application.platform){
-            case RuntimePlatform.OSXEditor:
-                files = dccDir.GetDirectories ("*." + ext);
-                break;
-            case RuntimePlatform.WindowsEditor:
-                files = dccDir.GetFiles ("*." + ext);
-                break;
-            default:
-                throw new System.NotImplementedException();
+            switch (Application.platform)
+            {
+                case RuntimePlatform.OSXEditor:
+                    files = dccDir.GetDirectories("*." + ext);
+                    break;
+                case RuntimePlatform.WindowsEditor:
+                    files = dccDir.GetFiles("*." + ext);
+                    break;
+                default:
+                    throw new System.NotImplementedException();
             }
 
             string newDccPath = null;
-            foreach (var file in files) {
-                var filename = Path.GetFileNameWithoutExtension (file.Name).ToLower ();
-                if (filename.Equals (dccName)) {
-                    newDccPath = file.FullName.Replace("\\","/");
+            foreach (var file in files)
+            {
+                var filename = Path.GetFileNameWithoutExtension(file.Name).ToLower();
+                if (filename.Equals(dccName))
+                {
+                    newDccPath = file.FullName.Replace("\\", "/");
                     break;
                 }
             }
@@ -466,14 +492,14 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         }
     }
 
-    [FilePath("ProjectSettings/FbxExportSettings.asset",FilePathAttribute.Location.ProjectFolder)]
+    [FilePath("ProjectSettings/FbxExportSettings.asset", FilePathAttribute.Location.ProjectFolder)]
     internal class ExportSettings : ScriptableObject
     {
-        public enum ExportFormat { ASCII = 0, Binary = 1}
+        public enum ExportFormat { ASCII = 0, Binary = 1 }
 
         public enum Include { Model = 0, Anim = 1, ModelAndAnim = 2 }
 
-        public enum ObjectPosition { LocalCentered = 0, WorldAbsolute = 1, Reset = 2 /* For convert to model only, no UI option*/}
+        public enum ObjectPosition { LocalCentered = 0, WorldAbsolute = 1, Reset = 2 /* For convert to model only, no UI option*/ }
 
         public enum LODExportType { All = 0, Highest = 1, Lowest = 2 }
 
@@ -553,8 +579,10 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             set { Verbose = value; }
         }
 
-        private static string DefaultIntegrationSavePath {
-            get{
+        private static string DefaultIntegrationSavePath
+        {
+            get
+            {
                 return Path.GetDirectoryName(Application.dataPath);
             }
         }
@@ -581,13 +609,13 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
-                //If we are on Windows, we need only go up one location to get to the "Autodesk" folder.                        
+                //If we are on Windows, we need only go up one location to get to the "Autodesk" folder.
                 result = Directory.GetParent(location).ToString();
             }
             else if (Application.platform == RuntimePlatform.OSXEditor)
             {
                 //We can assume our path is: /Applications/Autodesk/maya2017/Maya.app/Contents
-                //So we need to go up three folders.                
+                //So we need to go up three folders.
 
                 var appFolder = Directory.GetParent(location);
                 if (appFolder != null)
@@ -646,7 +674,6 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                     }
                 }
                 return existingDirectories;
-
             }
             else if (Application.platform == RuntimePlatform.OSXEditor)
             {
@@ -716,7 +743,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             get { return BakeAnimation; }
             set { BakeAnimation = value; }
         }
-        
+
         [SerializeField]
         private bool showConvertToPrefabDialog = true;
         public bool DisplayOptionsWindow
@@ -765,14 +792,14 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// value, properly interpreted for the current platform.
         /// </summary>
         [SerializeField]
-        private List<string> prefabSavePaths = new List<string> ();
+        private List<string> prefabSavePaths = new List<string>();
         internal List<string> GetCopyOfPrefabSavePaths()
         {
             return new List<string>(prefabSavePaths);
         }
 
         [SerializeField]
-        private List<string> fbxSavePaths = new List<string> ();
+        private List<string> fbxSavePaths = new List<string>();
         internal List<String> GetCopyOfFbxSavePaths()
         {
             return new List<string>(fbxSavePaths);
@@ -830,7 +857,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         // store contents of export model settings for serialization
         [SerializeField]
         private ExportModelSettingsSerialize exportModelSettingsSerialize;
-        
+
         [System.NonSerialized]
         private ConvertToPrefabSettings m_convertToPrefabSettings;
         internal ConvertToPrefabSettings ConvertToPrefabSettings
@@ -862,7 +889,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             LaunchAfterInstallation = true;
             HideSendToUnityMenuProperty = true;
             prefabSavePaths = new List<string>(){ kDefaultSavePath };
-            fbxSavePaths = new List<string> (){ kDefaultSavePath };
+            fbxSavePaths = new List<string>(){ kDefaultSavePath };
             integrationSavePath = DefaultIntegrationSavePath;
             dccOptionPaths = new List<string>();
             dccOptionNames = new List<string>();
@@ -879,34 +906,40 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         /// <returns>The unique name.</returns>
         /// <param name="name">Name.</param>
-        internal static string GetUniqueDCCOptionName(string name){
+        internal static string GetUniqueDCCOptionName(string name)
+        {
             Debug.Assert(instance != null);
             if (name == null)
             {
                 return null;
             }
-            if (!instance.dccOptionNames.Contains(name)) {
+            if (!instance.dccOptionNames.Contains(name))
+            {
                 return name;
             }
             var format = "{1} ({0})";
             int index = 1;
             // try extracting the current index from the name and incrementing it
             var result = System.Text.RegularExpressions.Regex.Match(name, @"\((?<number>\d+?)\)$");
-            if (result != null) {
+            if (result != null)
+            {
                 var number = result.Groups["number"].Value;
                 int tempIndex;
-                if (int.TryParse (number, out tempIndex)) {
-                    var indexOfNumber = name.LastIndexOf (number);
-                    format = name.Remove (indexOfNumber, number.Length).Insert (indexOfNumber, "{0}");
-                    index = tempIndex+1;
+                if (int.TryParse(number, out tempIndex))
+                {
+                    var indexOfNumber = name.LastIndexOf(number);
+                    format = name.Remove(indexOfNumber, number.Length).Insert(indexOfNumber, "{0}");
+                    index = tempIndex + 1;
                 }
             }
 
             string uniqueName = null;
-            do {
-                uniqueName = string.Format (format, index, name);
+            do
+            {
+                uniqueName = string.Format(format, index, name);
                 index++;
-            } while (instance.dccOptionNames.Contains(uniqueName));
+            }
+            while (instance.dccOptionNames.Contains(uniqueName));
 
             return uniqueName;
         }
@@ -1030,9 +1063,9 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 return -1;
             }
             AppName = AppName.Trim();
-            if (string.IsNullOrEmpty(AppName)) 
+            if (string.IsNullOrEmpty(AppName))
                 return -1;
-                
+
             string[] piecesArray = AppName.Split(' ');
             if (piecesArray.Length < 2)
             {
@@ -1070,11 +1103,12 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// <summary>
         /// Find Maya and 3DsMax installations at default install path.
         /// Add results to given dictionary.
-        /// 
+        ///
         /// If MAYA_LOCATION is set, add this to the list as well.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private static void FindDCCInstalls() {
+        private static void FindDCCInstalls()
+        {
             var dccOptionNames = instance.dccOptionNames;
             var dccOptionPaths = instance.dccOptionPaths;
 
@@ -1094,10 +1128,11 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                     var product = productDir.Name;
 
                     // Only accept those that start with 'maya' in either case.
-                    if (product.StartsWith ("maya", StringComparison.InvariantCultureIgnoreCase)) {
-                        string version = product.Substring ("maya".Length);
-                        dccOptionPaths.Add (GetMayaExePathFromLocation (productDir.FullName.Replace ("\\", "/")));
-                        dccOptionNames.Add (GetUniqueDCCOptionName(kMayaOptionName + version));
+                    if (product.StartsWith("maya", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        string version = product.Substring("maya".Length);
+                        dccOptionPaths.Add(GetMayaExePathFromLocation(productDir.FullName.Replace("\\", "/")));
+                        dccOptionNames.Add(GetUniqueDCCOptionName(kMayaOptionName + version));
                         continue;
                     }
 
@@ -1161,35 +1196,42 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// <param name="location">Location of Maya install.</param>
         private static string GetMayaExePathFromLocation(string location)
         {
-            switch (Application.platform) {
-            case RuntimePlatform.WindowsEditor:
-                return location + "/bin/maya.exe";
-            case RuntimePlatform.OSXEditor:
-                // MAYA_LOCATION on mac is set by Autodesk to be the
-                // Contents directory. But let's make it easier on people
-                // and allow just having it be the app bundle or a
-                // directory that holds the app bundle.
-                if (location.EndsWith(".app/Contents")) {
-                    return location + "/MacOS/Maya";
-                } else if (location.EndsWith(".app")) {
-                    return location + "/Contents/MacOS/Maya";
-                } else {
-                    return location + "/Maya.app/Contents/MacOS/Maya";
-                }
-            default:
-                throw new NotImplementedException ();
+            switch (Application.platform)
+            {
+                case RuntimePlatform.WindowsEditor:
+                    return location + "/bin/maya.exe";
+                case RuntimePlatform.OSXEditor:
+                    // MAYA_LOCATION on mac is set by Autodesk to be the
+                    // Contents directory. But let's make it easier on people
+                    // and allow just having it be the app bundle or a
+                    // directory that holds the app bundle.
+                    if (location.EndsWith(".app/Contents"))
+                    {
+                        return location + "/MacOS/Maya";
+                    }
+                    else if (location.EndsWith(".app"))
+                    {
+                        return location + "/Contents/MacOS/Maya";
+                    }
+                    else
+                    {
+                        return location + "/Maya.app/Contents/MacOS/Maya";
+                    }
+                default:
+                    throw new NotImplementedException();
             }
         }
 
         [SecurityPermission(SecurityAction.LinkDemand)]
-        internal static GUIContent[] GetDCCOptions(){
+        internal static GUIContent[] GetDCCOptions()
+        {
             if (instance.dccOptionNames == null ||
                 instance.dccOptionNames.Count != instance.dccOptionPaths.Count ||
-                instance.dccOptionNames.Count == 0) {
-
-                instance.dccOptionPaths = new List<string> ();
-                instance.dccOptionNames = new List<string> ();
-                FindDCCInstalls ();
+                instance.dccOptionNames.Count == 0)
+            {
+                instance.dccOptionPaths = new List<string>();
+                instance.dccOptionNames = new List<string>();
+                FindDCCInstalls();
             }
             // store the selected app if any
             string prevSelection = SelectedDCCPath;
@@ -1197,37 +1239,45 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // remove options that no longer exist
             List<string> pathsToDelete = new List<string>();
             List<string> namesToDelete = new List<string>();
-            for(int i = 0; i < instance.dccOptionPaths.Count; i++) {
-                var dccPath = instance.dccOptionPaths [i];
-                if (!File.Exists (dccPath)) {
-                    namesToDelete.Add (instance.dccOptionNames [i]);
-                    pathsToDelete.Add (dccPath);
+            for (int i = 0; i < instance.dccOptionPaths.Count; i++)
+            {
+                var dccPath = instance.dccOptionPaths[i];
+                if (!File.Exists(dccPath))
+                {
+                    namesToDelete.Add(instance.dccOptionNames[i]);
+                    pathsToDelete.Add(dccPath);
                 }
             }
-            foreach (var str in pathsToDelete) {
-                instance.dccOptionPaths.Remove (str);
+            foreach (var str in pathsToDelete)
+            {
+                instance.dccOptionPaths.Remove(str);
             }
-            foreach (var str in namesToDelete) {
-                instance.dccOptionNames.Remove (str);
+            foreach (var str in namesToDelete)
+            {
+                instance.dccOptionNames.Remove(str);
             }
 
             // set the selected DCC app to the previous selection
-            instance.SelectedDCCApp = instance.dccOptionPaths.IndexOf (prevSelection);
-            if (instance.SelectedDCCApp < 0) {
+            instance.SelectedDCCApp = instance.dccOptionPaths.IndexOf(prevSelection);
+            if (instance.SelectedDCCApp < 0)
+            {
                 // find preferred app if previous selection no longer exists
                 instance.SelectedDCCApp = instance.PreferredDCCApp;
             }
 
-            if (instance.dccOptionPaths.Count <= 0) {
+            if (instance.dccOptionPaths.Count <= 0)
+            {
                 instance.SelectedDCCApp = 0;
-                return new GUIContent[]{
+                return new GUIContent[]
+                {
                     new GUIContent("<No 3D Application found>")
                 };
             }
 
             GUIContent[] optionArray = new GUIContent[instance.dccOptionPaths.Count];
-            for(int i = 0; i < instance.dccOptionPaths.Count; i++){
-                optionArray [i] = new GUIContent(
+            for (int i = 0; i < instance.dccOptionPaths.Count; i++)
+            {
+                optionArray[i] = new GUIContent(
                     instance.dccOptionNames[i],
                     instance.dccOptionPaths[i]
                 );
@@ -1239,50 +1289,54 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
         [SecurityPermission(SecurityAction.InheritanceDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
-        internal static void AddDCCOption(string newOption, DCCType dcc){
-            if (Application.platform == RuntimePlatform.OSXEditor && dcc == DCCType.Maya) {
+        internal static void AddDCCOption(string newOption, DCCType dcc)
+        {
+            if (Application.platform == RuntimePlatform.OSXEditor && dcc == DCCType.Maya)
+            {
                 // on OSX we get a path ending in .app, which is not quite the exe
                 newOption = GetMayaExePathFromLocation(newOption);
             }
 
             var dccOptionPaths = instance.dccOptionPaths;
-            if (dccOptionPaths.Contains(newOption)) {
-                instance.SelectedDCCApp = dccOptionPaths.IndexOf (newOption);
+            if (dccOptionPaths.Contains(newOption))
+            {
+                instance.SelectedDCCApp = dccOptionPaths.IndexOf(newOption);
                 return;
             }
 
             string optionName = "";
-            switch (dcc) {
-            case DCCType.Maya:
-                var version = AskMayaVersion(newOption);
-                if (version == null)
-                {
-                    Debug.LogError("This version of Maya could not be launched properly");
-                    UnityEditor.EditorUtility.DisplayDialog("Error Loading 3D Application",
-                        "Failed to add Maya option, could not get version number from maya.exe",
-                        "Ok");
-                    return;
-                }
-                optionName = GetUniqueDCCOptionName("Maya " + version);
-                break;
-            case DCCType.Max:
-                optionName = GetMaxOptionName (newOption);
-                if (ExportSettings.IsEarlierThanMax2017(optionName))
-                {
-                    Debug.LogError("Earlier than 3ds Max 2017 is not supported");
-                    UnityEditor.EditorUtility.DisplayDialog(
-                        "Error adding 3D Application",
-                        "Unity Integration only supports 3ds Max 2017 or later",
-                        "Ok");
+            switch (dcc)
+            {
+                case DCCType.Maya:
+                    var version = AskMayaVersion(newOption);
+                    if (version == null)
+                    {
+                        Debug.LogError("This version of Maya could not be launched properly");
+                        UnityEditor.EditorUtility.DisplayDialog("Error Loading 3D Application",
+                            "Failed to add Maya option, could not get version number from maya.exe",
+                            "Ok");
                         return;
-                }
+                    }
+                    optionName = GetUniqueDCCOptionName("Maya " + version);
                     break;
-            default:
-                throw new System.NotImplementedException();
+                case DCCType.Max:
+                    optionName = GetMaxOptionName(newOption);
+                    if (ExportSettings.IsEarlierThanMax2017(optionName))
+                    {
+                        Debug.LogError("Earlier than 3ds Max 2017 is not supported");
+                        UnityEditor.EditorUtility.DisplayDialog(
+                            "Error adding 3D Application",
+                            "Unity Integration only supports 3ds Max 2017 or later",
+                            "Ok");
+                        return;
+                    }
+                    break;
+                default:
+                    throw new System.NotImplementedException();
             }
 
-            instance.dccOptionNames.Add (optionName);
-            dccOptionPaths.Add (newOption);
+            instance.dccOptionNames.Add(optionName);
+            dccOptionPaths.Add(newOption);
             instance.SelectedDCCApp = dccOptionPaths.Count - 1;
         }
 
@@ -1291,7 +1345,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         [SecurityPermission(SecurityAction.InheritanceDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
         [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.UnmanagedCode)]
-        internal static string AskMayaVersion(string exePath) {
+        internal static string AskMayaVersion(string exePath)
+        {
             System.Diagnostics.Process myProcess = new System.Diagnostics.Process();
             myProcess.StartInfo.FileName = exePath;
             myProcess.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
@@ -1333,11 +1388,13 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         /// <returns>The 3DsMax dropdown option label.</returns>
         /// <param name="exePath">Exe path.</param>
-        internal static string GetMaxOptionName(string exePath){
-            return GetUniqueDCCOptionName(Path.GetFileName(Path.GetDirectoryName (exePath)));
+        internal static string GetMaxOptionName(string exePath)
+        {
+            return GetUniqueDCCOptionName(Path.GetFileName(Path.GetDirectoryName(exePath)));
         }
 
-        internal static bool IsEarlierThanMax2017(string AppName){
+        internal static bool IsEarlierThanMax2017(string AppName)
+        {
             int version = FindDCCVersion(AppName);
             return version != -1 && version < 2017;
         }
@@ -1367,10 +1424,12 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             return instance.dccOptionPaths.Count > 0;
         }
 
-        internal static string GetProjectRelativePath(string fullPath){
+        internal static string GetProjectRelativePath(string fullPath)
+        {
             var assetRelativePath = UnityEditor.Formats.Fbx.Exporter.ExportSettings.ConvertToAssetRelativePath(fullPath);
             var projectRelativePath = "Assets/" + assetRelativePath;
-            if (string.IsNullOrEmpty(assetRelativePath)) {
+            if (string.IsNullOrEmpty(assetRelativePath))
+            {
                 throw new FbxExportSettingsException("Path " + fullPath + " must be in the Assets folder.");
             }
             return projectRelativePath;
@@ -1381,21 +1440,24 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// This is relative to the Application.dataPath ; it uses '/' as the
         /// separator on all platforms.
         /// </summary>
-        internal static string[] GetRelativeSavePaths(List<string> exportSavePaths){
-            if(exportSavePaths == null)
+        internal static string[] GetRelativeSavePaths(List<string> exportSavePaths)
+        {
+            if (exportSavePaths == null)
             {
                 return null;
             }
 
-            if (exportSavePaths.Count == 0) {
-                exportSavePaths.Add (kDefaultSavePath);
+            if (exportSavePaths.Count == 0)
+            {
+                exportSavePaths.Add(kDefaultSavePath);
             }
             string[] relSavePaths = new string[exportSavePaths.Count];
             // use special forward slash unicode char as "/" is a special character
             // that affects the dropdown layout.
             string forwardslash = " \u2044 ";
-            for (int i = 0; i < relSavePaths.Length; i++) {
-                relSavePaths [i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
+            for (int i = 0; i < relSavePaths.Length; i++)
+            {
+                relSavePaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
             }
             return relSavePaths;
         }
@@ -1413,7 +1475,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 // if path is in Assets folder, shorten it
                 if (!Path.IsPathRooted(exportSavePaths[i]))
                 {
-					displayPaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "."? "" : NormalizePath(exportSavePaths [i], isRelative: true).Replace("/", forwardslash));
+                    displayPaths[i] = string.Format("Assets{0}{1}", forwardslash, exportSavePaths[i] == "." ? "" : NormalizePath(exportSavePaths[i], isRelative: true).Replace("/", forwardslash));
                 }
                 else
                 {
@@ -1430,7 +1492,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// separator on all platforms.
         /// Only returns the paths within the Assets folder of the project.
         /// </summary>
-        internal static string[] GetRelativeFbxSavePaths(){
+        internal static string[] GetRelativeFbxSavePaths()
+        {
             return GetRelativeFbxSavePaths(instance.fbxSavePaths, ref instance.selectedFbxPath);
         }
 
@@ -1460,13 +1523,14 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// This is relative to the Application.dataPath ; it uses '/' as the
         /// separator on all platforms.
         /// </summary>
-        internal static string[] GetRelativePrefabSavePaths(){
+        internal static string[] GetRelativePrefabSavePaths()
+        {
             return GetRelativeSavePaths(instance.prefabSavePaths);
         }
 
         /// <summary>
         /// The paths formatted for display in the menu.
-        /// Paths outside the Assets folder are kept as they are and ones inside are shortened. 
+        /// Paths outside the Assets folder are kept as they are and ones inside are shortened.
         /// </summary>
         internal static string[] GetMixedFbxSavePaths()
         {
@@ -1478,8 +1542,9 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         /// <param name="savePath">Save path.</param>
         /// <param name="exportSavePaths">Export save paths.</param>
-        internal static void AddSavePath(string savePath, List<string> exportSavePaths, bool exportOutsideProject = false){
-            if(exportSavePaths == null)
+        internal static void AddSavePath(string savePath, List<string> exportSavePaths, bool exportOutsideProject = false)
+        {
+            if (exportSavePaths == null)
             {
                 return;
             }
@@ -1493,36 +1558,42 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 savePath = NormalizePath(savePath, isRelative: true);
             }
 
-            if (exportSavePaths.Contains (savePath)) {
+            if (exportSavePaths.Contains(savePath))
+            {
                 // move to first place if it isn't already
-                if (exportSavePaths [0] == savePath) {
+                if (exportSavePaths[0] == savePath)
+                {
                     return;
                 }
-                exportSavePaths.Remove (savePath);
+                exportSavePaths.Remove(savePath);
             }
 
-            if (exportSavePaths.Count >= instance.maxStoredSavePaths) {
+            if (exportSavePaths.Count >= instance.maxStoredSavePaths)
+            {
                 // remove last used path
-                exportSavePaths.RemoveAt(exportSavePaths.Count-1);
+                exportSavePaths.RemoveAt(exportSavePaths.Count - 1);
             }
 
-            exportSavePaths.Insert (0, savePath);
+            exportSavePaths.Insert(0, savePath);
         }
 
-        internal static void AddFbxSavePath(string savePath, bool exportOutsideProject = false){
-            AddSavePath (savePath, instance.fbxSavePaths, exportOutsideProject);
+        internal static void AddFbxSavePath(string savePath, bool exportOutsideProject = false)
+        {
+            AddSavePath(savePath, instance.fbxSavePaths, exportOutsideProject);
             instance.SelectedFbxPath = 0;
         }
 
-        internal static void AddPrefabSavePath(string savePath){
-            AddSavePath (savePath, instance.prefabSavePaths);
+        internal static void AddPrefabSavePath(string savePath)
+        {
+            AddSavePath(savePath, instance.prefabSavePaths);
             instance.SelectedPrefabPath = 0;
         }
 
-        internal static string GetAbsoluteSavePath(string savePath){
+        internal static string GetAbsoluteSavePath(string savePath)
+        {
             var projectAbsolutePath = Path.Combine(Application.dataPath, savePath);
             projectAbsolutePath = NormalizePath(projectAbsolutePath, isRelative: false, separator: Path.DirectorySeparatorChar);
-            
+
             // if path is outside Assets folder, it's already absolute so return the original path
             if (string.IsNullOrEmpty(ExportSettings.ConvertToAssetRelativePath(projectAbsolutePath)))
             {
@@ -1532,7 +1603,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             return projectAbsolutePath;
         }
 
-        internal static string FbxAbsoluteSavePath{
+        internal static string FbxAbsoluteSavePath
+        {
             get
             {
                 if (instance.fbxSavePaths.Count <= 0)
@@ -1543,7 +1615,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             }
         }
 
-        internal static string PrefabAbsoluteSavePath{
+        internal static string PrefabAbsoluteSavePath
+        {
             get
             {
                 if (instance.prefabSavePaths.Count <= 0)
@@ -1565,12 +1638,15 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// </summary>
         internal static string ConvertToAssetRelativePath(string fullPathInAssets, bool requireSubdirectory = true)
         {
-            if (!Path.IsPathRooted(fullPathInAssets)) {
+            if (!Path.IsPathRooted(fullPathInAssets))
+            {
                 fullPathInAssets = Path.GetFullPath(fullPathInAssets);
             }
             var relativePath = GetRelativePath(Application.dataPath, fullPathInAssets);
-            if (requireSubdirectory && relativePath.StartsWith("..")) {
-                if (relativePath.Length == 2 || relativePath[2] == '/') {
+            if (requireSubdirectory && relativePath.StartsWith(".."))
+            {
+                if (relativePath.Length == 2 || relativePath[2] == '/')
+                {
                     // The relative path has us pop out to another directory,
                     // so return an empty string as requested.
                     return "";
@@ -1583,7 +1659,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// Compute how to get from 'fromDir' to 'toDir' via a relative path.
         /// </summary>
         internal static string GetRelativePath(string fromDir, string toDir,
-                char separator = '/')
+            char separator = '/')
         {
             // https://stackoverflow.com/questions/275689/how-to-get-relative-path-from-absolute-path
             // Except... the MakeRelativeUri that ships with Unity is buggy.
@@ -1601,7 +1677,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
             // Find the least common ancestor
             int lca = -1;
-            for(int i = 0, n = System.Math.Min(fromDirs.Length, toDirs.Length); i < n; ++i) {
+            for (int i = 0, n = System.Math.Min(fromDirs.Length, toDirs.Length); i < n; ++i)
+            {
                 if (fromDirs[i] != toDirs[i]) { break; }
                 lca = i;
             }
@@ -1612,15 +1689,18 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // Then we need to go up 2 and down 3.
             var nStepsUp = (fromDirs.Length - 1) - lca;
             var nStepsDown = (toDirs.Length - 1) - lca;
-            if (nStepsUp + nStepsDown == 0) {
+            if (nStepsUp + nStepsDown == 0)
+            {
                 return ".";
             }
 
             var relDirs = new string[nStepsUp + nStepsDown];
-            for(int i = 0; i < nStepsUp; ++i) {
+            for (int i = 0; i < nStepsUp; ++i)
+            {
                 relDirs[i] = "..";
             }
-            for(int i = 0; i < nStepsDown; ++i) {
+            for (int i = 0; i < nStepsDown; ++i)
+            {
                 relDirs[nStepsUp + i] = toDirs[lca + 1 + i];
             }
 
@@ -1638,9 +1718,9 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         /// treat it as a relative path.
         /// </summary>
         internal static string NormalizePath(string path, bool isRelative,
-                char separator = '/')
+            char separator = '/')
         {
-            if(path == null)
+            if (path == null)
             {
                 return null;
             }
@@ -1650,7 +1730,8 @@ namespace UnityEditor.Formats.Fbx.Exporter {
 
             // If we're supposed to be an absolute path, but we're actually a
             // relative path, ignore the 'isRelative' flag.
-            if (!isRelative && !Path.IsPathRooted(path)) {
+            if (!isRelative && !Path.IsPathRooted(path))
+            {
                 isRelative = true;
             }
 
@@ -1660,23 +1741,29 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             // Modify dirs in-place, reading from readIndex and remembering
             // what index we've written to.
             int lastWriteIndex = -1;
-            for (int readIndex = 0, n = dirs.Length; readIndex < n; ++readIndex) {
+            for (int readIndex = 0, n = dirs.Length; readIndex < n; ++readIndex)
+            {
                 var dir = dirs[readIndex];
 
                 // Skip duplicate path separators.
-                if (string.IsNullOrEmpty(dir)) {
+                if (string.IsNullOrEmpty(dir))
+                {
                     // Skip if it's not a leading path separator.
-                   if (lastWriteIndex >= 0) {
-                       continue; }
+                    if (lastWriteIndex >= 0)
+                    {
+                        continue;
+                    }
 
-                   // Also skip if it's leading and we have a relative path.
-                   if (isRelative) {
-                       continue;
-                   }
+                    // Also skip if it's leading and we have a relative path.
+                    if (isRelative)
+                    {
+                        continue;
+                    }
                 }
 
                 // Skip '.'
-                if (dir == ".") {
+                if (dir == ".")
+                {
                     continue;
                 }
 
@@ -1686,12 +1773,18 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 //
                 // Note: this ignores the actual file system and the funny
                 // results you see when there are symlinks.
-                if (dir == "..") {
-                    if (lastWriteIndex == -1) {
+                if (dir == "..")
+                {
+                    if (lastWriteIndex == -1)
+                    {
                         // Leading '..' => handle like a normal directory.
-                    } else if (dirs[lastWriteIndex] == "..") {
+                    }
+                    else if (dirs[lastWriteIndex] == "..")
+                    {
                         // Multiple ".." => handle like a normal directory.
-                    } else {
+                    }
+                    else
+                    {
                         // Usual case: delete the previous directory.
                         lastWriteIndex--;
                         continue;
@@ -1703,21 +1796,27 @@ namespace UnityEditor.Formats.Fbx.Exporter {
                 dirs[lastWriteIndex] = dirs[readIndex];
             }
 
-            if (lastWriteIndex == -1 || (lastWriteIndex == 0 && string.IsNullOrEmpty(dirs[lastWriteIndex]))) {
+            if (lastWriteIndex == -1 || (lastWriteIndex == 0 && string.IsNullOrEmpty(dirs[lastWriteIndex])))
+            {
                 // If we didn't keep anything, we have the empty path.
                 // For an absolute path that's / ; for a relative path it's .
-                if (isRelative) {
+                if (isRelative)
+                {
                     return ".";
-                } else {
+                }
+                else
+                {
                     return "" + separator;
                 }
-            } else {
+            }
+            else
+            {
                 // Otherwise print out the path with the proper separator.
                 return String.Join("" + separator, dirs, 0, lastWriteIndex + 1);
             }
         }
 
-        internal void Load ()
+        internal void Load()
         {
             string filePath = GetFilePath();
             if (!System.IO.File.Exists(filePath))
@@ -1744,7 +1843,7 @@ namespace UnityEditor.Formats.Fbx.Exporter {
         {
             exportModelSettingsSerialize = ExportModelSettings.info;
             convertToPrefabSettingsSerialize = ConvertToPrefabSettings.info;
-            this.SaveToFile ();
+            this.SaveToFile();
         }
 
         // Called on creation and whenever the reset button is clicked
@@ -1789,5 +1888,4 @@ namespace UnityEditor.Formats.Fbx.Exporter {
             }
         }
     }
-
 }

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -6,14 +6,14 @@ using UnityEngine.Timeline;
 using UnityEditor.Timeline;
 using System.Linq;
 using Autodesk.Fbx;
-using System.Runtime.CompilerServices;  
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using UnityEditor.Formats.Fbx.Exporter.Visitors;
 using System.Security.Permissions;
 using UnityEngine.Playables;
 
-[assembly: InternalsVisibleTo("Unity.Formats.Fbx.Editor.Tests")]  
-[assembly: InternalsVisibleTo("Unity.ProBuilder.AddOns.Editor")]  
+[assembly: InternalsVisibleTo("Unity.Formats.Fbx.Editor.Tests")]
+[assembly: InternalsVisibleTo("Unity.ProBuilder.AddOns.Editor")]
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
@@ -46,16 +46,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
     [System.Serializable]
     internal class ModelExportException : System.Exception
     {
-        public ModelExportException(){}
+        public ModelExportException() {}
 
         public ModelExportException(string message)
-            : base(message){}
+            : base(message) {}
 
         public ModelExportException(string message, System.Exception inner)
-            : base(message, inner){}
+            : base(message, inner) {}
 
         protected ModelExportException(SerializationInfo info, StreamingContext context)
-            : base(info, context){}
+            : base(info, context) {}
     }
 
     /// <summary>
@@ -118,7 +118,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         const string NamePrefix = "Unity_";
 
-        private static string MakeName (string basename)
+        private static string MakeName(string basename)
         {
             return NamePrefix + basename;
         }
@@ -126,9 +126,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Create instance of exporter.
         /// </summary>
-        static ModelExporter Create ()
+        static ModelExporter Create()
         {
-            return new ModelExporter ();
+            return new ModelExporter();
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Material
         }
 
-        internal static Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> MapsToFbxObject = new Dictionary<System.Type, KeyValuePair<System.Type,FbxNodeRelationType>> ()
+        internal static Dictionary<System.Type, KeyValuePair<System.Type, FbxNodeRelationType>> MapsToFbxObject = new Dictionary<System.Type, KeyValuePair<System.Type, FbxNodeRelationType>>()
         {
             { typeof(Transform),            new KeyValuePair<System.Type, FbxNodeRelationType>(typeof(FbxProperty), FbxNodeRelationType.Property) },
             { typeof(MeshFilter),           new KeyValuePair<System.Type, FbxNodeRelationType>(typeof(FbxMesh), FbxNodeRelationType.NodeAttribute) },
@@ -155,7 +155,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// keep a map between GameObject and FbxNode for quick lookup when we export
         /// animation.
         /// </summary>
-        Dictionary<GameObject, FbxNode> MapUnityObjectToFbxNode = new Dictionary<GameObject, FbxNode> ();
+        Dictionary<GameObject, FbxNode> MapUnityObjectToFbxNode = new Dictionary<GameObject, FbxNode>();
 
         /// <summary>
         /// keep a map between the constrained FbxNode (in Unity this is the GameObject with constraint component)
@@ -171,16 +171,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Map Unity material ID to FBX material object
         /// </summary>
-        Dictionary<int, FbxSurfaceMaterial> MaterialMap = new Dictionary<int, FbxSurfaceMaterial> ();
+        Dictionary<int, FbxSurfaceMaterial> MaterialMap = new Dictionary<int, FbxSurfaceMaterial>();
 
         /// <summary>
         /// Map texture properties to FBX texture object
         /// </summary>
-        Dictionary<(Texture unityTexture, Vector2 offset, Vector2 scale, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV), FbxFileTexture> TextureMap = 
+        Dictionary<(Texture unityTexture, Vector2 offset, Vector2 scale, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV), FbxFileTexture> TextureMap =
             new Dictionary<(Texture unityTexture, Vector2 offset, Vector2 scale, TextureWrapMode wrapModeU, TextureWrapMode wrapModeV), FbxFileTexture>();
 
         /// <summary>
-        /// Map a Unity mesh to an fbx node (for preserving instances) 
+        /// Map a Unity mesh to an fbx node (for preserving instances)
         /// </summary>
         Dictionary<Mesh, FbxNode> SharedMeshes = new Dictionary<Mesh, FbxNode>();
 
@@ -188,7 +188,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Map for the Name of an Object to number of objects with this name.
         /// Used for enforcing unique names on export.
         /// </summary>
-        Dictionary<string, int> NameToIndexMap = new Dictionary<string, int> ();
+        Dictionary<string, int> NameToIndexMap = new Dictionary<string, int>();
 
         /// <summary>
         /// Map for the Material Name to number of materials with this name.
@@ -201,7 +201,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Used for enforcing unique names on export.
         /// </summary>
         Dictionary<string, int> TextureNameToIndexMap = new Dictionary<string, int>();
-        
+
         /// <summary>
         /// Format for creating unique names
         /// </summary>
@@ -215,18 +215,23 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Gets the export settings.
         /// </summary>
-        internal static ExportSettings ExportSettings {
+        internal static ExportSettings ExportSettings
+        {
             get { return ExportSettings.instance; }
         }
 
-        internal static IExportOptions DefaultOptions {
+        internal static IExportOptions DefaultOptions
+        {
             get { return new ExportModelSettingsSerialize(); }
         }
 
         private IExportOptions m_exportOptions;
-        private IExportOptions ExportOptions {
-            get {
-                if (m_exportOptions == null) {
+        private IExportOptions ExportOptions
+        {
+            get
+            {
+                if (m_exportOptions == null)
+                {
                     // get default settings;
                     m_exportOptions = DefaultOptions;
                 }
@@ -238,12 +243,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Gets the Unity default material.
         /// </summary>
-        internal static Material DefaultMaterial {
-            get {
-                if (!s_defaultMaterial) {
-                    var obj = GameObject.CreatePrimitive (PrimitiveType.Quad);
-                    s_defaultMaterial = obj.GetComponent<Renderer> ().sharedMaterial;
-                    Object.DestroyImmediate (obj);
+        internal static Material DefaultMaterial
+        {
+            get
+            {
+                if (!s_defaultMaterial)
+                {
+                    var obj = GameObject.CreatePrimitive(PrimitiveType.Quad);
+                    s_defaultMaterial = obj.GetComponent<Renderer>().sharedMaterial;
+                    Object.DestroyImmediate(obj);
                 }
                 return s_defaultMaterial;
             }
@@ -251,7 +259,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         static Material s_defaultMaterial = null;
 
-        static Dictionary<UnityEngine.LightType, FbxLight.EType> MapLightType = new Dictionary<UnityEngine.LightType, FbxLight.EType> () {
+        static Dictionary<UnityEngine.LightType, FbxLight.EType> MapLightType = new Dictionary<UnityEngine.LightType, FbxLight.EType>()
+        {
             { UnityEngine.LightType.Directional,    FbxLight.EType.eDirectional },
             { UnityEngine.LightType.Spot,           FbxLight.EType.eSpot },
             { UnityEngine.LightType.Point,          FbxLight.EType.ePoint },
@@ -263,42 +272,48 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         internal static string GetVersionFromReadme()
         {
-            if (!File.Exists (ChangeLogPath)) {
-                Debug.LogWarning (string.Format("Could not find version number, the ChangeLog file is missing from: {0}", ChangeLogPath));
+            if (!File.Exists(ChangeLogPath))
+            {
+                Debug.LogWarning(string.Format("Could not find version number, the ChangeLog file is missing from: {0}", ChangeLogPath));
                 return null;
             }
 
-            try {
+            try
+            {
                 // The standard format is:
                 //   ## [a.b.c-whatever] - yyyy-mm-dd
                 // Another format is:
                 //   **Version**: a.b.c-whatever
                 // we handle either one and read out the version
-                var lines = File.ReadAllLines (ChangeLogPath);
-                var regexes = new string [] {
+                var lines = File.ReadAllLines(ChangeLogPath);
+                var regexes = new string[]
+                {
                     @"^\s*##\s*\[(.*)\]",
                     @"^\s*\*\*Version\*\*:\s*(.*)\s*"
                 };
-                foreach (var line in lines) {
-                    foreach (var regex in regexes) {
+                foreach (var line in lines)
+                {
+                    foreach (var regex in regexes)
+                    {
                         var match = System.Text.RegularExpressions.Regex.Match(line, regex);
-                        if (match.Success) {
+                        if (match.Success)
+                        {
                             var version = match.Groups[1].Value;
-                            return version.Trim ();
+                            return version.Trim();
                         }
                     }
                 }
 
                 // If we're here, we didn't find any match.
-                Debug.LogWarning (string.Format("Could not find most recent version number in {0}", ChangeLogPath));
+                Debug.LogWarning(string.Format("Could not find most recent version number in {0}", ChangeLogPath));
                 return null;
             }
-            catch(IOException e){
-                Debug.LogException (e);
-                Debug.LogWarning (string.Format("Error reading file {0} ({1})", ChangeLogPath, e));
+            catch (IOException e)
+            {
+                Debug.LogException(e);
+                Debug.LogWarning(string.Format("Error reading file {0} ({1})", ChangeLogPath, e));
                 return null;
             }
-
         }
 
         /// <summary>
@@ -308,27 +323,29 @@ namespace UnityEditor.Formats.Fbx.Exporter
         internal static FbxLayer GetOrCreateLayer(FbxMesh fbxMesh, int layer = 0 /* default layer */)
         {
             int maxLayerIndex = fbxMesh.GetLayerCount() - 1;
-            while (layer > maxLayerIndex) {
+            while (layer > maxLayerIndex)
+            {
                 // We'll have to create the layer (potentially several).
                 // Make sure to avoid infinite loops even if there's an
                 // FbxSdk bug.
                 int newLayerIndex = fbxMesh.CreateLayer();
-                if (newLayerIndex <= maxLayerIndex) {
+                if (newLayerIndex <= maxLayerIndex)
+                {
                     // Error!
                     throw new ModelExportException(
                         "Internal error: Unable to create mesh layer "
                         + (maxLayerIndex + 1)
-                        + " on mesh " + fbxMesh.GetName ());
+                        + " on mesh " + fbxMesh.GetName());
                 }
                 maxLayerIndex = newLayerIndex;
             }
-            return fbxMesh.GetLayer (layer);
+            return fbxMesh.GetLayer(layer);
         }
 
         /// <summary>
         /// Export the mesh's attributes using layer 0.
         /// </summary>
-        private bool ExportComponentAttributes (MeshInfo mesh, FbxMesh fbxMesh, int[] unmergedTriangles)
+        private bool ExportComponentAttributes(MeshInfo mesh, FbxMesh fbxMesh, int[] unmergedTriangles)
         {
             // return true if any attribute was exported
             bool exportedAttribute = false;
@@ -336,95 +353,109 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // Set the normals on Layer 0.
             FbxLayer fbxLayer = GetOrCreateLayer(fbxMesh);
 
-            if (mesh.HasValidNormals()) {
-                using (var fbxLayerElement = FbxLayerElementNormal.Create (fbxMesh, "Normals")) {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygonVertex);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eDirect);
+            if (mesh.HasValidNormals())
+            {
+                using (var fbxLayerElement = FbxLayerElementNormal.Create(fbxMesh, "Normals"))
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygonVertex);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eDirect);
 
                     // Add one normal per each vertex face index (3 per triangle)
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
 
-                    for (int n = 0; n < unmergedTriangles.Length; n++) {
-                        int unityTriangle = unmergedTriangles [n];
-                        fbxElementArray.Add (ConvertToFbxVector4 (mesh.Normals [unityTriangle]));
+                    for (int n = 0; n < unmergedTriangles.Length; n++)
+                    {
+                        int unityTriangle = unmergedTriangles[n];
+                        fbxElementArray.Add(ConvertToFbxVector4(mesh.Normals[unityTriangle]));
                     }
 
-                    fbxLayer.SetNormals (fbxLayerElement);
+                    fbxLayer.SetNormals(fbxLayerElement);
                 }
                 exportedAttribute = true;
             }
 
             /// Set the binormals on Layer 0.
-            if (mesh.HasValidBinormals()) {
-                using (var fbxLayerElement = FbxLayerElementBinormal.Create (fbxMesh, "Binormals")) {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygonVertex);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eDirect);
+            if (mesh.HasValidBinormals())
+            {
+                using (var fbxLayerElement = FbxLayerElementBinormal.Create(fbxMesh, "Binormals"))
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygonVertex);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eDirect);
 
                     // Add one normal per each vertex face index (3 per triangle)
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
 
-                    for (int n = 0; n < unmergedTriangles.Length; n++) {
-                        int unityTriangle = unmergedTriangles [n];
-                        fbxElementArray.Add (ConvertToFbxVector4 (mesh.Binormals [unityTriangle]));
+                    for (int n = 0; n < unmergedTriangles.Length; n++)
+                    {
+                        int unityTriangle = unmergedTriangles[n];
+                        fbxElementArray.Add(ConvertToFbxVector4(mesh.Binormals[unityTriangle]));
                     }
-                    fbxLayer.SetBinormals (fbxLayerElement);
+                    fbxLayer.SetBinormals(fbxLayerElement);
                 }
                 exportedAttribute = true;
             }
 
             /// Set the tangents on Layer 0.
-            if (mesh.HasValidTangents()) {
-                using (var fbxLayerElement = FbxLayerElementTangent.Create (fbxMesh, "Tangents")) {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygonVertex);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eDirect);
+            if (mesh.HasValidTangents())
+            {
+                using (var fbxLayerElement = FbxLayerElementTangent.Create(fbxMesh, "Tangents"))
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygonVertex);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eDirect);
 
                     // Add one normal per each vertex face index (3 per triangle)
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
 
-                    for (int n = 0; n < unmergedTriangles.Length; n++) {
-                        int unityTriangle = unmergedTriangles [n];
-                        fbxElementArray.Add (ConvertToFbxVector4 (
-                            new Vector3 (
-                                mesh.Tangents [unityTriangle] [0],
-                                mesh.Tangents [unityTriangle] [1],
-                                mesh.Tangents [unityTriangle] [2]
-                            )));
+                    for (int n = 0; n < unmergedTriangles.Length; n++)
+                    {
+                        int unityTriangle = unmergedTriangles[n];
+                        fbxElementArray.Add(ConvertToFbxVector4(
+                            new Vector3(
+                                mesh.Tangents[unityTriangle][0],
+                                mesh.Tangents[unityTriangle][1],
+                                mesh.Tangents[unityTriangle][2]
+                            )
+                        ));
                     }
-                    fbxLayer.SetTangents (fbxLayerElement);
+                    fbxLayer.SetTangents(fbxLayerElement);
                 }
                 exportedAttribute = true;
             }
 
-            exportedAttribute |= ExportUVs (fbxMesh, mesh, unmergedTriangles);
+            exportedAttribute |= ExportUVs(fbxMesh, mesh, unmergedTriangles);
 
-            if (mesh.HasValidVertexColors()) {
-                using (var fbxLayerElement = FbxLayerElementVertexColor.Create (fbxMesh, "VertexColors")) {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygonVertex);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eIndexToDirect);
+            if (mesh.HasValidVertexColors())
+            {
+                using (var fbxLayerElement = FbxLayerElementVertexColor.Create(fbxMesh, "VertexColors"))
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygonVertex);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eIndexToDirect);
 
                     // set texture coordinates per vertex
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
 
                     // (Uni-31596) only copy unique UVs into this array, and index appropriately
-                    for (int n = 0; n < mesh.VertexColors.Length; n++) {
+                    for (int n = 0; n < mesh.VertexColors.Length; n++)
+                    {
                         // Converting to Color from Color32, as Color32 stores the colors
                         // as ints between 0-255, while FbxColor and Color
                         // use doubles between 0-1
-                        Color color = mesh.VertexColors [n];
-                        fbxElementArray.Add (new FbxColor (color.r,
+                        Color color = mesh.VertexColors[n];
+                        fbxElementArray.Add(new FbxColor(color.r,
                             color.g,
                             color.b,
                             color.a));
                     }
 
                     // For each face index, point to a texture uv
-                    FbxLayerElementArray fbxIndexArray = fbxLayerElement.GetIndexArray ();
-                    fbxIndexArray.SetCount (unmergedTriangles.Length);
+                    FbxLayerElementArray fbxIndexArray = fbxLayerElement.GetIndexArray();
+                    fbxIndexArray.SetCount(unmergedTriangles.Length);
 
-                    for (int i = 0; i < unmergedTriangles.Length; i++) {
-                        fbxIndexArray.SetAt (i, unmergedTriangles [i]);
+                    for (int i = 0; i < unmergedTriangles.Length; i++)
+                    {
+                        fbxIndexArray.SetAt(i, unmergedTriangles[i]);
                     }
-                    fbxLayer.SetVertexColors (fbxLayerElement);
+                    fbxLayer.SetVertexColors(fbxLayerElement);
                 }
                 exportedAttribute = true;
             }
@@ -439,7 +470,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="unmergedTriangles">Unmerged triangles.</param>
         private static bool ExportUVs(FbxMesh fbxMesh, MeshInfo mesh, int[] unmergedTriangles)
         {
-            Vector2[][] uvs = new Vector2[][] {
+            Vector2[][] uvs = new Vector2[][]
+            {
                 mesh.UV,
                 mesh.mesh.uv2,
                 mesh.mesh.uv3,
@@ -447,34 +479,38 @@ namespace UnityEditor.Formats.Fbx.Exporter
             };
 
             int k = 0;
-            for (int i = 0; i < uvs.Length; i++) {
-                if (uvs [i] == null || uvs [i].Length == 0) {
+            for (int i = 0; i < uvs.Length; i++)
+            {
+                if (uvs[i] == null || uvs[i].Length == 0)
+                {
                     continue; // don't have these UV's, so skip
                 }
 
-                FbxLayer fbxLayer = GetOrCreateLayer (fbxMesh, k);
-                using (var fbxLayerElement = FbxLayerElementUV.Create (fbxMesh, "UVSet" + i))
+                FbxLayer fbxLayer = GetOrCreateLayer(fbxMesh, k);
+                using (var fbxLayerElement = FbxLayerElementUV.Create(fbxMesh, "UVSet" + i))
                 {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygonVertex);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eIndexToDirect);
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygonVertex);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eIndexToDirect);
 
                     // set texture coordinates per vertex
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetDirectArray();
 
                     // (Uni-31596) only copy unique UVs into this array, and index appropriately
-                    for (int n = 0; n < uvs[i].Length; n++) {
-                        fbxElementArray.Add (new FbxVector2 (uvs[i] [n] [0],
-                            uvs[i] [n] [1]));
+                    for (int n = 0; n < uvs[i].Length; n++)
+                    {
+                        fbxElementArray.Add(new FbxVector2(uvs[i][n][0],
+                            uvs[i][n][1]));
                     }
 
                     // For each face index, point to a texture uv
-                    FbxLayerElementArray fbxIndexArray = fbxLayerElement.GetIndexArray ();
-                    fbxIndexArray.SetCount (unmergedTriangles.Length);
+                    FbxLayerElementArray fbxIndexArray = fbxLayerElement.GetIndexArray();
+                    fbxIndexArray.SetCount(unmergedTriangles.Length);
 
-                    for(int j = 0; j < unmergedTriangles.Length; j++){
-                        fbxIndexArray.SetAt (j, unmergedTriangles [j]);
+                    for (int j = 0; j < unmergedTriangles.Length; j++)
+                    {
+                        fbxIndexArray.SetAt(j, unmergedTriangles[j]);
                     }
-                    fbxLayer.SetUVs (fbxLayerElement, FbxLayerElement.EType.eTextureDiffuse);
+                    fbxLayer.SetUVs(fbxLayerElement, FbxLayerElement.EType.eTextureDiffuse);
                 }
                 k++;
             }
@@ -582,7 +618,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         internal static FbxVector4 ConvertToFbxVector4(Vector3 leftHandedVector, float unitScale = 1f)
         {
             // negating the x component of the vector converts it from left to right handed coordinates
-            return unitScale * new FbxVector4 (
+            return unitScale * new FbxVector4(
                 leftHandedVector[0],
                 leftHandedVector[1],
                 leftHandedVector[2]);
@@ -599,39 +635,45 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="unityPropName">Unity property name, e.g. "_MainTex".</param>
         /// <param name="fbxMaterial">Fbx material.</param>
         /// <param name="fbxPropName">Fbx property name, e.g. <c>FbxSurfaceMaterial.sDiffuse</c>.</param>
-        internal bool ExportTexture (Material unityMaterial, string unityPropName,
-                                    FbxSurfaceMaterial fbxMaterial, string fbxPropName)
+        internal bool ExportTexture(Material unityMaterial, string unityPropName,
+            FbxSurfaceMaterial fbxMaterial, string fbxPropName)
         {
-            if (!unityMaterial) {
+            if (!unityMaterial)
+            {
                 return false;
             }
 
             // Get the texture on this property, if any.
-            if (!unityMaterial.HasProperty (unityPropName)) {
+            if (!unityMaterial.HasProperty(unityPropName))
+            {
                 return false;
             }
-            var unityTexture = unityMaterial.GetTexture (unityPropName);
-            if (!unityTexture) {
+            var unityTexture = unityMaterial.GetTexture(unityPropName);
+            if (!unityTexture)
+            {
                 return false;
             }
 
             // Find its filename
             var textureSourceFullPath = AssetDatabase.GetAssetPath(unityTexture);
-            if (string.IsNullOrEmpty(textureSourceFullPath)) {
+            if (string.IsNullOrEmpty(textureSourceFullPath))
+            {
                 return false;
             }
 
             // get absolute filepath to texture
-            textureSourceFullPath = Path.GetFullPath (textureSourceFullPath);
+            textureSourceFullPath = Path.GetFullPath(textureSourceFullPath);
 
-            if (Verbose) {
-                Debug.Log (string.Format ("{2}.{1} setting texture path {0}", textureSourceFullPath, fbxPropName, fbxMaterial.GetName ()));
+            if (Verbose)
+            {
+                Debug.Log(string.Format("{2}.{1} setting texture path {0}", textureSourceFullPath, fbxPropName, fbxMaterial.GetName()));
             }
 
             // Find the corresponding property on the fbx material.
-            var fbxMaterialProperty = fbxMaterial.FindProperty (fbxPropName);
-            if (fbxMaterialProperty == null || !fbxMaterialProperty.IsValid ()) {
-                Debug.Log ("property not found");
+            var fbxMaterialProperty = fbxMaterial.FindProperty(fbxPropName);
+            if (fbxMaterialProperty == null || !fbxMaterialProperty.IsValid())
+            {
+                Debug.Log("property not found");
                 return false;
             }
 
@@ -647,15 +689,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             if (!TextureMap.TryGetValue(tuple, out fbxTexture))
             {
                 var textureName = GetUniqueTextureName(fbxPropName + "_Texture");
-                fbxTexture = FbxFileTexture.Create (fbxMaterial, textureName);
-                fbxTexture.SetFileName (textureSourceFullPath);
-                fbxTexture.SetTextureUse (FbxTexture.ETextureUse.eStandard);
-                fbxTexture.SetMappingType (FbxTexture.EMappingType.eUV);
+                fbxTexture = FbxFileTexture.Create(fbxMaterial, textureName);
+                fbxTexture.SetFileName(textureSourceFullPath);
+                fbxTexture.SetTextureUse(FbxTexture.ETextureUse.eStandard);
+                fbxTexture.SetMappingType(FbxTexture.EMappingType.eUV);
                 fbxTexture.SetScale(scale.x, scale.y);
                 fbxTexture.SetTranslation(offset.x, offset.y);
                 fbxTexture.SetWrapMode(GetWrapModeFromUnityWrapMode(wrapModeU, unityMaterial.name, unityPropName),
-                                       GetWrapModeFromUnityWrapMode(wrapModeV, unityMaterial.name, unityPropName));
-                TextureMap.Add (tuple, fbxTexture);
+                    GetWrapModeFromUnityWrapMode(wrapModeV, unityMaterial.name, unityPropName));
+                TextureMap.Add(tuple, fbxTexture);
             }
             fbxTexture.ConnectDstProperty(fbxMaterialProperty);
 
@@ -673,34 +715,39 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     return FbxTexture.EWrapMode.eRepeat;
             }
         }
+
         /// <summary>
         /// Get the color of a material, or grey if we can't find it.
         /// </summary>
-        internal FbxDouble3 GetMaterialColor (Material unityMaterial, string unityPropName, float defaultValue = 1)
+        internal FbxDouble3 GetMaterialColor(Material unityMaterial, string unityPropName, float defaultValue = 1)
         {
-            if (!unityMaterial) {
+            if (!unityMaterial)
+            {
                 return new FbxDouble3(defaultValue);
             }
-            if (!unityMaterial.HasProperty (unityPropName)) {
+            if (!unityMaterial.HasProperty(unityPropName))
+            {
                 return new FbxDouble3(defaultValue);
             }
-            var unityColor = unityMaterial.GetColor (unityPropName);
-            return new FbxDouble3 (unityColor.r, unityColor.g, unityColor.b);
+            var unityColor = unityMaterial.GetColor(unityPropName);
+            return new FbxDouble3(unityColor.r, unityColor.g, unityColor.b);
         }
 
         /// <summary>
         /// Export (and map) a Unity PBS material to FBX classic material
         /// </summary>
-        internal bool ExportMaterial (Material unityMaterial, FbxScene fbxScene, FbxNode fbxNode)
+        internal bool ExportMaterial(Material unityMaterial, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if (!unityMaterial) {
+            if (!unityMaterial)
+            {
                 unityMaterial = DefaultMaterial;
             }
 
             var unityID = unityMaterial.GetInstanceID();
             FbxSurfaceMaterial mappedMaterial;
-            if (MaterialMap.TryGetValue (unityID, out mappedMaterial)) {
-                fbxNode.AddMaterial (mappedMaterial);
+            if (MaterialMap.TryGetValue(unityID, out mappedMaterial))
+            {
+                fbxNode.AddMaterial(mappedMaterial);
                 return true;
             }
 
@@ -710,10 +757,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             fbxName = GetUniqueMaterialName(fbxName);
 
-            if (Verbose) {
-                if (unityName != fbxName) {
-                    Debug.Log (string.Format ("exporting material {0} as {1}", unityName, fbxName));
-                } else {
+            if (Verbose)
+            {
+                if (unityName != fbxName)
+                {
+                    Debug.Log(string.Format("exporting material {0} as {1}", unityName, fbxName));
+                }
+                else
+                {
                     Debug.Log(string.Format("exporting material {0}", unityName));
                 }
             }
@@ -721,38 +772,41 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // We'll export either Phong or Lambert. Phong if it calls
             // itself specular, Lambert otherwise.
             var shader = unityMaterial.shader;
-            bool specular = shader.name.ToLower ().Contains ("specular");
+            bool specular = shader.name.ToLower().Contains("specular");
             bool hdrp = shader.name.ToLower().Contains("hdrp");
 
             var fbxMaterial = specular
-                ? FbxSurfacePhong.Create (fbxScene, fbxName)
-                : FbxSurfaceLambert.Create (fbxScene, fbxName);
+                ? FbxSurfacePhong.Create(fbxScene, fbxName)
+                : FbxSurfaceLambert.Create(fbxScene, fbxName);
 
             // Copy the flat colours over from Unity standard materials to FBX.
-            fbxMaterial.Diffuse.Set (GetMaterialColor (unityMaterial, "_Color"));
-            fbxMaterial.Emissive.Set (GetMaterialColor (unityMaterial, "_EmissionColor", 0));
+            fbxMaterial.Diffuse.Set(GetMaterialColor(unityMaterial, "_Color"));
+            fbxMaterial.Emissive.Set(GetMaterialColor(unityMaterial, "_EmissionColor", 0));
             // hdrp materials dont export emission properly, so default to 0
-            if (hdrp) {
+            if (hdrp)
+            {
                 fbxMaterial.Emissive.Set(new FbxDouble3(0, 0, 0));
             }
-            fbxMaterial.Ambient.Set (new FbxDouble3 ());
+            fbxMaterial.Ambient.Set(new FbxDouble3());
 
-            fbxMaterial.BumpFactor.Set (unityMaterial.HasProperty ("_BumpScale") ? unityMaterial.GetFloat ("_BumpScale") : 0);
+            fbxMaterial.BumpFactor.Set(unityMaterial.HasProperty("_BumpScale") ? unityMaterial.GetFloat("_BumpScale") : 0);
 
-            if (specular) {
-                (fbxMaterial as FbxSurfacePhong).Specular.Set (GetMaterialColor (unityMaterial, "_SpecColor"));
+            if (specular)
+            {
+                (fbxMaterial as FbxSurfacePhong).Specular.Set(GetMaterialColor(unityMaterial, "_SpecColor"));
             }
 
             // Export the textures from Unity standard materials to FBX.
-            ExportTexture (unityMaterial, "_MainTex", fbxMaterial, FbxSurfaceMaterial.sDiffuse);
-            ExportTexture (unityMaterial, "_EmissionMap", fbxMaterial, FbxSurfaceMaterial.sEmissive);
-            ExportTexture (unityMaterial, "_BumpMap", fbxMaterial, FbxSurfaceMaterial.sNormalMap);
-            if (specular) {
-                ExportTexture (unityMaterial, "_SpecGlossMap", fbxMaterial, FbxSurfaceMaterial.sSpecular);
+            ExportTexture(unityMaterial, "_MainTex", fbxMaterial, FbxSurfaceMaterial.sDiffuse);
+            ExportTexture(unityMaterial, "_EmissionMap", fbxMaterial, FbxSurfaceMaterial.sEmissive);
+            ExportTexture(unityMaterial, "_BumpMap", fbxMaterial, FbxSurfaceMaterial.sNormalMap);
+            if (specular)
+            {
+                ExportTexture(unityMaterial, "_SpecGlossMap", fbxMaterial, FbxSurfaceMaterial.sSpecular);
             }
 
-            MaterialMap.Add (unityID, fbxMaterial);
-            fbxNode.AddMaterial (fbxMaterial);
+            MaterialMap.Add(unityID, fbxMaterial);
+            fbxNode.AddMaterial(fbxMaterial);
             return true;
         }
 
@@ -769,31 +823,38 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private void AssignLayerElementMaterial(FbxMesh fbxMesh, Mesh mesh, int materialCount)
         {
             // Add FbxLayerElementMaterial to layer 0 of the node
-            FbxLayer fbxLayer = fbxMesh.GetLayer (0 /* default layer */);
-            if (fbxLayer == null) {
-                fbxMesh.CreateLayer ();
-                fbxLayer = fbxMesh.GetLayer (0 /* default layer */);
+            FbxLayer fbxLayer = fbxMesh.GetLayer(0 /* default layer */);
+            if (fbxLayer == null)
+            {
+                fbxMesh.CreateLayer();
+                fbxLayer = fbxMesh.GetLayer(0 /* default layer */);
             }
 
-            using (var fbxLayerElement = FbxLayerElementMaterial.Create (fbxMesh, "Material")) {
+            using (var fbxLayerElement = FbxLayerElementMaterial.Create(fbxMesh, "Material"))
+            {
                 // if there is only one material then set everything to that material
-                if (materialCount == 1) {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eAllSame);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eIndexToDirect);
+                if (materialCount == 1)
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eAllSame);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eIndexToDirect);
 
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetIndexArray ();
-                    fbxElementArray.Add (0);
-                } else {
-                    fbxLayerElement.SetMappingMode (FbxLayerElement.EMappingMode.eByPolygon);
-                    fbxLayerElement.SetReferenceMode (FbxLayerElement.EReferenceMode.eIndexToDirect);
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetIndexArray();
+                    fbxElementArray.Add(0);
+                }
+                else
+                {
+                    fbxLayerElement.SetMappingMode(FbxLayerElement.EMappingMode.eByPolygon);
+                    fbxLayerElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eIndexToDirect);
 
-                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetIndexArray ();
+                    FbxLayerElementArray fbxElementArray = fbxLayerElement.GetIndexArray();
 
-                    for (int subMeshIndex = 0; subMeshIndex < mesh.subMeshCount; subMeshIndex++) {
-                        var topology = mesh.GetTopology (subMeshIndex);
+                    for (int subMeshIndex = 0; subMeshIndex < mesh.subMeshCount; subMeshIndex++)
+                    {
+                        var topology = mesh.GetTopology(subMeshIndex);
                         int polySize;
 
-                        switch (topology) {
+                        switch (topology)
+                        {
                             case MeshTopology.Triangles:
                                 polySize = 3;
                                 break;
@@ -813,12 +874,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         // Specify the material index for each polygon.
                         // Material index should match subMeshIndex.
                         var indices = mesh.GetIndices(subMeshIndex);
-                        for (int j = 0, n = indices.Length / polySize; j < n; j++) {
+                        for (int j = 0, n = indices.Length / polySize; j < n; j++)
+                        {
                             fbxElementArray.Add(subMeshIndex);
                         }
                     }
                 }
-                fbxLayer.SetMaterials (fbxLayerElement);
+                fbxLayer.SetMaterials(fbxLayerElement);
             }
         }
 
@@ -829,7 +891,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         ///
         /// Use fbxNode.GetMesh() to access the exported mesh.
         /// </summary>
-        internal bool ExportMesh (Mesh mesh, FbxNode fbxNode, Material[] materials = null)
+        internal bool ExportMesh(Mesh mesh, FbxNode fbxNode, Material[] materials = null)
         {
             var meshInfo = new MeshInfo(mesh, materials);
             return ExportMesh(meshInfo, fbxNode);
@@ -838,14 +900,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Keeps track of the index of each point in the exported vertex array.
         /// </summary>
-        private Dictionary<Vector3, int> ControlPointToIndex = new Dictionary<Vector3, int> ();
+        private Dictionary<Vector3, int> ControlPointToIndex = new Dictionary<Vector3, int>();
 
         /// <summary>
         /// Exports a unity mesh and attaches it to the node as an FbxMesh.
         /// </summary>
-        bool ExportMesh (MeshInfo meshInfo, FbxNode fbxNode)
+        bool ExportMesh(MeshInfo meshInfo, FbxNode fbxNode)
         {
-            if (!meshInfo.IsValid) {
+            if (!meshInfo.IsValid)
+            {
                 return false;
             }
 
@@ -854,37 +917,42 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // create the mesh structure.
             var fbxScene = fbxNode.GetScene();
-            FbxMesh fbxMesh = FbxMesh.Create (fbxScene, "Scene");
+            FbxMesh fbxMesh = FbxMesh.Create(fbxScene, "Scene");
 
             // Create control points.
             ControlPointToIndex.Clear();
             {
                 var vertices = meshInfo.Vertices;
-                for (int v = 0, n = meshInfo.VertexCount; v < n; v++) {
-                    if (ControlPointToIndex.ContainsKey (vertices [v])) {
+                for (int v = 0, n = meshInfo.VertexCount; v < n; v++)
+                {
+                    if (ControlPointToIndex.ContainsKey(vertices[v]))
+                    {
                         continue;
                     }
-                    ControlPointToIndex [vertices [v]] = ControlPointToIndex.Count();
+                    ControlPointToIndex[vertices[v]] = ControlPointToIndex.Count();
                 }
-                fbxMesh.InitControlPoints (ControlPointToIndex.Count());
+                fbxMesh.InitControlPoints(ControlPointToIndex.Count());
 
-                foreach (var kvp in ControlPointToIndex) {
+                foreach (var kvp in ControlPointToIndex)
+                {
                     var controlPoint = kvp.Key;
                     var index = kvp.Value;
-                    fbxMesh.SetControlPointAt (ConvertToFbxVector4(controlPoint, UnitScaleFactor), index);
+                    fbxMesh.SetControlPointAt(ConvertToFbxVector4(controlPoint, UnitScaleFactor), index);
                 }
             }
 
-            var unmergedPolygons = new List<int> ();
+            var unmergedPolygons = new List<int>();
             var mesh = meshInfo.mesh;
-            for (int s = 0; s < mesh.subMeshCount; s++) {
-                var topology = mesh.GetTopology (s);
-                var indices = mesh.GetIndices (s);
+            for (int s = 0; s < mesh.subMeshCount; s++)
+            {
+                var topology = mesh.GetTopology(s);
+                var indices = mesh.GetIndices(s);
 
                 int polySize;
                 int[] vertOrder;
 
-                switch (topology) {
+                switch (topology)
+                {
                     case MeshTopology.Triangles:
                         polySize = 3;
                         vertOrder = new int[] { 0, 1, 2 };
@@ -903,37 +971,39 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         throw new System.NotImplementedException();
                 }
 
-                for (int f = 0; f < indices.Length / polySize; f++) {
-                    fbxMesh.BeginPolygon ();
+                for (int f = 0; f < indices.Length / polySize; f++)
+                {
+                    fbxMesh.BeginPolygon();
 
-                    foreach (int val in vertOrder) {
-                        int polyVert = indices [polySize * f + val];
+                    foreach (int val in vertOrder)
+                    {
+                        int polyVert = indices[polySize * f + val];
 
                         // Save the polygon order (without merging vertices) so we
                         // properly export UVs, normals, binormals, etc.
                         unmergedPolygons.Add(polyVert);
 
-                        polyVert = ControlPointToIndex [meshInfo.Vertices [polyVert]];
-                        fbxMesh.AddPolygon (polyVert);
-
+                        polyVert = ControlPointToIndex[meshInfo.Vertices[polyVert]];
+                        fbxMesh.AddPolygon(polyVert);
                     }
-                    fbxMesh.EndPolygon ();
+                    fbxMesh.EndPolygon();
                 }
             }
 
             // Set up materials per submesh.
-            foreach (var mat in meshInfo.Materials) {
-                ExportMaterial (mat, fbxScene, fbxNode);
+            foreach (var mat in meshInfo.Materials)
+            {
+                ExportMaterial(mat, fbxScene, fbxNode);
             }
-            AssignLayerElementMaterial (fbxMesh, meshInfo.mesh, meshInfo.Materials.Length);
+            AssignLayerElementMaterial(fbxMesh, meshInfo.mesh, meshInfo.Materials.Length);
 
             // Set up normals, etc.
-            ExportComponentAttributes (meshInfo, fbxMesh, unmergedPolygons.ToArray());
+            ExportComponentAttributes(meshInfo, fbxMesh, unmergedPolygons.ToArray());
 
             // Set up blend shapes.
             FbxBlendShape fbxBlendShape = ExportBlendShapes(meshInfo, fbxMesh, fbxScene, unmergedPolygons.ToArray());
-            
-            if(fbxBlendShape != null && fbxBlendShape.GetBlendShapeChannelCount() > 0)
+
+            if (fbxBlendShape != null && fbxBlendShape.GetBlendShapeChannelCount() > 0)
             {
                 // Populate mapping for faster lookup when exporting blendshape animations
                 List<FbxBlendShapeChannel> blendshapeChannels;
@@ -942,8 +1012,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     blendshapeChannels = new List<FbxBlendShapeChannel>();
                     MapUnityObjectToBlendShapes.Add(fbxNode, blendshapeChannels);
                 }
-                
-                for(int i = 0; i < fbxBlendShape.GetBlendShapeChannelCount(); i++)
+
+                for (int i = 0; i < fbxBlendShape.GetBlendShapeChannelCount(); i++)
                 {
                     var bsChannel = fbxBlendShape.GetBlendShapeChannel(i);
                     blendshapeChannels.Add(bsChannel);
@@ -951,8 +1021,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             // set the fbxNode containing the mesh
-            fbxNode.SetNodeAttribute (fbxMesh);
-            fbxNode.SetShadingMode (FbxNode.EShadingMode.eWireFrame);
+            fbxNode.SetNodeAttribute(fbxMesh);
+            fbxNode.SetShadingMode(FbxNode.EShadingMode.eWireFrame);
             return true;
         }
 
@@ -960,27 +1030,29 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Export GameObject as a skinned mesh with material, bones, a skin and, a bind pose.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private bool ExportSkinnedMesh (GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
+        private bool ExportSkinnedMesh(GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(!unityGo || fbxNode == null)
+            if (!unityGo || fbxNode == null)
             {
                 return false;
             }
 
             SkinnedMeshRenderer unitySkin
-            = unityGo.GetComponent<SkinnedMeshRenderer> ();
+                = unityGo.GetComponent<SkinnedMeshRenderer>();
 
-            if (unitySkin == null) {
+            if (unitySkin == null)
+            {
                 return false;
             }
 
             var mesh = unitySkin.sharedMesh;
-            if (!mesh) {
+            if (!mesh)
+            {
                 return false;
             }
 
             if (Verbose)
-                Debug.Log (string.Format ("exporting {0} {1}", "Skin", fbxNode.GetName ()));
+                Debug.Log(string.Format("exporting {0} {1}", "Skin", fbxNode.GetName()));
 
 
             var meshInfo = new MeshInfo(unitySkin.sharedMesh, unitySkin.sharedMaterials);
@@ -998,12 +1070,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             Dictionary<SkinnedMeshRenderer, Transform[]> skinnedMeshToBonesMap;
             // export skeleton
-            if (ExportSkeleton (unitySkin, fbxScene, out skinnedMeshToBonesMap)) {
+            if (ExportSkeleton(unitySkin, fbxScene, out skinnedMeshToBonesMap))
+            {
                 // bind mesh to skeleton
-                ExportSkin (unitySkin, meshInfo, fbxScene, fbxMesh, fbxNode);
+                ExportSkin(unitySkin, meshInfo, fbxScene, fbxMesh, fbxNode);
 
                 // add bind pose
-                ExportBindPose (unitySkin, fbxNode, fbxScene, skinnedMeshToBonesMap);
+                ExportBindPose(unitySkin, fbxNode, fbxScene, skinnedMeshToBonesMap);
 
                 // now that the skin and bindpose are set, make sure that each of the bones
                 // is set to its original position
@@ -1062,7 +1135,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // it will be present in the boneToBindPose dictionary,
             // simply return this bindpose.
             Matrix4x4 bindPose;
-            if(boneToBindPose.TryGetValue(unityBone, out bindPose))
+            if (boneToBindPose.TryGetValue(unityBone, out bindPose))
             {
                 return bindPose;
             }
@@ -1083,7 +1156,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // If this is the rootbone of the mesh or an object without a parent, use the global matrix relative to the skinned mesh
             // as the bindpose.
-            if(unityBone == skinnedMesh.rootBone || unityBone.parent == null)
+            if (unityBone == skinnedMesh.rootBone || unityBone.parent == null)
             {
                 // there is no bone above this object with a bindpose, calculate bindpose relative to skinned mesh
                 bindPose = (unityBone.worldToLocalMatrix * skinnedMesh.transform.localToWorldMatrix);
@@ -1118,24 +1191,28 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// bones and bind poses.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private bool ExportSkeleton (SkinnedMeshRenderer skinnedMesh, FbxScene fbxScene, out Dictionary<SkinnedMeshRenderer, Transform[]> skinnedMeshToBonesMap)
+        private bool ExportSkeleton(SkinnedMeshRenderer skinnedMesh, FbxScene fbxScene, out Dictionary<SkinnedMeshRenderer, Transform[]> skinnedMeshToBonesMap)
         {
-            skinnedMeshToBonesMap = new Dictionary<SkinnedMeshRenderer, Transform[]> ();
+            skinnedMeshToBonesMap = new Dictionary<SkinnedMeshRenderer, Transform[]>();
 
-            if (!skinnedMesh) {
+            if (!skinnedMesh)
+            {
                 return false;
             }
             var bones = skinnedMesh.bones;
-            if (bones == null || bones.Length == 0) {
+            if (bones == null || bones.Length == 0)
+            {
                 return false;
             }
             var mesh = skinnedMesh.sharedMesh;
-            if (!mesh) {
+            if (!mesh)
+            {
                 return false;
             }
 
             var bindPoses = mesh.bindposes;
-            if (bindPoses == null || bindPoses.Length != bones.Length) {
+            if (bindPoses == null || bindPoses.Length != bones.Length)
+            {
                 return false;
             }
 
@@ -1145,8 +1222,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // Step 0: map transform to index so we can look up index by bone.
             Dictionary<Transform, int> index = new Dictionary<Transform, int>();
-            for (int boneIndex = 0; boneIndex < bones.Length; boneIndex++) {
-                Transform unityBoneTransform = bones [boneIndex];
+            for (int boneIndex = 0; boneIndex < bones.Length; boneIndex++)
+            {
+                Transform unityBoneTransform = bones[boneIndex];
 
                 // ignore null bones
                 if (unityBoneTransform != null)
@@ -1155,11 +1233,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
 
-            skinnedMeshToBonesMap.Add (skinnedMesh, bones);
+            skinnedMeshToBonesMap.Add(skinnedMesh, bones);
 
             // Step 1: Set transforms
-            var boneInfo = new SkinnedMeshBoneInfo (skinnedMesh, index);
-            foreach (var bone in bones) {
+            var boneInfo = new SkinnedMeshBoneInfo(skinnedMesh, index);
+            foreach (var bone in bones)
+            {
                 // ignore null bones
                 if (bone != null)
                 {
@@ -1173,18 +1252,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Export binding of mesh to skeleton
         /// </summary>
-        private bool ExportSkin (SkinnedMeshRenderer skinnedMesh, 
-                                    MeshInfo meshInfo, FbxScene fbxScene, FbxMesh fbxMesh,
-                                    FbxNode fbxRootNode)
+        private bool ExportSkin(SkinnedMeshRenderer skinnedMesh,
+            MeshInfo meshInfo, FbxScene fbxScene, FbxMesh fbxMesh,
+            FbxNode fbxRootNode)
         {
-            FbxSkin fbxSkin = FbxSkin.Create (fbxScene, (skinnedMesh.name + SkinPrefix));
+            FbxSkin fbxSkin = FbxSkin.Create(fbxScene, (skinnedMesh.name + SkinPrefix));
 
-            FbxAMatrix fbxMeshMatrix = fbxRootNode.EvaluateGlobalTransform ();
+            FbxAMatrix fbxMeshMatrix = fbxRootNode.EvaluateGlobalTransform();
 
             // keep track of the bone index -> fbx cluster mapping, so that we can add the bone weights afterwards
-            Dictionary<int, FbxCluster> boneCluster = new Dictionary<int, FbxCluster> ();
+            Dictionary<int, FbxCluster> boneCluster = new Dictionary<int, FbxCluster>();
 
-            for(int i = 0; i < skinnedMesh.bones.Length; i++) {
+            for (int i = 0; i < skinnedMesh.bones.Length; i++)
+            {
                 // ignore null bones
                 if (skinnedMesh.bones[i] != null)
                 {
@@ -1213,7 +1293,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             SetVertexWeights(meshInfo, boneCluster);
 
             // Add the skin to the mesh after the clusters have been added
-            fbxMesh.AddDeformer (fbxSkin);
+            fbxMesh.AddDeformer(fbxSkin);
 
             return true;
         }
@@ -1221,7 +1301,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// set vertex weights in cluster
         /// </summary>
-        private void SetVertexWeights (MeshInfo meshInfo, Dictionary<int, FbxCluster> boneIndexToCluster)
+        private void SetVertexWeights(MeshInfo meshInfo, Dictionary<int, FbxCluster> boneIndexToCluster)
         {
             var mesh = meshInfo.mesh;
             // Get the number of bone weights per vertex
@@ -1290,8 +1370,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Export bind pose of mesh to skeleton
         /// </summary>
-        private bool ExportBindPose (SkinnedMeshRenderer skinnedMesh, FbxNode fbxMeshNode,
-                                FbxScene fbxScene, Dictionary<SkinnedMeshRenderer, Transform[]> skinnedMeshToBonesMap)
+        private bool ExportBindPose(SkinnedMeshRenderer skinnedMesh, FbxNode fbxMeshNode,
+            FbxScene fbxScene, Dictionary<SkinnedMeshRenderer, Transform[]> skinnedMeshToBonesMap)
         {
             if (fbxMeshNode == null || skinnedMeshToBonesMap == null || fbxScene == null)
             {
@@ -1301,14 +1381,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
             FbxPose fbxPose = FbxPose.Create(fbxScene, fbxMeshNode.GetName());
 
             // set as bind pose
-            fbxPose.SetIsBindPose (true);
+            fbxPose.SetIsBindPose(true);
 
             // assume each bone node has one weighted vertex cluster
             Transform[] bones;
-            if (!skinnedMeshToBonesMap.TryGetValue (skinnedMesh, out bones)) {
+            if (!skinnedMeshToBonesMap.TryGetValue(skinnedMesh, out bones))
+            {
                 return false;
             }
-            for (int i = 0; i < bones.Length; i++) {
+            for (int i = 0; i < bones.Length; i++)
+            {
                 // ignore null bones
                 if (bones[i] != null)
                 {
@@ -1330,14 +1412,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
 
-            fbxPose.Add (fbxMeshNode, new FbxMatrix (fbxMeshNode.EvaluateGlobalTransform ()));
+            fbxPose.Add(fbxMeshNode, new FbxMatrix(fbxMeshNode.EvaluateGlobalTransform()));
 
             // add the pose to the scene
-            fbxScene.AddPose (fbxPose);
+            fbxScene.AddPose(fbxPose);
 
             return true;
         }
-        
+
         internal static FbxDouble3 ToFbxDouble3(Vector3 v)
         {
             return new FbxDouble3(v.x, v.y, v.z);
@@ -1366,19 +1448,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns>a quaternion</returns>
         internal static FbxQuaternion EulerToQuaternionXYZ(FbxVector4 euler)
         {
-            FbxAMatrix m = new FbxAMatrix ();
-            m.SetR (euler);
-            return m.GetQ ();
+            FbxAMatrix m = new FbxAMatrix();
+            m.SetR(euler);
+            return m.GetQ();
         }
 
         // get a fbxNode's global default position.
-        internal bool ExportTransform (UnityEngine.Transform unityTransform, FbxNode fbxNode, Vector3 newCenter, TransformExportType exportType)
+        internal bool ExportTransform(UnityEngine.Transform unityTransform, FbxNode fbxNode, Vector3 newCenter, TransformExportType exportType)
         {
             UnityEngine.Vector3 unityTranslate;
             FbxDouble3 fbxRotate;
             UnityEngine.Vector3 unityScale;
 
-            switch (exportType) {
+            switch (exportType)
+            {
                 case TransformExportType.Reset:
                     unityTranslate = Vector3.zero;
                     fbxRotate = new FbxDouble3(0);
@@ -1398,28 +1481,28 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // Transfer transform data from Unity to Fbx
             var fbxTranslate = ConvertToFbxVector4(unityTranslate, UnitScaleFactor);
-            var fbxScale = new FbxDouble3 (unityScale.x, unityScale.y, unityScale.z);
+            var fbxScale = new FbxDouble3(unityScale.x, unityScale.y, unityScale.z);
 
             // Zero scale causes issues in 3ds Max (child of object with zero scale will end up with a much larger scale, e.g. >9000).
             // When exporting 0 scale from Maya, the FBX contains 1e-12 instead of 0,
             // which doesn't cause issues in Max. Do the same here.
-            if(fbxScale.X == 0)
+            if (fbxScale.X == 0)
             {
                 fbxScale.X = 1e-12;
             }
-            if(fbxScale.Y == 0)
+            if (fbxScale.Y == 0)
             {
                 fbxScale.Y = 1e-12;
             }
-            if(fbxScale.Z == 0)
+            if (fbxScale.Z == 0)
             {
                 fbxScale.Z = 1e-12;
             }
 
             // set the local position of fbxNode
-            fbxNode.LclTranslation.Set (new FbxDouble3(fbxTranslate.X, fbxTranslate.Y, fbxTranslate.Z));
-            fbxNode.LclRotation.Set (fbxRotate);
-            fbxNode.LclScaling.Set (fbxScale);
+            fbxNode.LclTranslation.Set(new FbxDouble3(fbxTranslate.X, fbxTranslate.Y, fbxTranslate.Z));
+            fbxNode.LclRotation.Set(fbxRotate);
+            fbxNode.LclScaling.Set(fbxScale);
 
             return true;
         }
@@ -1439,7 +1522,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             FbxMesh fbxMesh = null;
             // store the shared mesh of the game object
             Mesh unityGoMesh = null;
-            
+
             // get the mesh of the game object
             if (unityGo.TryGetComponent<MeshFilter>(out MeshFilter meshFilter))
             {
@@ -1455,9 +1538,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 if (Verbose)
                 {
-                    Debug.Log (string.Format ("exporting instance {0}", unityGo.name));
+                    Debug.Log(string.Format("exporting instance {0}", unityGo.name));
                 }
-                
+
                 fbxMesh = node.GetMesh();
             }
             // unique mesh, so save it to find future duplicates
@@ -1480,7 +1563,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Autodesk.Fbx.FbxSurfaceMaterial newMaterial = null;
             if (materials != null)
             {
-                foreach (var mat in materials) {
+                foreach (var mat in materials)
+                {
                     if (mat != null && MaterialMap.TryGetValue(mat.GetInstanceID(), out newMaterial))
                     {
                         fbxNode.AddMaterial(newMaterial);
@@ -1494,8 +1578,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             // set the fbxNode containing the mesh
-            fbxNode.SetNodeAttribute (fbxMesh);
-            fbxNode.SetShadingMode (FbxNode.EShadingMode.eWireFrame);
+            fbxNode.SetNodeAttribute(fbxMesh);
+            fbxNode.SetShadingMode(FbxNode.EShadingMode.eWireFrame);
 
             return true;
         }
@@ -1503,34 +1587,36 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Exports camera component
         /// </summary>
-        private bool ExportCamera (GameObject unityGO, FbxScene fbxScene, FbxNode fbxNode)
+        private bool ExportCamera(GameObject unityGO, FbxScene fbxScene, FbxNode fbxNode)
         {
             if (!unityGO || fbxScene == null || fbxNode == null)
             {
                 return false;
             }
 
-            Camera unityCamera = unityGO.GetComponent<Camera> ();
-            if (unityCamera == null) {
+            Camera unityCamera = unityGO.GetComponent<Camera>();
+            if (unityCamera == null)
+            {
                 return false;
             }
 
-            FbxCamera fbxCamera = FbxCamera.Create (fbxScene.GetFbxManager(), unityCamera.name);
-            if (fbxCamera == null) {
+            FbxCamera fbxCamera = FbxCamera.Create(fbxScene.GetFbxManager(), unityCamera.name);
+            if (fbxCamera == null)
+            {
                 return false;
             }
 
             CameraVisitor.ConfigureCamera(unityCamera, fbxCamera);
-                
-            fbxNode.SetNodeAttribute (fbxCamera);
+
+            fbxNode.SetNodeAttribute(fbxCamera);
 
             // set +90 post rotation to counteract for FBX camera's facing +X direction by default
-            fbxNode.SetPostRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(0,90,0));
+            fbxNode.SetPostRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(0, 90, 0));
             // have to set rotation active to true in order for post rotation to be applied
-            fbxNode.SetRotationActive (true);
+            fbxNode.SetRotationActive(true);
 
             // make the last camera exported the default camera
-            DefaultCamera = fbxNode.GetName ();
+            DefaultCamera = fbxNode.GetName();
 
             return true;
         }
@@ -1540,14 +1626,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Supported types: point, spot and directional
         /// Cookie => Gobo
         /// </summary>
-        private bool ExportLight (GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
+        private bool ExportLight(GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(!unityGo || fbxScene == null || fbxNode == null)
+            if (!unityGo || fbxScene == null || fbxNode == null)
             {
                 return false;
             }
 
-            Light unityLight = unityGo.GetComponent<Light> ();
+            Light unityLight = unityGo.GetComponent<Light>();
 
             if (unityLight == null)
                 return false;
@@ -1555,62 +1641,66 @@ namespace UnityEditor.Formats.Fbx.Exporter
             FbxLight.EType fbxLightType;
 
             // Is light type supported?
-            if (!MapLightType.TryGetValue (unityLight.type, out fbxLightType))
+            if (!MapLightType.TryGetValue(unityLight.type, out fbxLightType))
                 return false;
-                
-            FbxLight fbxLight = FbxLight.Create (fbxScene.GetFbxManager (), unityLight.name);
 
-            // Set the type of the light.      
+            FbxLight fbxLight = FbxLight.Create(fbxScene.GetFbxManager(), unityLight.name);
+
+            // Set the type of the light.
             fbxLight.LightType.Set(fbxLightType);
 
-            switch (unityLight.type) 
+            switch (unityLight.type)
             {
-            case LightType.Directional : {
+                case LightType.Directional:
+                {
                     break;
                 }
-            case LightType.Spot : {
+                case LightType.Spot:
+                {
                     // Set the angle of the light's spotlight cone in degrees.
                     fbxLight.InnerAngle.Set(unityLight.spotAngle);
                     fbxLight.OuterAngle.Set(unityLight.spotAngle);
                     break;
                 }
-            case LightType.Point : {
+                case LightType.Point:
+                {
                     break;
                 }
-            case LightType.Area : {
+                case LightType.Area:
+                {
                     // TODO: areaSize: The size of the area light by scaling the node XY
                     break;
                 }
             }
             // The color of the light.
             var unityLightColor = unityLight.color;
-            fbxLight.Color.Set (new FbxDouble3(unityLightColor.r, unityLightColor.g, unityLightColor.b));
+            fbxLight.Color.Set(new FbxDouble3(unityLightColor.r, unityLightColor.g, unityLightColor.b));
 
             // Set the Intensity of a light is multiplied with the Light color.
-            fbxLight.Intensity.Set (unityLight.intensity * UnitScaleFactor /*compensate for Maya scaling by system units*/ );
+            fbxLight.Intensity.Set(unityLight.intensity * UnitScaleFactor /*compensate for Maya scaling by system units*/);
 
             // Set the range of the light.
             // applies-to: Point & Spot
             // => FarAttenuationStart, FarAttenuationEnd
-            fbxLight.FarAttenuationStart.Set (0.01f /* none zero start */);
-            fbxLight.FarAttenuationEnd.Set(unityLight.range*UnitScaleFactor);
+            fbxLight.FarAttenuationStart.Set(0.01f /* none zero start */);
+            fbxLight.FarAttenuationEnd.Set(unityLight.range * UnitScaleFactor);
 
             // shadows           Set how this light casts shadows
             // applies-to: Point & Spot
             bool unityLightCastShadows = unityLight.shadows != LightShadows.None;
-            fbxLight.CastShadows.Set (unityLightCastShadows);
+            fbxLight.CastShadows.Set(unityLightCastShadows);
 
-            fbxNode.SetNodeAttribute (fbxLight);
+            fbxNode.SetNodeAttribute(fbxLight);
 
             // set +90 post rotation on x to counteract for FBX light's facing -Y direction by default
-            fbxNode.SetPostRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(90,0,0));
+            fbxNode.SetPostRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(90, 0, 0));
             // have to set rotation active to true in order for post rotation to be applied
-            fbxNode.SetRotationActive (true);
+            fbxNode.SetRotationActive(true);
 
             return true;
         }
 
-        private bool ExportCommonConstraintProperties<TUnityConstraint,TFbxConstraint>(TUnityConstraint uniConstraint, TFbxConstraint fbxConstraint, FbxNode fbxNode)
+        private bool ExportCommonConstraintProperties<TUnityConstraint, TFbxConstraint>(TUnityConstraint uniConstraint, TFbxConstraint fbxConstraint, FbxNode fbxNode)
             where TUnityConstraint : IConstraint where TFbxConstraint : FbxConstraint
         {
             fbxConstraint.Active.Set(uniConstraint.constraintActive);
@@ -1646,7 +1736,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private List<ExpConstraintSource> GetConstraintSources(IConstraint unityConstraint)
         {
-            if(unityConstraint == null)
+            if (unityConstraint == null)
             {
                 return null;
             }
@@ -1680,13 +1770,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private bool ExportPositionConstraint(IConstraint uniConstraint, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return false;
             }
 
             var uniPosConstraint = uniConstraint as PositionConstraint;
-            Debug.Assert (uniPosConstraint != null);
+            Debug.Assert(uniPosConstraint != null);
 
             FbxConstraintPosition fbxPosConstraint = FbxConstraintPosition.Create(fbxScene, fbxNode.GetName() + "_positionConstraint");
             fbxPosConstraint.SetConstrainedObject(fbxNode);
@@ -1711,7 +1801,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private bool ExportRotationConstraint(IConstraint uniConstraint, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return false;
             }
@@ -1745,7 +1835,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private bool ExportScaleConstraint(IConstraint uniConstraint, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return false;
             }
@@ -1778,7 +1868,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private bool ExportAimConstraint(IConstraint uniConstraint, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return false;
             }
@@ -1828,7 +1918,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     throw new System.NotImplementedException();
             }
             fbxAimConstraint.WorldUpType.Set((int)fbxWorldUpType);
-                
+
             var uniAimVector = ConvertToFbxVector4(uniAimConstraint.aimVector);
             fbxAimConstraint.AimVector.Set(ToFbxDouble3(uniAimVector));
             fbxAimConstraint.UpVector.Set(ToFbxDouble3(uniAimConstraint.upVector));
@@ -1843,7 +1933,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private bool ExportParentConstraint(IConstraint uniConstraint, FbxScene fbxScene, FbxNode fbxNode)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return false;
             }
@@ -1856,17 +1946,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
             var uniSources = GetConstraintSources(uniParentConstraint);
             var uniTranslationOffsets = uniParentConstraint.translationOffsets;
             var uniRotationOffsets = uniParentConstraint.rotationOffsets;
-            for(int i = 0; i < uniSources.Count; i++)
+            for (int i = 0; i < uniSources.Count; i++)
             {
                 var uniSource = uniSources[i];
                 var uniTranslationOffset = uniTranslationOffsets[i];
                 var uniRotationOffset = uniRotationOffsets[i];
 
                 fbxParentConstraint.AddConstraintSource(uniSource.node, uniSource.weight);
-                    
+
                 var fbxTranslationOffset = ConvertToFbxVector4(uniTranslationOffset, UnitScaleFactor);
                 fbxParentConstraint.SetTranslationOffset(uniSource.node, fbxTranslationOffset);
-                    
+
                 var fbxRotationOffset = ConvertToFbxVector4(uniRotationOffset);
                 fbxParentConstraint.SetRotationOffset(uniSource.node, fbxRotationOffset);
             }
@@ -1896,7 +1986,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private delegate bool ExportConstraintDelegate(IConstraint c , FbxScene fs, FbxNode fn);
 
-        private bool ExportConstraints (GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
+        private bool ExportConstraints(GameObject unityGo, FbxScene fbxScene, FbxNode fbxNode)
         {
             if (!unityGo)
             {
@@ -1915,7 +2005,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // check if GameObject has one of the 5 supported constraints: aim, parent, position, rotation, scale
             var uniConstraints = unityGo.GetComponents<IConstraint>();
 
-            foreach(var uniConstraint in uniConstraints)
+            foreach (var uniConstraint in uniConstraints)
             {
                 var uniConstraintType = uniConstraint.GetType();
                 ExportConstraintDelegate constraintDelegate;
@@ -1937,29 +2027,30 @@ namespace UnityEditor.Formats.Fbx.Exporter
         internal static HashSet<float> GetSampleTimes(AnimationCurve[] animCurves, double sampleRate)
         {
             var keyTimes = new HashSet<float>();
-            double fs = 1.0/sampleRate;
+            double fs = 1.0 / sampleRate;
 
             double firstTime = double.MaxValue, lastTime = double.MinValue;
 
             foreach (var ac in animCurves)
             {
-                if (ac==null || ac.length<=0) continue;
+                if (ac == null || ac.length <= 0) continue;
 
                 firstTime = System.Math.Min(firstTime, ac[0].time);
-                lastTime = System.Math.Max(lastTime, ac[ac.length-1].time);
+                lastTime = System.Math.Max(lastTime, ac[ac.length - 1].time);
             }
 
             // if these values didn't get set there were no valid anim curves,
             // so don't return any keys
-            if(firstTime == double.MaxValue || lastTime == double.MinValue)
+            if (firstTime == double.MaxValue || lastTime == double.MinValue)
             {
                 return keyTimes;
             }
 
             int firstframe = (int)System.Math.Floor(firstTime * sampleRate);
             int lastframe = (int)System.Math.Ceiling(lastTime * sampleRate);
-            for (int i = firstframe; i <= lastframe; i++) {
-                keyTimes.Add ((float)(i * fs));
+            for (int i = firstframe; i <= lastframe; i++)
+            {
+                keyTimes.Add((float)(i * fs));
             }
 
             return keyTimes;
@@ -1975,30 +2066,30 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             foreach (var ac in animCurves)
             {
-                if (ac!=null) foreach(var key in ac.keys) { keyTimes.Add(key.time); }
+                if (ac != null) foreach (var key in ac.keys) { keyTimes.Add(key.time); }
             }
 
             return keyTimes;
         }
 
         /// <summary>
-        /// Export animation curve key frames with key tangents 
+        /// Export animation curve key frames with key tangents
         /// NOTE : This is a work in progress (WIP). We only export the key time and value on
         /// a Cubic curve using the default tangents.
         /// </summary>
-        internal static void ExportAnimationKeys (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve, 
+        internal static void ExportAnimationKeys(AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve,
             UnityToMayaConvertSceneHelper convertSceneHelper)
         {
             // Copy Unity AnimCurve to FBX AnimCurve.
             // NOTE: only cubic keys are supported by the FbxImporter
-            using (new FbxAnimCurveModifyHelper(new List<FbxAnimCurve>{fbxAnimCurve}))
+            using (new FbxAnimCurveModifyHelper(new List<FbxAnimCurve> {fbxAnimCurve}))
             {
-                for (int keyIndex = 0; keyIndex < uniAnimCurve.length; ++keyIndex) 
+                for (int keyIndex = 0; keyIndex < uniAnimCurve.length; ++keyIndex)
                 {
-                    var uniKeyFrame = uniAnimCurve [keyIndex];
-                    var fbxTime = FbxTime.FromSecondDouble (uniKeyFrame.time);
+                    var uniKeyFrame = uniAnimCurve[keyIndex];
+                    var fbxTime = FbxTime.FromSecondDouble(uniKeyFrame.time);
 
-                    int fbxKeyIndex = fbxAnimCurve.KeyAdd (fbxTime);
+                    int fbxKeyIndex = fbxAnimCurve.KeyAdd(fbxTime);
 
 
                     // configure tangents
@@ -2023,15 +2114,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
                             break;
                     }
 
-                    fbxAnimCurve.KeySet (fbxKeyIndex, 
-                        fbxTime, 
+                    fbxAnimCurve.KeySet(fbxKeyIndex,
+                        fbxTime,
                         convertSceneHelper.Convert(uniKeyFrame.value),
                         interpMode,
                         tanMode,
                         // value of right slope
                         convertSceneHelper.Convert(uniKeyFrame.outTangent),
                         // value of next left slope
-                        keyIndex < uniAnimCurve.length -1 ? convertSceneHelper.Convert(uniAnimCurve[keyIndex+1].inTangent) : 0,
+                        keyIndex < uniAnimCurve.length - 1 ? convertSceneHelper.Convert(uniAnimCurve[keyIndex + 1].inTangent) : 0,
                         FbxAnimCurveDef.EWeightedMode.eWeightedAll,
                         // weight for right slope
                         uniKeyFrame.outWeight,
@@ -2046,23 +2137,22 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Export animation curve key samples
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        internal void ExportAnimationSamples (AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve,
+        internal void ExportAnimationSamples(AnimationCurve uniAnimCurve, FbxAnimCurve fbxAnimCurve,
             double sampleRate,
             UnityToMayaConvertSceneHelper convertSceneHelper)
         {
-                
-            using (new FbxAnimCurveModifyHelper(new List<FbxAnimCurve>{fbxAnimCurve}))
+            using (new FbxAnimCurveModifyHelper(new List<FbxAnimCurve> {fbxAnimCurve}))
             {
-                foreach (var currSampleTime in GetSampleTimes(new AnimationCurve[]{uniAnimCurve}, sampleRate)) 
+                foreach (var currSampleTime in GetSampleTimes(new AnimationCurve[] {uniAnimCurve}, sampleRate))
                 {
                     float currSampleValue = uniAnimCurve.Evaluate((float)currSampleTime);
 
-                    var fbxTime = FbxTime.FromSecondDouble (currSampleTime);
+                    var fbxTime = FbxTime.FromSecondDouble(currSampleTime);
 
-                    int fbxKeyIndex = fbxAnimCurve.KeyAdd (fbxTime);
+                    int fbxKeyIndex = fbxAnimCurve.KeyAdd(fbxTime);
 
-                    fbxAnimCurve.KeySet (fbxKeyIndex, 
-                        fbxTime, 
+                    fbxAnimCurve.KeySet(fbxKeyIndex,
+                        fbxTime,
                         convertSceneHelper.Convert(currSampleValue)
                     );
                 }
@@ -2116,7 +2206,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     if (targetChannel != null)
                     {
                         return targetChannel;
-                    }    
+                    }
                 }
             }
             return null;
@@ -2124,7 +2214,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private FbxProperty GetFbxProperty(FbxNode fbxNode, string fbxPropertyName, System.Type uniPropertyType, string uniPropertyName)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return null;
             }
@@ -2133,7 +2223,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // check this first because both constraints and FbxNodes can contain a RotationOffset property,
             // but only the constraint one is animatable.
             var fbxConstraint = GetFbxConstraint(fbxNode, uniPropertyType);
-            if(fbxConstraint != null)
+            if (fbxConstraint != null)
             {
                 var prop = fbxConstraint.FindProperty(fbxPropertyName, false);
                 if (prop.IsValid())
@@ -2174,35 +2264,38 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// quaternion to euler and various other stuff.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private void ExportAnimationCurve (FbxNode fbxNode,
-                                                AnimationCurve uniAnimCurve,
-                                                float frameRate,
-                                                string uniPropertyName,
-                                                System.Type uniPropertyType,
-                                                FbxAnimLayer fbxAnimLayer)
+        private void ExportAnimationCurve(FbxNode fbxNode,
+            AnimationCurve uniAnimCurve,
+            float frameRate,
+            string uniPropertyName,
+            System.Type uniPropertyType,
+            FbxAnimLayer fbxAnimLayer)
         {
-            if(fbxNode == null)
+            if (fbxNode == null)
             {
                 return;
             }
 
-            if (Verbose) {
-                Debug.Log ("Exporting animation for " + fbxNode.GetName() + " (" + uniPropertyName + ")");
+            if (Verbose)
+            {
+                Debug.Log("Exporting animation for " + fbxNode.GetName() + " (" + uniPropertyName + ")");
             }
 
             var fbxConstraint = GetFbxConstraint(fbxNode, uniPropertyType);
             FbxPropertyChannelPair[] fbxPropertyChannelPairs;
-            if (!FbxPropertyChannelPair.TryGetValue (uniPropertyName, out fbxPropertyChannelPairs, fbxConstraint)) {
+            if (!FbxPropertyChannelPair.TryGetValue(uniPropertyName, out fbxPropertyChannelPairs, fbxConstraint))
+            {
                 Debug.LogWarning(string.Format("no mapping from Unity '{0}' to fbx property", uniPropertyName));
                 return;
             }
 
-            foreach (var fbxPropertyChannelPair in fbxPropertyChannelPairs) {
+            foreach (var fbxPropertyChannelPair in fbxPropertyChannelPairs)
+            {
                 // map unity property name to fbx property
                 var fbxProperty = GetFbxProperty(fbxNode, fbxPropertyChannelPair.Property, uniPropertyType, uniPropertyName);
-                if (!fbxProperty.IsValid ()) 
+                if (!fbxProperty.IsValid())
                 {
-                    Debug.LogError (string.Format ("no fbx property {0} found on {1} node or nodeAttribute ", fbxPropertyChannelPair.Property, fbxNode.GetName ()));
+                    Debug.LogError(string.Format("no fbx property {0} found on {1} node or nodeAttribute ", fbxPropertyChannelPair.Property, fbxNode.GetName()));
                     return;
                 }
                 if (!fbxProperty.GetFlag(FbxPropertyFlags.EFlags.eAnimatable))
@@ -2211,21 +2304,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
 
                 // Create the AnimCurve on the channel
-                FbxAnimCurve fbxAnimCurve = fbxProperty.GetCurve (fbxAnimLayer, fbxPropertyChannelPair.Channel, true);
-                if(fbxAnimCurve == null)
+                FbxAnimCurve fbxAnimCurve = fbxProperty.GetCurve(fbxAnimLayer, fbxPropertyChannelPair.Channel, true);
+                if (fbxAnimCurve == null)
                 {
                     return;
                 }
 
                 // create a convert scene helper so that we can convert from Unity to Maya
-                // AxisSystem (LeftHanded to RightHanded) and FBX's default units 
+                // AxisSystem (LeftHanded to RightHanded) and FBX's default units
                 // (Meters to Centimetres)
-                var convertSceneHelper = new UnityToMayaConvertSceneHelper (uniPropertyName, fbxNode);
-                
-                if (ModelExporter.ExportSettings.BakeAnimationProperty) {
-                    ExportAnimationSamples (uniAnimCurve, fbxAnimCurve, frameRate, convertSceneHelper);
-                } else {
-                    ExportAnimationKeys (uniAnimCurve, fbxAnimCurve, convertSceneHelper);
+                var convertSceneHelper = new UnityToMayaConvertSceneHelper(uniPropertyName, fbxNode);
+
+                if (ModelExporter.ExportSettings.BakeAnimationProperty)
+                {
+                    ExportAnimationSamples(uniAnimCurve, fbxAnimCurve, frameRate, convertSceneHelper);
+                }
+                else
+                {
+                    ExportAnimationKeys(uniAnimCurve, fbxAnimCurve, convertSceneHelper);
                 }
             }
         }
@@ -2248,7 +2344,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 bool partT = uniPropertyName.StartsWith("m_LocalPosition.", cc) || uniPropertyName.StartsWith("m_TranslationOffset", cc);
 
                 convertDistance |= partT;
-                convertDistance |= uniPropertyName.StartsWith ("m_Intensity", cc);
+                convertDistance |= uniPropertyName.StartsWith("m_Intensity", cc);
                 convertDistance |= uniPropertyName.ToLower().EndsWith("weight", cc);
                 convertLensShiftX |= uniPropertyName.StartsWith("m_LensShift.x", cc);
                 convertLensShiftY |= uniPropertyName.StartsWith("m_LensShift.y", cc);
@@ -2274,7 +2370,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 float convertedValue = value;
                 if (convertLensShiftX || convertLensShiftY)
                 {
-                    convertedValue = Mathf.Clamp(Mathf.Abs(value), 0f, 1f)*Mathf.Sign(value);
+                    convertedValue = Mathf.Clamp(Mathf.Abs(value), 0f, 1f) * Mathf.Sign(value);
                 }
                 if (camera != null)
                 {
@@ -2292,126 +2388,138 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 // meters to centimetres conversion
                 return unitScaleFactor * convertedValue;
             }
-
         }
 
         /// <summary>
         /// Export an AnimationClip as a single take
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private void ExportAnimationClip (AnimationClip uniAnimClip, GameObject uniRoot, FbxScene fbxScene)
+        private void ExportAnimationClip(AnimationClip uniAnimClip, GameObject uniRoot, FbxScene fbxScene)
         {
             if (!uniAnimClip || !uniRoot || fbxScene == null) return;
 
             if (Verbose)
-                Debug.Log (string.Format ("Exporting animation clip ({1}) for {0}", uniRoot.name, uniAnimClip.name));
+                Debug.Log(string.Format("Exporting animation clip ({1}) for {0}", uniRoot.name, uniAnimClip.name));
 
             // setup anim stack
-            FbxAnimStack fbxAnimStack = FbxAnimStack.Create (fbxScene, uniAnimClip.name);
-            fbxAnimStack.Description.Set ("Animation Take: " + uniAnimClip.name);
+            FbxAnimStack fbxAnimStack = FbxAnimStack.Create(fbxScene, uniAnimClip.name);
+            fbxAnimStack.Description.Set("Animation Take: " + uniAnimClip.name);
 
             // add one mandatory animation layer
-            FbxAnimLayer fbxAnimLayer = FbxAnimLayer.Create (fbxScene, "Animation Base Layer");
-            fbxAnimStack.AddMember (fbxAnimLayer);
+            FbxAnimLayer fbxAnimLayer = FbxAnimLayer.Create(fbxScene, "Animation Base Layer");
+            fbxAnimStack.AddMember(fbxAnimLayer);
 
             // Set up the FPS so our frame-relative math later works out
             // Custom frame rate isn't really supported in FBX SDK (there's
             // a bug), so try hard to find the nearest time mode.
             FbxTime.EMode timeMode = FbxTime.EMode.eCustom;
             double precision = 1e-6;
-            while (timeMode == FbxTime.EMode.eCustom && precision < 1000) {
-                timeMode = FbxTime.ConvertFrameRateToTimeMode (uniAnimClip.frameRate, precision);
+            while (timeMode == FbxTime.EMode.eCustom && precision < 1000)
+            {
+                timeMode = FbxTime.ConvertFrameRateToTimeMode(uniAnimClip.frameRate, precision);
                 precision *= 10;
             }
-            if (timeMode == FbxTime.EMode.eCustom) {
+            if (timeMode == FbxTime.EMode.eCustom)
+            {
                 timeMode = FbxTime.EMode.eFrames30;
             }
 
-            fbxScene.GetGlobalSettings ().SetTimeMode (timeMode);
+            fbxScene.GetGlobalSettings().SetTimeMode(timeMode);
 
             // set time correctly
-            var fbxStartTime = FbxTime.FromSecondDouble (0);
-            var fbxStopTime = FbxTime.FromSecondDouble (uniAnimClip.length);
+            var fbxStartTime = FbxTime.FromSecondDouble(0);
+            var fbxStopTime = FbxTime.FromSecondDouble(uniAnimClip.length);
 
-            fbxAnimStack.SetLocalTimeSpan (new FbxTimeSpan (fbxStartTime, fbxStopTime));
+            fbxAnimStack.SetLocalTimeSpan(new FbxTimeSpan(fbxStartTime, fbxStopTime));
 
-            var unityCurves = new Dictionary<GameObject, List<UnityCurve>> ();
+            var unityCurves = new Dictionary<GameObject, List<UnityCurve>>();
 
             // extract and store all necessary information from the curve bindings, namely the animation curves
             // and their corresponding property names for each GameObject.
-            foreach (EditorCurveBinding uniCurveBinding in AnimationUtility.GetCurveBindings (uniAnimClip)) {
-                Object uniObj = AnimationUtility.GetAnimatedObject (uniRoot, uniCurveBinding);
-                if (!uniObj) {
+            foreach (EditorCurveBinding uniCurveBinding in AnimationUtility.GetCurveBindings(uniAnimClip))
+            {
+                Object uniObj = AnimationUtility.GetAnimatedObject(uniRoot, uniCurveBinding);
+                if (!uniObj)
+                {
                     continue;
                 }
 
-                AnimationCurve uniAnimCurve = AnimationUtility.GetEditorCurve (uniAnimClip, uniCurveBinding);
-                if (uniAnimCurve == null) {
+                AnimationCurve uniAnimCurve = AnimationUtility.GetEditorCurve(uniAnimClip, uniCurveBinding);
+                if (uniAnimCurve == null)
+                {
                     continue;
                 }
 
-                var uniGO = GetGameObject (uniObj);
-                // Check if the GameObject has an FBX node to the animation. It might be null because the LOD selected doesn't match the one on the gameobject. 
-                if (!uniGO || MapUnityObjectToFbxNode.ContainsKey(uniGO) == false) {
+                var uniGO = GetGameObject(uniObj);
+                // Check if the GameObject has an FBX node to the animation. It might be null because the LOD selected doesn't match the one on the gameobject.
+                if (!uniGO || MapUnityObjectToFbxNode.ContainsKey(uniGO) == false)
+                {
                     continue;
                 }
 
-                if (unityCurves.ContainsKey (uniGO)) {
-                    unityCurves [uniGO].Add (new UnityCurve(uniCurveBinding.propertyName, uniAnimCurve, uniCurveBinding.type));
+                if (unityCurves.ContainsKey(uniGO))
+                {
+                    unityCurves[uniGO].Add(new UnityCurve(uniCurveBinding.propertyName, uniAnimCurve, uniCurveBinding.type));
                     continue;
                 }
-                unityCurves.Add (uniGO, new List<UnityCurve> (){ new UnityCurve(uniCurveBinding.propertyName, uniAnimCurve, uniCurveBinding.type) });
+                unityCurves.Add(uniGO, new List<UnityCurve>(){ new UnityCurve(uniCurveBinding.propertyName, uniAnimCurve, uniCurveBinding.type) });
             }
 
             // transfer root motion
             var animSource = ExportOptions.AnimationSource;
             var animDest = ExportOptions.AnimationDest;
-            if (animSource && animDest && animSource != animDest) {
+            if (animSource && animDest && animSource != animDest)
+            {
                 // list of all transforms between source and dest, including source and dest
-                var transformsFromSourceToDest = new List<Transform> ();
+                var transformsFromSourceToDest = new List<Transform>();
                 var curr = animDest;
-                while (curr != animSource) {
-                    transformsFromSourceToDest.Add (curr);
+                while (curr != animSource)
+                {
+                    transformsFromSourceToDest.Add(curr);
                     curr = curr.parent;
                 }
-                transformsFromSourceToDest.Add (animSource);
-                transformsFromSourceToDest.Reverse ();
+                transformsFromSourceToDest.Add(animSource);
+                transformsFromSourceToDest.Reverse();
 
                 // while there are 2 transforms in the list, transfer the animation from the
                 // first to the next transform.
                 // Then remove the first transform from the list.
-                while (transformsFromSourceToDest.Count >= 2) {
-                    var source = transformsFromSourceToDest [0];
-                    transformsFromSourceToDest.RemoveAt (0);
-                    var dest = transformsFromSourceToDest [0];
+                while (transformsFromSourceToDest.Count >= 2)
+                {
+                    var source = transformsFromSourceToDest[0];
+                    transformsFromSourceToDest.RemoveAt(0);
+                    var dest = transformsFromSourceToDest[0];
 
-                    TransferMotion (source, dest, uniAnimClip.frameRate, ref unityCurves);
+                    TransferMotion(source, dest, uniAnimClip.frameRate, ref unityCurves);
                 }
             }
 
             /* The major difficulty: Unity uses quaternions for rotation
                 * (which is how it should be) but FBX uses Euler angles. So we
                 * need to gather up the list of transform curves per object.
-                * 
+                *
                 * For euler angles, Unity uses ZXY rotation order while Maya uses XYZ.
                 * Maya doesn't import files with ZXY rotation correctly, so have to convert to XYZ.
                 * Need all 3 curves in order to convert.
-                * 
+                *
                 * Also, in both cases, prerotation has to be removed from the animated rotation if
                 * there are bones being exported.
                 */
             var rotations = new Dictionary<GameObject, RotationCurve>();
 
             // export the animation curves for each GameObject that has animation
-            foreach (var kvp in unityCurves) {
+            foreach (var kvp in unityCurves)
+            {
                 var uniGO = kvp.Key;
-                foreach (var uniCurve in kvp.Value) {
+                foreach (var uniCurve in kvp.Value)
+                {
                     var propertyName = uniCurve.propertyName;
                     var uniAnimCurve = uniCurve.uniAnimCurve;
 
                     // Do not create the curves if the component is a SkinnedMeshRenderer and if the option in FBX Export settings is toggled on.
-                    if (!ExportOptions.AnimateSkinnedMesh && (uniGO.GetComponent<SkinnedMeshRenderer> () != null)) {
-                        continue;    
+                    if (!ExportOptions.AnimateSkinnedMesh && (uniGO.GetComponent<SkinnedMeshRenderer>() != null))
+                    {
+                        continue;
                     }
 
                     FbxNode fbxNode;
@@ -2421,46 +2529,49 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         continue;
                     }
 
-                    int index = QuaternionCurve.GetQuaternionIndex (propertyName);
-                    if (index >= 0) {
+                    int index = QuaternionCurve.GetQuaternionIndex(propertyName);
+                    if (index >= 0)
+                    {
                         // Rotation property; save it to convert quaternion -> euler later.
-                        RotationCurve rotCurve = GetRotationCurve<QuaternionCurve> (uniGO, uniAnimClip.frameRate, ref rotations);
-                        rotCurve.SetCurve (index, uniAnimCurve);
+                        RotationCurve rotCurve = GetRotationCurve<QuaternionCurve>(uniGO, uniAnimClip.frameRate, ref rotations);
+                        rotCurve.SetCurve(index, uniAnimCurve);
                         continue;
-                    } 
+                    }
 
                     // If this is an euler curve with a prerotation, then need to sample animations to remove the prerotation.
                     // Otherwise can export normally with tangents.
-                    index = EulerCurve.GetEulerIndex (propertyName);
-                    if (index >= 0 && 
+                    index = EulerCurve.GetEulerIndex(propertyName);
+                    if (index >= 0 &&
                         // still need to sample euler curves if baking is specified
                         (ModelExporter.ExportSettings.BakeAnimationProperty ||
-                        // also need to make sure to sample if there is a prerotation, as this is baked into the Unity curves
-                        fbxNode.GetPreRotation(FbxNode.EPivotSet.eSourcePivot).Distance(new FbxVector4()) > 0)) {
-
-                        RotationCurve rotCurve = GetRotationCurve<EulerCurve> (uniGO, uniAnimClip.frameRate, ref rotations);
-                        rotCurve.SetCurve (index, uniAnimCurve);
+                         // also need to make sure to sample if there is a prerotation, as this is baked into the Unity curves
+                         fbxNode.GetPreRotation(FbxNode.EPivotSet.eSourcePivot).Distance(new FbxVector4()) > 0))
+                    {
+                        RotationCurve rotCurve = GetRotationCurve<EulerCurve>(uniGO, uniAnimClip.frameRate, ref rotations);
+                        rotCurve.SetCurve(index, uniAnimCurve);
                         continue;
                     }
 
                     // simple property (e.g. intensity), export right away
-                    ExportAnimationCurve (fbxNode, uniAnimCurve, uniAnimClip.frameRate, 
+                    ExportAnimationCurve(fbxNode, uniAnimCurve, uniAnimClip.frameRate,
                         propertyName, uniCurve.propertyType,
                         fbxAnimLayer);
                 }
             }
 
-            // now export all the quaternion curves 
-            foreach (var kvp in rotations) {
+            // now export all the quaternion curves
+            foreach (var kvp in rotations)
+            {
                 var unityGo = kvp.Key;
                 var rot = kvp.Value;
 
                 FbxNode fbxNode;
-                if (!MapUnityObjectToFbxNode.TryGetValue (unityGo, out fbxNode)) {
-                    Debug.LogError (string.Format ("no FbxNode found for {0}", unityGo.name));
+                if (!MapUnityObjectToFbxNode.TryGetValue(unityGo, out fbxNode))
+                {
+                    Debug.LogError(string.Format("no FbxNode found for {0}", unityGo.name));
                     continue;
                 }
-                rot.Animate (unityGo.transform, fbxNode, fbxAnimLayer, Verbose);
+                rot.Animate(unityGo.transform, fbxNode, fbxAnimLayer, Verbose);
             }
         }
 
@@ -2473,42 +2584,49 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="sampleRate">Sample rate.</param>
         /// <param name="unityCurves">Unity curves.</param>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private void TransferMotion(Transform source, Transform dest, float sampleRate, ref Dictionary<GameObject, List<UnityCurve>> unityCurves){
+        private void TransferMotion(Transform source, Transform dest, float sampleRate, ref Dictionary<GameObject, List<UnityCurve>> unityCurves)
+        {
             // get sample times for curves in dest + source
             // at each sample time, evaluate all 18 transfom anim curves, creating 2 transform matrices
             // combine the matrices, get the new values, apply to the 9 new anim curves for dest
-            if (dest.parent != source) {
-                Debug.LogError ("dest must be a child of source");
+            if (dest.parent != source)
+            {
+                Debug.LogError("dest must be a child of source");
                 return;
             }
 
             List<UnityCurve> sourceUnityCurves;
-            if (!unityCurves.TryGetValue (source.gameObject, out sourceUnityCurves)) {
+            if (!unityCurves.TryGetValue(source.gameObject, out sourceUnityCurves))
+            {
                 return; // nothing to do, source has no animation
             }
 
             List<UnityCurve> destUnityCurves;
-            if (!unityCurves.TryGetValue (dest.gameObject, out destUnityCurves)) {
-                destUnityCurves = new List<UnityCurve> ();
+            if (!unityCurves.TryGetValue(dest.gameObject, out destUnityCurves))
+            {
+                destUnityCurves = new List<UnityCurve>();
             }
 
-            List<AnimationCurve> animCurves = new List<AnimationCurve> ();
-            foreach (var curve in sourceUnityCurves) {
+            List<AnimationCurve> animCurves = new List<AnimationCurve>();
+            foreach (var curve in sourceUnityCurves)
+            {
                 // TODO: check if curve is anim related
                 animCurves.Add(curve.uniAnimCurve);
             }
-            foreach (var curve in destUnityCurves) {
-                animCurves.Add (curve.uniAnimCurve);
+            foreach (var curve in destUnityCurves)
+            {
+                animCurves.Add(curve.uniAnimCurve);
             }
 
-            var sampleTimes = GetSampleTimes (animCurves.ToArray (), sampleRate);
+            var sampleTimes = GetSampleTimes(animCurves.ToArray(), sampleRate);
             // need to create 9 new UnityCurves, one for each property
             var posKeyFrames = new Keyframe[3][];
             var rotKeyFrames = new Keyframe[3][];
             var scaleKeyFrames = new Keyframe[3][];
 
-            for (int k = 0; k < posKeyFrames.Length; k++) {
-                posKeyFrames [k] = new Keyframe[sampleTimes.Count];
+            for (int k = 0; k < posKeyFrames.Length; k++)
+            {
+                posKeyFrames[k] = new Keyframe[sampleTimes.Count];
                 rotKeyFrames[k] = new Keyframe[sampleTimes.Count];
                 scaleKeyFrames[k] = new Keyframe[sampleTimes.Count];
             }
@@ -2524,24 +2642,25 @@ namespace UnityEditor.Formats.Fbx.Exporter
             //   dest' = (source')^-1 * source * dest
             int keyIndex = 0;
             var sourceStaticMatrixInverse = Matrix4x4.TRS(source.localPosition, source.localRotation, source.localScale).inverse;
-            foreach (var currSampleTime in sampleTimes) 
+            foreach (var currSampleTime in sampleTimes)
             {
-                var sourceLocalMatrix = GetTransformMatrix (currSampleTime, source, sourceUnityCurves);
-                var destLocalMatrix = GetTransformMatrix (currSampleTime, dest, destUnityCurves);
+                var sourceLocalMatrix = GetTransformMatrix(currSampleTime, source, sourceUnityCurves);
+                var destLocalMatrix = GetTransformMatrix(currSampleTime, dest, destUnityCurves);
 
                 var newLocalMatrix = sourceStaticMatrixInverse * sourceLocalMatrix * destLocalMatrix;
 
                 FbxVector4 translation, rotation, scale;
-                GetTRSFromMatrix (newLocalMatrix, out translation, out rotation, out scale);
+                GetTRSFromMatrix(newLocalMatrix, out translation, out rotation, out scale);
 
                 // get rotation directly from matrix, as otherwise causes issues
                 // with negative rotations.
                 var rot = newLocalMatrix.rotation.eulerAngles;
 
-                for (int k = 0; k < 3; k++) {
-                    posKeyFrames [k][keyIndex] = new Keyframe(currSampleTime, (float)translation [k]);
-                    rotKeyFrames [k][keyIndex] = new Keyframe(currSampleTime, rot [k]);
-                    scaleKeyFrames [k][keyIndex] = new Keyframe(currSampleTime, (float)scale [k]);
+                for (int k = 0; k < 3; k++)
+                {
+                    posKeyFrames[k][keyIndex] = new Keyframe(currSampleTime, (float)translation[k]);
+                    rotKeyFrames[k][keyIndex] = new Keyframe(currSampleTime, rot[k]);
+                    scaleKeyFrames[k][keyIndex] = new Keyframe(currSampleTime, (float)scale[k]);
                 }
                 keyIndex++;
             }
@@ -2552,128 +2671,145 @@ namespace UnityEditor.Formats.Fbx.Exporter
             string rotPropName = "localEulerAnglesRaw.";
             string scalePropName = "m_LocalScale.";
             var xyz = "xyz";
-            for (int k = 0; k < 3; k++) {
-                var posUniCurve = new UnityCurve ( posPropName + xyz[k], new AnimationCurve(posKeyFrames[k]), typeof(Transform));
-                newUnityCurves.Add (posUniCurve);
+            for (int k = 0; k < 3; k++)
+            {
+                var posUniCurve = new UnityCurve(posPropName + xyz[k], new AnimationCurve(posKeyFrames[k]), typeof(Transform));
+                newUnityCurves.Add(posUniCurve);
 
-                var rotUniCurve = new UnityCurve ( rotPropName + xyz[k], new AnimationCurve(rotKeyFrames[k]), typeof(Transform));
-                newUnityCurves.Add (rotUniCurve);
+                var rotUniCurve = new UnityCurve(rotPropName + xyz[k], new AnimationCurve(rotKeyFrames[k]), typeof(Transform));
+                newUnityCurves.Add(rotUniCurve);
 
-                var scaleUniCurve = new UnityCurve ( scalePropName + xyz[k], new AnimationCurve(scaleKeyFrames[k]), typeof(Transform));
-                newUnityCurves.Add (scaleUniCurve);
+                var scaleUniCurve = new UnityCurve(scalePropName + xyz[k], new AnimationCurve(scaleKeyFrames[k]), typeof(Transform));
+                newUnityCurves.Add(scaleUniCurve);
             }
 
             // remove old transform curves
-            RemoveTransformCurves (ref sourceUnityCurves);
-            RemoveTransformCurves (ref destUnityCurves);
+            RemoveTransformCurves(ref sourceUnityCurves);
+            RemoveTransformCurves(ref destUnityCurves);
 
-            unityCurves [source.gameObject] = sourceUnityCurves;
-            if (!unityCurves.ContainsKey(dest.gameObject)) {
-                unityCurves.Add (dest.gameObject, newUnityCurves);
+            unityCurves[source.gameObject] = sourceUnityCurves;
+            if (!unityCurves.ContainsKey(dest.gameObject))
+            {
+                unityCurves.Add(dest.gameObject, newUnityCurves);
                 return;
             }
-            unityCurves [dest.gameObject].AddRange(newUnityCurves);
-
+            unityCurves[dest.gameObject].AddRange(newUnityCurves);
         }
 
-
-        private void RemoveTransformCurves(ref List<UnityCurve> curves){
-            var transformCurves = new List<UnityCurve> ();
-            var transformPropNames = new string[]{"m_LocalPosition.", "m_LocalRotation", "localEulerAnglesRaw.", "m_LocalScale."};
-            foreach (var curve in curves) {
-                foreach (var prop in transformPropNames) {
-                    if (curve.propertyName.StartsWith (prop)) {
-                        transformCurves.Add (curve);
+        private void RemoveTransformCurves(ref List<UnityCurve> curves)
+        {
+            var transformCurves = new List<UnityCurve>();
+            var transformPropNames = new string[] {"m_LocalPosition.", "m_LocalRotation", "localEulerAnglesRaw.", "m_LocalScale."};
+            foreach (var curve in curves)
+            {
+                foreach (var prop in transformPropNames)
+                {
+                    if (curve.propertyName.StartsWith(prop))
+                    {
+                        transformCurves.Add(curve);
                         break;
                     }
                 }
             }
-            foreach (var curve in transformCurves) {
-                curves.Remove (curve);
+            foreach (var curve in transformCurves)
+            {
+                curves.Remove(curve);
             }
         }
 
-        private Matrix4x4 GetTransformMatrix(float currSampleTime, Transform orig, List<UnityCurve> unityCurves){
+        private Matrix4x4 GetTransformMatrix(float currSampleTime, Transform orig, List<UnityCurve> unityCurves)
+        {
             var sourcePos = orig.localPosition;
             var sourceRot = orig.localRotation;
             var sourceScale = orig.localScale;
 
-            foreach (var uniCurve in unityCurves) {
+            foreach (var uniCurve in unityCurves)
+            {
                 float currSampleValue = uniCurve.uniAnimCurve.Evaluate(currSampleTime);
                 string propName = uniCurve.propertyName;
                 // try position, scale, quat then euler
                 int temp = QuaternionCurve.GetQuaternionIndex(propName);
-                if (temp >= 0) {
-                    sourceRot [temp] = currSampleValue;
+                if (temp >= 0)
+                {
+                    sourceRot[temp] = currSampleValue;
                     continue;
                 }
-                temp = EulerCurve.GetEulerIndex (propName);
-                if (temp >= 0) {
+                temp = EulerCurve.GetEulerIndex(propName);
+                if (temp >= 0)
+                {
                     var euler = sourceRot.eulerAngles;
-                    euler [temp] = currSampleValue;
+                    euler[temp] = currSampleValue;
                     sourceRot.eulerAngles = euler;
                     continue;
                 }
-                temp = GetPositionIndex (propName);
-                if (temp >= 0) {
-                    sourcePos [temp] = currSampleValue;
+                temp = GetPositionIndex(propName);
+                if (temp >= 0)
+                {
+                    sourcePos[temp] = currSampleValue;
                     continue;
                 }
-                temp = GetScaleIndex (propName);
-                if (temp >= 0) {
-                    sourceScale [temp] = currSampleValue;
+                temp = GetScaleIndex(propName);
+                if (temp >= 0)
+                {
+                    sourceScale[temp] = currSampleValue;
                 }
             }
 
             sourceRot = Quaternion.Euler(sourceRot.eulerAngles.x, sourceRot.eulerAngles.y, sourceRot.eulerAngles.z);
-            return Matrix4x4.TRS(sourcePos, sourceRot, sourceScale); 
+            return Matrix4x4.TRS(sourcePos, sourceRot, sourceScale);
         }
 
-        internal struct UnityCurve {
+        internal struct UnityCurve
+        {
             public string propertyName;
             public AnimationCurve uniAnimCurve;
             public System.Type propertyType;
 
-            public UnityCurve(string propertyName, AnimationCurve uniAnimCurve, System.Type propertyType){
+            public UnityCurve(string propertyName, AnimationCurve uniAnimCurve, System.Type propertyType)
+            {
                 this.propertyName = propertyName;
                 this.uniAnimCurve = uniAnimCurve;
                 this.propertyType = propertyType;
             }
         }
 
-        private int GetPositionIndex(string uniPropertyName){
+        private int GetPositionIndex(string uniPropertyName)
+        {
             System.StringComparison ct = System.StringComparison.CurrentCulture;
-            bool isPositionComponent = uniPropertyName.StartsWith ("m_LocalPosition.", ct);
+            bool isPositionComponent = uniPropertyName.StartsWith("m_LocalPosition.", ct);
 
             if (!isPositionComponent) { return -1; }
 
-            switch (uniPropertyName [uniPropertyName.Length - 1]) {
-            case 'x':
-                return 0;
-            case 'y':
-                return 1;
-            case 'z':
-                return 2;
-            default:
-                return -1;
+            switch (uniPropertyName[uniPropertyName.Length - 1])
+            {
+                case 'x':
+                    return 0;
+                case 'y':
+                    return 1;
+                case 'z':
+                    return 2;
+                default:
+                    return -1;
             }
         }
 
-        private int GetScaleIndex(string uniPropertyName){
+        private int GetScaleIndex(string uniPropertyName)
+        {
             System.StringComparison ct = System.StringComparison.CurrentCulture;
-            bool isScaleComponent = uniPropertyName.StartsWith ("m_LocalScale.", ct);
+            bool isScaleComponent = uniPropertyName.StartsWith("m_LocalScale.", ct);
 
             if (!isScaleComponent) { return -1; }
 
-            switch (uniPropertyName [uniPropertyName.Length - 1]) {
-            case 'x':
-                return 0;
-            case 'y':
-                return 1;
-            case 'z':
-                return 2;
-            default:
-                return -1;
+            switch (uniPropertyName[uniPropertyName.Length - 1])
+            {
+                case 'x':
+                    return 0;
+                case 'y':
+                    return 1;
+                case 'z':
+                    return 2;
+                default:
+                    return -1;
             }
         }
 
@@ -2688,12 +2824,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private RotationCurve GetRotationCurve<T>(
             GameObject uniGO, float frameRate,
             ref Dictionary<GameObject, RotationCurve> rotations
-            ) where T : RotationCurve, new()
+        ) where T : RotationCurve, new()
         {
             RotationCurve rotCurve;
-            if (!rotations.TryGetValue (uniGO, out rotCurve)) {
+            if (!rotations.TryGetValue(uniGO, out rotCurve))
+            {
                 rotCurve = new T { SampleRate = frameRate };
-                rotations.Add (uniGO, rotCurve);
+                rotations.Add(uniGO, rotCurve);
             }
             return rotCurve;
         }
@@ -2702,34 +2839,36 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Export the Animator component on this game object
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        private void ExportAnimation (GameObject uniRoot, FbxScene fbxScene)
+        private void ExportAnimation(GameObject uniRoot, FbxScene fbxScene)
         {
             if (!uniRoot)
             {
                 return;
             }
 
-            var exportedClips = new HashSet<AnimationClip> ();
+            var exportedClips = new HashSet<AnimationClip>();
 
-            var uniAnimator = uniRoot.GetComponent<Animator> ();
+            var uniAnimator = uniRoot.GetComponent<Animator>();
             if (uniAnimator)
-            { 
+            {
                 // Try the animator controller (mecanim)
                 var controller = uniAnimator.runtimeAnimatorController;
 
-                if (controller) 
-                { 
+                if (controller)
+                {
                     // Only export each clip once per game object.
-                    foreach (var clip in controller.animationClips) {
-                        if (exportedClips.Add (clip)) {
-                            ExportAnimationClip (clip, uniRoot, fbxScene);
+                    foreach (var clip in controller.animationClips)
+                    {
+                        if (exportedClips.Add(clip))
+                        {
+                            ExportAnimationClip(clip, uniRoot, fbxScene);
                         }
                     }
                 }
             }
 
             // Try the playable director
-            var director = uniRoot.GetComponent<UnityEngine.Playables.PlayableDirector> ();
+            var director = uniRoot.GetComponent<UnityEngine.Playables.PlayableDirector>();
             if (director)
             {
                 Debug.LogWarning(string.Format("Exporting animation from PlayableDirector on {0} not supported", uniRoot.name));
@@ -2737,17 +2876,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             // Try the animation (legacy)
-            var uniAnimation = uniRoot.GetComponent<Animation> ();
-            if (uniAnimation) 
-            { 
+            var uniAnimation = uniRoot.GetComponent<Animation>();
+            if (uniAnimation)
+            {
                 // Only export each clip once per game object.
-                foreach (var uniAnimObj in uniAnimation) {
+                foreach (var uniAnimObj in uniAnimation)
+                {
                     AnimationState uniAnimState = uniAnimObj as AnimationState;
                     if (uniAnimState)
                     {
                         AnimationClip uniAnimClip = uniAnimState.clip;
-                        if (exportedClips.Add (uniAnimClip)) {
-                            ExportAnimationClip (uniAnimClip, uniRoot, fbxScene);
+                        if (exportedClips.Add(uniAnimClip))
+                        {
+                            ExportAnimationClip(uniAnimClip, uniRoot, fbxScene);
                         }
                     }
                 }
@@ -2757,14 +2898,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// configures default camera for the scene
         /// </summary>
-        private void SetDefaultCamera (FbxScene fbxScene)
+        private void SetDefaultCamera(FbxScene fbxScene)
         {
-            if(fbxScene == null) { return; }
+            if (fbxScene == null) { return; }
 
             if (string.IsNullOrEmpty(DefaultCamera))
                 DefaultCamera = Globals.FBXSDK_CAMERA_PERSPECTIVE;
 
-            fbxScene.GetGlobalSettings ().SetDefaultCamera (DefaultCamera);
+            fbxScene.GetGlobalSettings().SetDefaultCamera(DefaultCamera);
         }
 
         /// <summary>
@@ -2835,7 +2976,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns>the created FbxNode</returns>
         private FbxNode CreateFbxNode(GameObject unityGo, FbxScene fbxScene)
         {
-
             string fbxName = unityGo.name;
             if (ExportOptions.UseMayaCompatibleNames)
             {
@@ -2846,7 +2986,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     unityGo.name = fbxName;
                 }
             }
-            
+
             FbxNode fbxNode = FbxNode.Create(fbxScene, GetUniqueFbxNodeName(fbxName));
 
             // Default inheritance type in FBX is RrSs, which causes scaling issues in Maya as
@@ -2882,60 +3022,70 @@ namespace UnityEditor.Formats.Fbx.Exporter
             FbxNode fbxNode = CreateFbxNode(unityGo, fbxScene);
 
             if (Verbose)
-                Debug.Log (string.Format ("exporting {0}", fbxNode.GetName ()));
+                Debug.Log(string.Format("exporting {0}", fbxNode.GetName()));
 
             numObjectsExported++;
-            if (EditorUtility.DisplayCancelableProgressBar (
-                    ProgressBarTitle,
-                    string.Format ("Creating FbxNode {0}/{1}", numObjectsExported, objectCount),
-                    (numObjectsExported / (float)objectCount) * 0.25f)) {
+            if (EditorUtility.DisplayCancelableProgressBar(
+                ProgressBarTitle,
+                string.Format("Creating FbxNode {0}/{1}", numObjectsExported, objectCount),
+                (numObjectsExported / (float)objectCount) * 0.25f))
+            {
                 // cancel silently
                 return -1;
             }
 
-            ExportTransform (unityGo.transform, fbxNode, newCenter, exportType);
+            ExportTransform(unityGo.transform, fbxNode, newCenter, exportType);
 
-            fbxNodeParent.AddChild (fbxNode);
+            fbxNodeParent.AddChild(fbxNode);
 
             // if this object has an LOD group, then export according to the LOD preference setting
             var lodGroup = unityGo.GetComponent<LODGroup>();
-            if (lodGroup && lodExportType != ExportSettings.LODExportType.All) {
-                LOD[] lods = lodGroup.GetLODs ();
+            if (lodGroup && lodExportType != ExportSettings.LODExportType.All)
+            {
+                LOD[] lods = lodGroup.GetLODs();
 
                 // LODs are ordered from highest to lowest.
                 // If exporting lowest LOD, reverse the array
-                if (lodExportType == ExportSettings.LODExportType.Lowest) {
+                if (lodExportType == ExportSettings.LODExportType.Lowest)
+                {
                     // reverse the array
                     LOD[] tempLods = new LOD[lods.Length];
-                    System.Array.Copy (lods, tempLods, lods.Length);
-                    System.Array.Reverse (tempLods);
+                    System.Array.Copy(lods, tempLods, lods.Length);
+                    System.Array.Reverse(tempLods);
                     lods = tempLods;
                 }
 
-                for(int i = 0; i < lods.Length; i++){
-                    var lod = lods [i];
+                for (int i = 0; i < lods.Length; i++)
+                {
+                    var lod = lods[i];
                     bool exportedRenderer = false;
-                    foreach (var renderer in lod.renderers) {
+                    foreach (var renderer in lod.renderers)
+                    {
                         // only export if parented under LOD group
-                        if (renderer.transform.parent == unityGo.transform) {
-                            numObjectsExported = ExportTransformHierarchy (renderer.gameObject, fbxScene, fbxNode, numObjectsExported, objectCount, newCenter, lodExportType: lodExportType);
+                        if (renderer.transform.parent == unityGo.transform)
+                        {
+                            numObjectsExported = ExportTransformHierarchy(renderer.gameObject, fbxScene, fbxNode, numObjectsExported, objectCount, newCenter, lodExportType: lodExportType);
                             exportedRenderer = true;
-                        } else if(Verbose) {
-                            Debug.LogFormat ("FbxExporter: Not exporting LOD {0}: {1}", i, renderer.name);
+                        }
+                        else if (Verbose)
+                        {
+                            Debug.LogFormat("FbxExporter: Not exporting LOD {0}: {1}", i, renderer.name);
                         }
                     }
 
                     // if at least one renderer for this LOD was exported, then we succeeded
                     // so stop exporting.
-                    if (exportedRenderer) {
+                    if (exportedRenderer)
+                    {
                         return numObjectsExported;
                     }
                 }
             }
 
             // now  unityGo  through our children and recurse
-            foreach (Transform childT in  unityGo.transform) {
-                numObjectsExported = ExportTransformHierarchy (childT.gameObject, fbxScene, fbxNode, numObjectsExported, objectCount, newCenter, lodExportType: lodExportType);
+            foreach (Transform childT in  unityGo.transform)
+            {
+                numObjectsExported = ExportTransformHierarchy(childT.gameObject, fbxScene, fbxNode, numObjectsExported, objectCount, newCenter, lodExportType: lodExportType);
             }
 
             return numObjectsExported;
@@ -2944,7 +3094,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Exports all animation clips in the hierarchy along with
         /// the minimum required GameObject information.
-        /// i.e. Animated GameObjects, their ancestors, and their transforms are exported, 
+        /// i.e. Animated GameObjects, their ancestors, and their transforms are exported,
         ///     but components are only exported if explicitly animated. Meshes are not exported.
         /// </summary>
         /// <returns>The number of nodes exported.</returns>
@@ -2957,7 +3107,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Vector3 newCenter,
             IExportData data,
             TransformExportType exportType = TransformExportType.Local
-        ){
+        )
+        {
             AnimationOnlyExportData exportData = (AnimationOnlyExportData)data;
             int numObjectsExported = exportProgress;
 
@@ -2970,18 +3121,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // first export all the animated bones that are in the export set
             // as only a subset of bones are exported, but we still need to make sure the bone transforms are correct
-            if(!ExportAnimatedBones(unityGO, fbxScene, ref numObjectsExported, objectCount, exportData))
+            if (!ExportAnimatedBones(unityGO, fbxScene, ref numObjectsExported, objectCount, exportData))
             {
                 // export cancelled
                 return -1;
             }
 
             // export everything else and make sure all nodes are connected
-            foreach (var go in exportSet) {
+            foreach (var go in exportSet)
+            {
                 FbxNode node;
-                if (!ExportGameObjectAndParents (
+                if (!ExportGameObjectAndParents(
                     go, unityGO, fbxScene, out node, newCenter, exportType, ref numObjectsExported, objectCount
-                    )) {
+                ))
+                {
                     // export cancelled
                     return -1;
                 }
@@ -2989,12 +3142,18 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 ExportConstraints(go, fbxScene, node);
 
                 System.Type compType;
-                if (exportData.exportComponent.TryGetValue (go, out compType)) {
-                    if (compType == typeof(Light)) {
-                        ExportLight (go, fbxScene, node);
-                    } else if (compType == typeof(Camera)) {
-                        ExportCamera (go, fbxScene, node);
-                    } else if (compType == typeof(SkinnedMeshRenderer)) {
+                if (exportData.exportComponent.TryGetValue(go, out compType))
+                {
+                    if (compType == typeof(Light))
+                    {
+                        ExportLight(go, fbxScene, node);
+                    }
+                    else if (compType == typeof(Camera))
+                    {
+                        ExportCamera(go, fbxScene, node);
+                    }
+                    else if (compType == typeof(SkinnedMeshRenderer))
+                    {
                         // export only what is necessary for exporting blendshape animation
                         var unitySkin = go.GetComponent<SkinnedMeshRenderer>();
                         var meshInfo = new MeshInfo(unitySkin.sharedMesh, unitySkin.sharedMaterials);
@@ -3006,25 +3165,27 @@ namespace UnityEditor.Formats.Fbx.Exporter
             return numObjectsExported;
         }
 
-        internal class SkinnedMeshBoneInfo {
+        internal class SkinnedMeshBoneInfo
+        {
             public SkinnedMeshRenderer skinnedMesh;
             public Dictionary<Transform, int> boneDict;
             public Dictionary<Transform, Matrix4x4> boneToBindPose;
 
-            public SkinnedMeshBoneInfo(SkinnedMeshRenderer skinnedMesh, Dictionary<Transform, int> boneDict){
+            public SkinnedMeshBoneInfo(SkinnedMeshRenderer skinnedMesh, Dictionary<Transform, int> boneDict)
+            {
                 this.skinnedMesh = skinnedMesh;
                 this.boneDict = boneDict;
                 this.boneToBindPose = new Dictionary<Transform, Matrix4x4>();
             }
         }
 
-        private bool ExportAnimatedBones (
+        private bool ExportAnimatedBones(
             GameObject unityGo,
             FbxScene fbxScene,
             ref int exportProgress,
             int objectCount,
             AnimationOnlyExportData exportData
-            )
+        )
         {
             var skinnedMeshRenderers = unityGo.GetComponentsInChildren<SkinnedMeshRenderer>();
             foreach (var skinnedMesh in skinnedMeshRenderers)
@@ -3055,7 +3216,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                     exportProgress++;
                     if (EditorUtility.DisplayCancelableProgressBar(
-                            ProgressBarTitle,
+                        ProgressBarTitle,
                         string.Format("Creating FbxNode {0}/{1}", exportProgress, objectCount),
                         (exportProgress / (float)objectCount) * 0.5f))
                     {
@@ -3076,13 +3237,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private bool ExportGameObjectAndParents(
             GameObject unityGo,
             GameObject rootObject,
-            FbxScene fbxScene, 
+            FbxScene fbxScene,
             out FbxNode fbxNode,
             Vector3 newCenter,
             TransformExportType exportType,
             ref int exportProgress,
             int objectCount
-            )
+        )
         {
             // node doesn't exist so create it
             if (!MapUnityObjectToFbxNode.TryGetValue(unityGo, out fbxNode))
@@ -3091,7 +3252,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 exportProgress++;
                 if (EditorUtility.DisplayCancelableProgressBar(
-                        ProgressBarTitle,
+                    ProgressBarTitle,
                     string.Format("Creating FbxNode {0}/{1}", exportProgress, objectCount),
                     (exportProgress / (float)objectCount) * 0.5f))
                 {
@@ -3110,7 +3271,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // make sure all the nodes are connected and exported
             FbxNode fbxNodeParent;
-            if (!ExportGameObjectAndParents (
+            if (!ExportGameObjectAndParents(
                 unityGo.transform.parent.gameObject,
                 rootObject,
                 fbxScene,
@@ -3119,11 +3280,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 TransformExportType.Local,
                 ref exportProgress,
                 objectCount
-            )) {
+            ))
+            {
                 // export cancelled
                 return false;
             }
-            fbxNodeParent.AddChild (fbxNode);
+            fbxNodeParent.AddChild(fbxNode);
 
             return true;
         }
@@ -3138,8 +3300,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="boneInfo">Bone info.</param>
         private bool ExportBoneTransform(
             FbxNode fbxNode, FbxScene fbxScene, Transform unityBone, SkinnedMeshBoneInfo boneInfo
-        ){
-            if (boneInfo == null || boneInfo.skinnedMesh == null || boneInfo.boneDict == null || unityBone == null) {
+        )
+        {
+            if (boneInfo == null || boneInfo.skinnedMesh == null || boneInfo.boneDict == null || unityBone == null)
+            {
                 return false;
             }
 
@@ -3148,12 +3312,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
             var rootBone = skinnedMesh.rootBone;
 
             // setup the skeleton
-            var fbxSkeleton = fbxNode.GetSkeleton ();
-            if (fbxSkeleton == null) {
-                fbxSkeleton = FbxSkeleton.Create (fbxScene, unityBone.name + SkeletonPrefix);
+            var fbxSkeleton = fbxNode.GetSkeleton();
+            if (fbxSkeleton == null)
+            {
+                fbxSkeleton = FbxSkeleton.Create(fbxScene, unityBone.name + SkeletonPrefix);
 
-                fbxSkeleton.Size.Set (1.0f * UnitScaleFactor);
-                fbxNode.SetNodeAttribute (fbxSkeleton);
+                fbxSkeleton.Size.Set(1.0f * UnitScaleFactor);
+                fbxNode.SetNodeAttribute(fbxSkeleton);
             }
             var fbxSkeletonType = FbxSkeleton.EType.eLimbNode;
 
@@ -3177,7 +3342,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     fbxSkeletonType = FbxSkeleton.EType.eRoot;
                 }
             }
-            fbxSkeleton.SetSkeletonType (fbxSkeletonType);
+            fbxSkeleton.SetSkeletonType(fbxSkeletonType);
 
             var bindPoses = skinnedMesh.sharedMesh.bindposes;
 
@@ -3190,35 +3355,36 @@ namespace UnityEditor.Formats.Fbx.Exporter
             pose = parentBindPose * bindPose.inverse;
 
             FbxVector4 translation, rotation, scale;
-            GetTRSFromMatrix (pose, out translation, out rotation, out scale);
+            GetTRSFromMatrix(pose, out translation, out rotation, out scale);
 
             // Export bones with zero rotation, using a pivot instead to set the rotation
             // so that the bones are easier to animate and the rotation shows up as the "joint orientation" in Maya.
-            fbxNode.LclTranslation.Set (new FbxDouble3(translation.X*UnitScaleFactor, translation.Y*UnitScaleFactor, translation.Z*UnitScaleFactor));
-            fbxNode.LclRotation.Set (new FbxDouble3(0,0,0));
-            fbxNode.LclScaling.Set (new FbxDouble3 (scale.X, scale.Y, scale.Z));
+            fbxNode.LclTranslation.Set(new FbxDouble3(translation.X * UnitScaleFactor, translation.Y * UnitScaleFactor, translation.Z * UnitScaleFactor));
+            fbxNode.LclRotation.Set(new FbxDouble3(0, 0, 0));
+            fbxNode.LclScaling.Set(new FbxDouble3(scale.X, scale.Y, scale.Z));
 
             // TODO (UNI-34294): add detailed comment about why we export rotation as pre-rotation
-            fbxNode.SetRotationActive (true);
-            fbxNode.SetPivotState (FbxNode.EPivotSet.eSourcePivot, FbxNode.EPivotState.ePivotReference);
-            fbxNode.SetPreRotation (FbxNode.EPivotSet.eSourcePivot, new FbxVector4 (rotation.X, rotation.Y, rotation.Z));
+            fbxNode.SetRotationActive(true);
+            fbxNode.SetPivotState(FbxNode.EPivotSet.eSourcePivot, FbxNode.EPivotState.ePivotReference);
+            fbxNode.SetPreRotation(FbxNode.EPivotSet.eSourcePivot, new FbxVector4(rotation.X, rotation.Y, rotation.Z));
 
             return true;
         }
 
-        private void GetTRSFromMatrix(Matrix4x4 unityMatrix, out FbxVector4 translation, out FbxVector4 rotation, out FbxVector4 scale){
+        private void GetTRSFromMatrix(Matrix4x4 unityMatrix, out FbxVector4 translation, out FbxVector4 rotation, out FbxVector4 scale)
+        {
             // FBX is transposed relative to Unity: transpose as we convert.
-            FbxMatrix matrix = new FbxMatrix ();
-            matrix.SetColumn (0, new FbxVector4 (unityMatrix.GetRow (0).x, unityMatrix.GetRow (0).y, unityMatrix.GetRow (0).z, unityMatrix.GetRow (0).w));
-            matrix.SetColumn (1, new FbxVector4 (unityMatrix.GetRow (1).x, unityMatrix.GetRow (1).y, unityMatrix.GetRow (1).z, unityMatrix.GetRow (1).w));
-            matrix.SetColumn (2, new FbxVector4 (unityMatrix.GetRow (2).x, unityMatrix.GetRow (2).y, unityMatrix.GetRow (2).z, unityMatrix.GetRow (2).w));
-            matrix.SetColumn (3, new FbxVector4 (unityMatrix.GetRow (3).x, unityMatrix.GetRow (3).y, unityMatrix.GetRow (3).z, unityMatrix.GetRow (3).w));
+            FbxMatrix matrix = new FbxMatrix();
+            matrix.SetColumn(0, new FbxVector4(unityMatrix.GetRow(0).x, unityMatrix.GetRow(0).y, unityMatrix.GetRow(0).z, unityMatrix.GetRow(0).w));
+            matrix.SetColumn(1, new FbxVector4(unityMatrix.GetRow(1).x, unityMatrix.GetRow(1).y, unityMatrix.GetRow(1).z, unityMatrix.GetRow(1).w));
+            matrix.SetColumn(2, new FbxVector4(unityMatrix.GetRow(2).x, unityMatrix.GetRow(2).y, unityMatrix.GetRow(2).z, unityMatrix.GetRow(2).w));
+            matrix.SetColumn(3, new FbxVector4(unityMatrix.GetRow(3).x, unityMatrix.GetRow(3).y, unityMatrix.GetRow(3).z, unityMatrix.GetRow(3).w));
 
             // FBX wants translation, rotation (in euler angles) and scale.
             // We assume there's no real shear, just rounding error.
             FbxVector4 shear;
             double sign;
-            matrix.GetElements (out translation, out rotation, out shear, out scale, out sign);
+            matrix.GetElements(out translation, out rotation, out shear, out scale, out sign);
         }
 
         /// <summary>
@@ -3227,24 +3393,26 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <returns>The object to root count.</returns>
         /// <param name="startObject">Start object.</param>
         /// <param name="root">Root object.</param>
-        private static int GetObjectToRootDepth(Transform startObject, Transform root){
-            if (startObject == null) {
+        private static int GetObjectToRootDepth(Transform startObject, Transform root)
+        {
+            if (startObject == null)
+            {
                 return 0;
             }
 
             int count = 0;
             var parent = startObject.parent;
-            while (parent != null && parent != root) {
+            while (parent != null && parent != root)
+            {
                 count++;
                 parent = parent.parent;
             }
             return count;
         }
 
-
         /// <summary>
         /// Gets the count of animated objects to be exported.
-        /// 
+        ///
         /// In addition, collects the minimum set of what needs to be exported for each GameObject hierarchy.
         /// This contains all the animated GameObjects, their ancestors, their transforms, as well as any animated
         /// components and the animation clips. Also, the first animation to export, if any.
@@ -3256,16 +3424,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             // including any parents of animated objects that are exported
             var completeExpSet = new HashSet<GameObject>();
-            foreach (var data in hierarchyToExportData.Values) {
-                if(data == null || data.Objects == null || data.Objects.Count <= 0)
+            foreach (var data in hierarchyToExportData.Values)
+            {
+                if (data == null || data.Objects == null || data.Objects.Count <= 0)
                 {
                     continue;
                 }
-                foreach (var go in data.Objects) {
+                foreach (var go in data.Objects)
+                {
                     completeExpSet.Add(go);
 
                     var parent = go.transform.parent;
-                    while (parent != null && completeExpSet.Add(parent.gameObject)) {
+                    while (parent != null && completeExpSet.Add(parent.gameObject))
+                    {
                         parent = parent.parent;
                     }
                 }
@@ -3277,7 +3448,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         [SecurityPermission(SecurityAction.LinkDemand)]
         internal static Dictionary<GameObject, IExportData> GetExportData(TimelineClip timelineClip, PlayableDirector director = null, IExportOptions exportOptions = null)
         {
-            if(timelineClip == null)
+            if (timelineClip == null)
             {
                 return null;
             }
@@ -3296,7 +3467,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Dictionary<GameObject, IExportData> exportData = new Dictionary<GameObject, IExportData>();
             KeyValuePair<GameObject, AnimationClip> pair = AnimationOnlyExportData.GetGameObjectAndAnimationClip(timelineClip, director);
             var boundGo = pair.Key;
-            if(boundGo == null)
+            if (boundGo == null)
             {
                 return null;
             }
@@ -3308,9 +3479,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
         [SecurityPermission(SecurityAction.LinkDemand)]
         internal static Dictionary<GameObject, IExportData> GetExportData(Object[] objects, IExportOptions exportOptions = null)
         {
-            if (exportOptions==null)
+            if (exportOptions == null)
                 exportOptions = DefaultOptions;
-            Debug.Assert(exportOptions!=null);
+            Debug.Assert(exportOptions != null);
 
             if (exportOptions.ModelAnimIncludeOption == ExportSettings.Include.Model)
             {
@@ -3318,9 +3489,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
             }
 
             Dictionary<GameObject, IExportData> exportData = new Dictionary<GameObject, IExportData>();
-            foreach (var obj in objects) 
+            foreach (var obj in objects)
             {
-                GameObject go = ModelExporter.GetGameObject (obj);
+                GameObject go = ModelExporter.GetGameObject(obj);
                 if (go)
                 {
                     exportData[go] = GetExportData(go, exportOptions);
@@ -3333,20 +3504,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
         [SecurityPermission(SecurityAction.LinkDemand)]
         internal static IExportData GetExportData(GameObject rootObject, AnimationClip animationClip, IExportOptions exportOptions = null)
         {
-            if(rootObject == null || animationClip == null)
+            if (rootObject == null || animationClip == null)
             {
                 return null;
             }
 
-            if (exportOptions==null)
+            if (exportOptions == null)
                 exportOptions = DefaultOptions;
-            Debug.Assert(exportOptions!=null);
-                
+            Debug.Assert(exportOptions != null);
+
             var exportData = new AnimationOnlyExportData();
             exportData.CollectDependencies(animationClip, rootObject, exportOptions);
-                
+
             // could not find any dependencies, return null
-            if(exportData.Objects.Count <= 0)
+            if (exportData.Objects.Count <= 0)
             {
                 return null;
             }
@@ -3355,9 +3526,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         internal static IExportData GetExportData(GameObject go, IExportOptions exportOptions = null)
         {
-            if (exportOptions==null)
+            if (exportOptions == null)
                 exportOptions = DefaultOptions;
-            Debug.Assert(exportOptions!=null);
+            Debug.Assert(exportOptions != null);
 
             // gather all animation clips
             var legacyAnim = go.GetComponentsInChildren<Animation>();
@@ -3406,7 +3577,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 exportData.defaultClip = rootAnimation.clip;
             }
-            else if(rootAnimator)
+            else if (rootAnimator)
             {
                 // Try the animator controller (mecanim)
                 var controller = rootAnimator.runtimeAnimatorController;
@@ -3423,11 +3594,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         }
                         else
                         {
-                            if (motion != null) {
+                            if (motion != null)
+                            {
                                 Debug.LogWarningFormat("Couldn't export motion {0}", motion.name);
                             }
                             // missing animation
-                            else {
+                            else
+                            {
                                 Debug.LogWarningFormat("Couldn't export motion. Motion is missing.");
                             }
                         }
@@ -3445,16 +3618,18 @@ namespace UnityEditor.Formats.Fbx.Exporter
         [SecurityPermission(SecurityAction.LinkDemand)]
         private bool ExportComponents(FbxScene fbxScene)
         {
-            var animationNodes = new HashSet<GameObject> ();
+            var animationNodes = new HashSet<GameObject>();
 
             int numObjectsExported = 0;
             int objectCount = MapUnityObjectToFbxNode.Count;
-            foreach (KeyValuePair<GameObject, FbxNode> entry in MapUnityObjectToFbxNode) {
+            foreach (KeyValuePair<GameObject, FbxNode> entry in MapUnityObjectToFbxNode)
+            {
                 numObjectsExported++;
-                if (EditorUtility.DisplayCancelableProgressBar (
-                        ProgressBarTitle,
-                        string.Format ("Exporting Components for GameObject {0}/{1}", numObjectsExported, objectCount),
-                        ((numObjectsExported / (float)objectCount) * 0.25f) + 0.25f)) {
+                if (EditorUtility.DisplayCancelableProgressBar(
+                    ProgressBarTitle,
+                    string.Format("Exporting Components for GameObject {0}/{1}", numObjectsExported, objectCount),
+                    ((numObjectsExported / (float)objectCount) * 0.25f) + 0.25f))
+                {
                     // cancel silently
                     return false;
                 }
@@ -3464,23 +3639,27 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 // try export mesh
                 bool exportedMesh = false;
-                if(ExportOptions.KeepInstances) {
-                    exportedMesh = ExportInstance (unityGo, fbxScene, fbxNode);
+                if (ExportOptions.KeepInstances)
+                {
+                    exportedMesh = ExportInstance(unityGo, fbxScene, fbxNode);
                 }
 
-                if (!exportedMesh) {
-                    exportedMesh = ExportMesh (unityGo, fbxNode);
+                if (!exportedMesh)
+                {
+                    exportedMesh = ExportMesh(unityGo, fbxNode);
                 }
 
                 // export camera, but only if no mesh was exported
                 bool exportedCamera = false;
-                if (!exportedMesh) {
-                    exportedCamera = ExportCamera (unityGo, fbxScene, fbxNode);
+                if (!exportedMesh)
+                {
+                    exportedCamera = ExportCamera(unityGo, fbxScene, fbxNode);
                 }
 
                 // export light, but only if no mesh or camera was exported
-                if (!exportedMesh && !exportedCamera) {
-                    ExportLight (unityGo, fbxScene, fbxNode);
+                if (!exportedMesh && !exportedCamera)
+                {
+                    ExportLight(unityGo, fbxScene, fbxNode);
                 }
 
                 ExportConstraints(unityGo, fbxScene, fbxNode);
@@ -3493,11 +3672,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         /// <returns><c>true</c>, if object has animation, <c>false</c> otherwise.</returns>
         /// <param name="go">Go.</param>
-        private bool GameObjectHasAnimation(GameObject go){
+        private bool GameObjectHasAnimation(GameObject go)
+        {
             return go != null &&
-                (go.GetComponent<Animator> () ||
-                go.GetComponent<Animation> () ||
-                go.GetComponent<UnityEngine.Playables.PlayableDirector> ());
+                (go.GetComponent<Animator>() ||
+                    go.GetComponent<Animation>() ||
+                    go.GetComponent<UnityEngine.Playables.PlayableDirector>());
         }
 
         /// <summary>
@@ -3506,15 +3686,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         /// <returns>The hierarchy count.</returns>
         /// <param name="exportSet">Export set.</param>
-        internal int GetHierarchyCount (HashSet<GameObject> exportSet)
+        internal int GetHierarchyCount(HashSet<GameObject> exportSet)
         {
             int count = 0;
-            Queue<GameObject> queue = new Queue<GameObject> (exportSet);
-            while (queue.Count > 0) {
-                var obj = queue.Dequeue ();
+            Queue<GameObject> queue = new Queue<GameObject>(exportSet);
+            while (queue.Count > 0)
+            {
+                var obj = queue.Dequeue();
                 var objTransform = obj.transform;
-                foreach (Transform child in objTransform) {
-                    queue.Enqueue (child.gameObject);
+                foreach (Transform child in objTransform)
+                {
+                    queue.Enqueue(child.gameObject);
                 }
                 count++;
             }
@@ -3532,27 +3714,32 @@ namespace UnityEditor.Formats.Fbx.Exporter
         internal static HashSet<GameObject> RemoveRedundantObjects(IEnumerable<UnityEngine.Object> unityExportSet)
         {
             // basically just remove the descendents from the unity export set
-            HashSet<GameObject> toExport = new HashSet<GameObject> ();
-            HashSet<UnityEngine.Object> hashedExportSet = new HashSet<Object> (unityExportSet);
+            HashSet<GameObject> toExport = new HashSet<GameObject>();
+            HashSet<UnityEngine.Object> hashedExportSet = new HashSet<Object>(unityExportSet);
 
-            foreach(var obj in unityExportSet){
-                var unityGo = GetGameObject (obj);
+            foreach (var obj in unityExportSet)
+            {
+                var unityGo = GetGameObject(obj);
 
-                if (unityGo) {
+                if (unityGo)
+                {
                     // if any of this nodes ancestors is already in the export set,
                     // then ignore it, it will get exported already
                     bool parentInSet = false;
                     var parent = unityGo.transform.parent;
-                    while (parent != null) {
-                        if (hashedExportSet.Contains (parent.gameObject)) {
+                    while (parent != null)
+                    {
+                        if (hashedExportSet.Contains(parent.gameObject))
+                        {
                             parentInSet = true;
                             break;
                         }
                         parent = parent.parent;
                     }
 
-                    if (!parentInSet) {
-                        toExport.Add (unityGo);
+                    if (!parentInSet)
+                    {
+                        toExport.Add(unityGo);
                     }
                 }
             }
@@ -3567,16 +3754,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="boundsUnion">The Bounds that is the Union of all the bounds on this transform's hierarchy.</param>
         private static void EncapsulateBounds(Transform t, ref Bounds boundsUnion)
         {
-            var bounds = GetBounds (t);
-            boundsUnion.Encapsulate (bounds);
+            var bounds = GetBounds(t);
+            boundsUnion.Encapsulate(bounds);
 
-            foreach (Transform child in t) {
-                EncapsulateBounds (child, ref boundsUnion);
+            foreach (Transform child in t)
+            {
+                EncapsulateBounds(child, ref boundsUnion);
             }
         }
 
         /// <summary>
-        /// Gets the bounds of a transform. 
+        /// Gets the bounds of a transform.
         /// Looks first at the Renderer, then Mesh, then Collider.
         /// Default to a bounds with center transform.position and size zero.
         /// </summary>
@@ -3584,16 +3772,19 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="t">Transform.</param>
         private static Bounds GetBounds(Transform t)
         {
-            var renderer = t.GetComponent<Renderer> ();
-            if (renderer) {
+            var renderer = t.GetComponent<Renderer>();
+            if (renderer)
+            {
                 return renderer.bounds;
             }
-            var mesh = t.GetComponent<Mesh> ();
-            if (mesh) {
+            var mesh = t.GetComponent<Mesh>();
+            if (mesh)
+            {
                 return mesh.bounds;
             }
-            var collider = t.GetComponent<Collider> ();
-            if (collider) {
+            var collider = t.GetComponent<Collider>();
+            if (collider)
+            {
                 return collider.bounds;
             }
             return new Bounds(t.position, Vector3.zero);
@@ -3609,13 +3800,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Bounds bounds = new Bounds();
             // Assign the initial bounds to first GameObject's bounds
             // (if we initialize the bounds to 0, then 0 will be part of the bounds)
-            foreach (var go in gameObjects) {
-                var tempBounds = GetBounds (go.transform);
-                bounds = new Bounds (tempBounds.center, tempBounds.size);
+            foreach (var go in gameObjects)
+            {
+                var tempBounds = GetBounds(go.transform);
+                bounds = new Bounds(tempBounds.center, tempBounds.size);
                 break;
             }
-            foreach (var go in gameObjects) {
-                EncapsulateBounds (go.transform, ref bounds);
+            foreach (var go in gameObjects)
+            {
+                EncapsulateBounds(go.transform, ref bounds);
             }
             return bounds.center;
         }
@@ -3640,12 +3833,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// This refreshes the asset database.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        internal int ExportAll (
-            IEnumerable<UnityEngine.Object> unityExportSet, 
+        internal int ExportAll(
+            IEnumerable<UnityEngine.Object> unityExportSet,
             Dictionary<GameObject, IExportData> exportData)
         {
             exportCancelled = false;
-            
+
             m_lastFilePath = LastFilePath;
 
             // Export first to a temporary file
@@ -3659,27 +3852,31 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 var tempFileName = Path.GetFileNameWithoutExtension(Path.GetRandomFileName()) + "_" + lastFileName;
                 m_tempFilePath = Path.Combine(new string[] { exportDir, tempFileName });
             }
-            catch(IOException){
+            catch (IOException)
+            {
                 return 0;
             }
 
-            if (string.IsNullOrEmpty (m_tempFilePath)) {
+            if (string.IsNullOrEmpty(m_tempFilePath))
+            {
                 return 0;
             }
 
-            try {
+            try
+            {
                 bool animOnly = exportData != null && ExportOptions.ModelAnimIncludeOption == ExportSettings.Include.Anim;
                 bool status = false;
                 // Create the FBX manager
-                using (var fbxManager = FbxManager.Create ()) {
+                using (var fbxManager = FbxManager.Create())
+                {
                     // Configure fbx IO settings.
-                    var settings = FbxIOSettings.Create (fbxManager, Globals.IOSROOT);
-                    if(ExportOptions.EmbedTextures)
-                        settings.SetBoolProp (Globals.EXP_FBX_EMBEDDED, true);
-                    fbxManager.SetIOSettings (settings);
+                    var settings = FbxIOSettings.Create(fbxManager, Globals.IOSROOT);
+                    if (ExportOptions.EmbedTextures)
+                        settings.SetBoolProp(Globals.EXP_FBX_EMBEDDED, true);
+                    fbxManager.SetIOSettings(settings);
 
                     // Create the exporter
-                    var fbxExporter = FbxExporter.Create (fbxManager, "Exporter");
+                    var fbxExporter = FbxExporter.Create(fbxManager, "Exporter");
 
                     // Initialize the exporter.
                     // fileFormat must be binary if we are embedding textures
@@ -3687,21 +3884,21 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     if (ExportOptions.ExportFormat == ExportSettings.ExportFormat.ASCII)
                     {
                         fileFormat = fbxManager.GetIOPluginRegistry().FindWriterIDByDescription("FBX ascii (*.fbx)");
-                    }                        
-                        
-                    status = fbxExporter.Initialize (m_tempFilePath, fileFormat, fbxManager.GetIOSettings ());
+                    }
+
+                    status = fbxExporter.Initialize(m_tempFilePath, fileFormat, fbxManager.GetIOSettings());
                     // Check that initialization of the fbxExporter was successful
                     if (!status)
                         return 0;
 
                     // Set the progress callback.
-                    fbxExporter.SetProgressCallback (ExportProgressCallback);
+                    fbxExporter.SetProgressCallback(ExportProgressCallback);
 
                     // Create a scene
-                    var fbxScene = FbxScene.Create (fbxManager, "Scene");
+                    var fbxScene = FbxScene.Create(fbxManager, "Scene");
 
                     // set up the scene info
-                    FbxDocumentInfo fbxSceneInfo = FbxDocumentInfo.Create (fbxManager, "SceneInfo");
+                    FbxDocumentInfo fbxSceneInfo = FbxDocumentInfo.Create(fbxManager, "SceneInfo");
                     fbxSceneInfo.mTitle = Title;
                     fbxSceneInfo.mSubject = Subject;
                     fbxSceneInfo.mAuthor = "Unity Technologies";
@@ -3713,32 +3910,33 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     fbxSceneInfo.LastSaved_ApplicationName.Set(fbxSceneInfo.Original_ApplicationName.Get());
 
                     var version = GetVersionFromReadme();
-                    if(version != null){
+                    if (version != null)
+                    {
                         fbxSceneInfo.Original_ApplicationVersion.Set(version);
                         fbxSceneInfo.LastSaved_ApplicationVersion.Set(fbxSceneInfo.Original_ApplicationVersion.Get());
                     }
-                    fbxScene.SetSceneInfo (fbxSceneInfo);
+                    fbxScene.SetSceneInfo(fbxSceneInfo);
 
                     // Set up the axes (Y up, Z forward, X to the right) and units (centimeters)
                     // Exporting in centimeters as this is the default unit for FBX files, and easiest
                     // to work with when importing into Maya or Max
-                    var fbxSettings = fbxScene.GetGlobalSettings ();
-                    fbxSettings.SetSystemUnit (FbxSystemUnit.cm);
+                    var fbxSettings = fbxScene.GetGlobalSettings();
+                    fbxSettings.SetSystemUnit(FbxSystemUnit.cm);
 
                     // The Unity axis system has Y up, Z forward, X to the right (left handed system with odd parity).
                     // DirectX has the same axis system, so use this constant.
                     var unityAxisSystem = FbxAxisSystem.DirectX;
-                    fbxSettings.SetAxisSystem (unityAxisSystem);
+                    fbxSettings.SetAxisSystem(unityAxisSystem);
 
                     // export set of object
-                    FbxNode fbxRootNode = fbxScene.GetRootNode ();
+                    FbxNode fbxRootNode = fbxScene.GetRootNode();
                     // stores how many objects we have exported, -1 if export was cancelled
                     int exportProgress = 0;
                     IEnumerable<GameObject> revisedExportSet = null;
 
                     // Total # of objects to be exported
                     // Used by progress bar to show how many objects will be exported in total
-                    // i.e. exporting x/count... 
+                    // i.e. exporting x/count...
                     int count = 0;
 
                     // number of object hierarchies being exported.
@@ -3746,20 +3944,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     // i.e. if we are exporting a single hierarchy at local position, then it's root is set to zero,
                     // but if we are exporting multiple hierarchies at local position, then each hierarchy will be recentered according
                     // to the center of the bounding box.
-                    int rootObjCount = 0; 
+                    int rootObjCount = 0;
 
-                    if(animOnly){
+                    if (animOnly)
+                    {
                         count = GetAnimOnlyHierarchyCount(exportData);
                         revisedExportSet = from entry in exportData select entry.Key;
                         rootObjCount = exportData.Keys.Count;
-                    } else {
+                    }
+                    else
+                    {
                         var revisedGOSet = RemoveRedundantObjects(unityExportSet);
-                        count = GetHierarchyCount (revisedGOSet);
+                        count = GetHierarchyCount(revisedGOSet);
                         rootObjCount = revisedGOSet.Count;
                         revisedExportSet = revisedGOSet;
                     }
 
-                    if(count <= 0){
+                    if (count <= 0)
+                    {
                         // nothing to export
                         Debug.LogWarning("Nothing to Export");
                         return 0;
@@ -3767,44 +3969,52 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                     Vector3 center = Vector3.zero;
                     TransformExportType transformExportType = TransformExportType.Global;
-                    switch(ExportOptions.ObjectPosition){
-                    case ExportSettings.ObjectPosition.LocalCentered:
-                        // one object to export -> move to (0,0,0)
-                        if(rootObjCount == 1){
-                            var tempList = new List<GameObject>(revisedExportSet);
-                            center = tempList[0].transform.position;
+                    switch (ExportOptions.ObjectPosition)
+                    {
+                        case ExportSettings.ObjectPosition.LocalCentered:
+                            // one object to export -> move to (0,0,0)
+                            if (rootObjCount == 1)
+                            {
+                                var tempList = new List<GameObject>(revisedExportSet);
+                                center = tempList[0].transform.position;
+                                break;
+                            }
+                            // more than one object to export -> get bounding center
+                            center = FindCenter(revisedExportSet);
                             break;
-                        }
-                        // more than one object to export -> get bounding center
-                        center = FindCenter(revisedExportSet);
-                        break;
-                    case ExportSettings.ObjectPosition.Reset:
-                        transformExportType = TransformExportType.Reset;
-                        break;
-                    // absolute center -> don't do anything
-                    default:
-                        center = Vector3.zero;
-                        break;
+                        case ExportSettings.ObjectPosition.Reset:
+                            transformExportType = TransformExportType.Reset;
+                            break;
+                        // absolute center -> don't do anything
+                        default:
+                            center = Vector3.zero;
+                            break;
                     }
 
-                    foreach (var unityGo in revisedExportSet) {
+                    foreach (var unityGo in revisedExportSet)
+                    {
                         IExportData data;
-                        if(animOnly && exportData.TryGetValue(unityGo, out data)){
+                        if (animOnly && exportData.TryGetValue(unityGo, out data))
+                        {
                             exportProgress = this.ExportAnimationOnly(unityGo, fbxScene, exportProgress, count, center, data, transformExportType);
                         }
-                        else {
-                            exportProgress = this.ExportTransformHierarchy (unityGo, fbxScene, fbxRootNode,
+                        else
+                        {
+                            exportProgress = this.ExportTransformHierarchy(unityGo, fbxScene, fbxRootNode,
                                 exportProgress, count, center, transformExportType, ExportOptions.LODExportType);
                         }
-                        if (exportCancelled || exportProgress < 0) {
-                            Debug.LogWarning ("Export Cancelled");
+                        if (exportCancelled || exportProgress < 0)
+                        {
+                            Debug.LogWarning("Export Cancelled");
                             return 0;
                         }
                     }
 
-                    if(!animOnly){
-                        if(!ExportComponents(fbxScene)){
-                            Debug.LogWarning ("Export Cancelled");
+                    if (!animOnly)
+                    {
+                        if (!ExportComponents(fbxScene))
+                        {
+                            Debug.LogWarning("Export Cancelled");
                             return 0;
                         }
                     }
@@ -3841,7 +4051,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         }
                     }
                     // Set the scene's default camera.
-                    SetDefaultCamera (fbxScene);
+                    SetDefaultCamera(fbxScene);
 
                     // The Maya axis system has Y up, Z forward, X to the left (right handed system with odd parity).
                     // We need to export right-handed for Maya because ConvertScene (used by Maya and Max importers) can't switch handedness:
@@ -3850,15 +4060,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     FbxAxisSystem.MayaYUp.DeepConvertScene(fbxScene);
 
                     // Export the scene to the file.
-                    status = fbxExporter.Export (fbxScene);
+                    status = fbxExporter.Export(fbxScene);
 
                     // cleanup
-                    fbxScene.Destroy ();
-                    fbxExporter.Destroy ();
+                    fbxScene.Destroy();
+                    fbxExporter.Destroy();
                 }
 
-                if (exportCancelled) {
-                    Debug.LogWarning ("Export Cancelled");
+                if (exportCancelled)
+                {
+                    Debug.LogWarning("Export Cancelled");
                     return 0;
                 }
 
@@ -3874,7 +4085,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 // refresh the database so Unity knows the file's been deleted
                 AssetDatabase.Refresh();
-                
+
                 // replace with original metafile if specified to
                 if (ExportOptions.PreserveImportSettings && !string.IsNullOrEmpty(originalMetafilePath))
                 {
@@ -3883,11 +4094,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 return status == true ? NumNodes : 0;
             }
-            finally {
+            finally
+            {
                 // You must clear the progress bar when you're done,
                 // otherwise it never goes away and many actions in Unity
                 // are blocked (e.g. you can't quit).
-                EditorUtility.ClearProgressBar ();
+                EditorUtility.ClearProgressBar();
 
                 // make sure the temp file is deleted, no matter
                 // when we return
@@ -3897,16 +4109,17 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         static bool exportCancelled = false;
 
-        static bool ExportProgressCallback (float percentage, string status)
+        static bool ExportProgressCallback(float percentage, string status)
         {
             // Convert from percentage to [0,1].
             // Then convert from that to [0.5,1] because the first half of
             // the progress bar was for creating the scene.
             var progress01 = 0.5f * (1f + (percentage / 100.0f));
 
-            bool cancel = EditorUtility.DisplayCancelableProgressBar (ProgressBarTitle, "Exporting Scene...", progress01);
+            bool cancel = EditorUtility.DisplayCancelableProgressBar(ProgressBarTitle, "Exporting Scene...", progress01);
 
-            if (cancel) {
+            if (cancel)
+            {
                 exportCancelled = true;
             }
 
@@ -3917,19 +4130,24 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Deletes the file that got created while exporting.
         /// </summary>
-        private void DeleteTempFile ()
+        private void DeleteTempFile()
         {
-            if (!File.Exists (m_tempFilePath)) {
+            if (!File.Exists(m_tempFilePath))
+            {
                 return;
             }
 
-            try {
-                File.Delete (m_tempFilePath);
-            } catch (IOException) {
+            try
+            {
+                File.Delete(m_tempFilePath);
+            }
+            catch (IOException)
+            {
             }
 
-            if (File.Exists (m_tempFilePath)) {
-                Debug.LogWarning ("Failed to delete file: " + m_tempFilePath);
+            if (File.Exists(m_tempFilePath))
+            {
+                Debug.LogWarning("Failed to delete file: " + m_tempFilePath);
             }
         }
 
@@ -3937,35 +4155,43 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Replaces the file we are overwriting with
         /// the temp file that was exported to.
         /// </summary>
-        private void ReplaceFile ()
+        private void ReplaceFile()
         {
-            if (m_tempFilePath.Equals (m_lastFilePath) || !File.Exists (m_tempFilePath)) {
+            if (m_tempFilePath.Equals(m_lastFilePath) || !File.Exists(m_tempFilePath))
+            {
                 return;
             }
             // delete old file
-            try {
-                File.Delete (m_lastFilePath);
+            try
+            {
+                File.Delete(m_lastFilePath);
                 // delete meta file also
                 File.Delete(m_lastFilePath + ".meta");
-            } catch (IOException) {
+            }
+            catch (IOException)
+            {
             }
 
-            if (File.Exists (m_lastFilePath)) {
-                Debug.LogWarning ("Failed to delete file: " + m_lastFilePath);
+            if (File.Exists(m_lastFilePath))
+            {
+                Debug.LogWarning("Failed to delete file: " + m_lastFilePath);
             }
 
             // rename the new file
-            try{
+            try
+            {
                 File.Move(m_tempFilePath, m_lastFilePath);
-            } catch(IOException){
-                Debug.LogWarning (string.Format("Failed to move file {0} to {1}", m_tempFilePath, m_lastFilePath));
+            }
+            catch (IOException)
+            {
+                Debug.LogWarning(string.Format("Failed to move file {0} to {1}", m_tempFilePath, m_lastFilePath));
             }
         }
 
         private string SaveMetafile()
         {
             var tempMetafilePath = Path.GetTempFileName();
-            
+
             // get relative path
             var fbxPath = "Assets/" + ExportSettings.ConvertToAssetRelativePath(m_lastFilePath);
             if (AssetDatabase.LoadAssetAtPath(fbxPath, typeof(Object)) == null)
@@ -3973,7 +4199,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
                 return "";
             }
-            
+
             // get metafile for original fbx file
             var metafile = fbxPath + ".meta";
 
@@ -3982,10 +4208,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
 #endif
 
             // save it to a temp file
-            try {
+            try
+            {
                 File.Copy(metafile, tempMetafilePath, true);
-            } catch(IOException) {
-                Debug.LogWarning (string.Format("Failed to copy file {0} to {1}. Import settings will be reset to default values.", metafile, tempMetafilePath));
+            }
+            catch (IOException)
+            {
+                Debug.LogWarning(string.Format("Failed to copy file {0} to {1}. Import settings will be reset to default values.", metafile, tempMetafilePath));
                 return "";
             }
 
@@ -4001,7 +4230,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 Debug.LogWarning(string.Format("Failed to find a valid asset at {0}. Import settings will be reset to default values.", m_lastFilePath));
                 return;
             }
-            
+
             // get metafile for new fbx file
             var metafile = fbxPath + ".meta";
 
@@ -4010,10 +4239,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
 #endif
 
             // replace metafile with original one in temp file
-            try {
+            try
+            {
                 File.Copy(metafilePath, metafile, true);
-            } catch(IOException) {
-                Debug.LogWarning (string.Format("Failed to copy file {0} to {1}. Import settings will be reset to default values.", metafilePath, m_lastFilePath));
+            }
+            catch (IOException)
+            {
+                Debug.LogWarning(string.Format("Failed to copy file {0} to {1}. Import settings will be reset to default values.", metafilePath, m_lastFilePath));
             }
         }
 
@@ -4038,7 +4270,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             var previousInclude = ExportSettings.instance.ExportModelSettings.info.ModelAnimIncludeOption;
             ExportSettings.instance.ExportModelSettings.info.SetModelAnimIncludeOption(ExportSettings.Include.Anim);
 
-            if(ExportTimelineClip(filePath, timelineClip, director, ExportSettings.instance.ExportModelSettings.info) != null)
+            if (ExportTimelineClip(filePath, timelineClip, director, ExportSettings.instance.ExportModelSettings.info) != null)
             {
                 // refresh the asset database so that the file appears in the
                 // asset folder view.
@@ -4052,30 +4284,31 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// Add a menu item "Export Model..." to a GameObject's context menu.
         /// </summary>
         /// <param name="command">Command.</param>
-        [MenuItem (MenuItemName, false, 30)]
-        internal static void OnContextItem (MenuCommand command)
+        [MenuItem(MenuItemName, false, 30)]
+        internal static void OnContextItem(MenuCommand command)
         {
-            if (Selection.objects.Length <= 0) {
-                DisplayNoSelectionDialog ();
+            if (Selection.objects.Length <= 0)
+            {
+                DisplayNoSelectionDialog();
                 return;
             }
-            OnExport ();
+            OnExport();
         }
 
         /// <summary>
         /// Validate the menu item defined by the function OnContextItem.
         /// </summary>
-        [MenuItem (MenuItemName, true, 30)]
-        internal static bool OnValidateMenuItem ()
+        [MenuItem(MenuItemName, true, 30)]
+        internal static bool OnValidateMenuItem()
         {
             return true;
         }
 
         internal static void DisplayNoSelectionDialog()
         {
-            UnityEditor.EditorUtility.DisplayDialog (
-                string.Format("{0} Warning", PACKAGE_UI_NAME), 
-                "No GameObjects selected for export.", 
+            UnityEditor.EditorUtility.DisplayDialog(
+                string.Format("{0} Warning", PACKAGE_UI_NAME),
+                "No GameObjects selected for export.",
                 "Ok");
         }
 
@@ -4106,31 +4339,43 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// </summary>
             /// <value>The triangles.</value>
             private int[] m_triangles;
-            public int [] Triangles { get { 
-                    if(m_triangles == null) { m_triangles = mesh.triangles; }
-                    return m_triangles; 
-                } }
+            public int[] Triangles
+            {
+                get
+                {
+                    if (m_triangles == null) { m_triangles = mesh.triangles; }
+                    return m_triangles;
+                }
+            }
 
             /// <summary>
             /// Gets the vertices, represented in local coordinates.
             /// </summary>
             /// <value>The vertices.</value>
             private Vector3[] m_vertices;
-            public Vector3 [] Vertices { get { 
-                    if(m_vertices == null) { m_vertices = mesh.vertices; }
-                    return m_vertices; 
-                } }
+            public Vector3[] Vertices
+            {
+                get
+                {
+                    if (m_vertices == null) { m_vertices = mesh.vertices; }
+                    return m_vertices;
+                }
+            }
 
             /// <summary>
             /// Gets the normals for the vertices.
             /// </summary>
             /// <value>The normals.</value>
             private Vector3[] m_normals;
-            public Vector3 [] Normals { get {
-                    if (m_normals == null) {
+            public Vector3[] Normals
+            {
+                get
+                {
+                    if (m_normals == null)
+                    {
                         m_normals = mesh.normals;
                     }
-                    return m_normals; 
+                    return m_normals;
                 }
             }
 
@@ -4140,23 +4385,26 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// <value>The normals.</value>
             private Vector3[] m_Binormals;
 
-            public Vector3 [] Binormals {
-                get {
+            public Vector3[] Binormals
+            {
+                get
+                {
                     /// NOTE: LINQ
                     ///    return mesh.normals.Zip (mesh.tangents, (first, second)
                     ///    => Math.cross (normal, tangent.xyz) * tangent.w
-                    if (m_Binormals == null || m_Binormals.Length == 0) 
+                    if (m_Binormals == null || m_Binormals.Length == 0)
                     {
                         var normals = Normals;
                         var tangents = Tangents;
 
-                        if (HasValidNormals() && HasValidTangents()) {
-                            m_Binormals = new Vector3 [normals.Length];
+                        if (HasValidNormals() && HasValidTangents())
+                        {
+                            m_Binormals = new Vector3[normals.Length];
 
                             for (int i = 0; i < normals.Length; i++)
-                                m_Binormals [i] = Vector3.Cross (normals [i],
-                                    tangents [i])
-                                * tangents [i].w;
+                                m_Binormals[i] = Vector3.Cross(normals[i],
+                                    tangents[i])
+                                    * tangents[i].w;
                         }
                     }
                     return m_Binormals;
@@ -4168,11 +4416,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// </summary>
             /// <value>The tangents.</value>
             private Vector4[] m_tangents;
-            public Vector4 [] Tangents { get { 
-                    if (m_tangents == null) {
+            public Vector4[] Tangents
+            {
+                get
+                {
+                    if (m_tangents == null)
+                    {
                         m_tangents = mesh.tangents;
                     }
-                    return m_tangents; 
+                    return m_tangents;
                 }
             }
 
@@ -4180,12 +4432,16 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// Gets the vertex colors for the vertices.
             /// </summary>
             /// <value>The vertex colors.</value>
-            private Color32 [] m_vertexColors;
-            public Color32 [] VertexColors { get { 
-                    if (m_vertexColors == null) {
+            private Color32[] m_vertexColors;
+            public Color32[] VertexColors
+            {
+                get
+                {
+                    if (m_vertexColors == null)
+                    {
                         m_vertexColors = mesh.colors32;
                     }
-                    return m_vertexColors; 
+                    return m_vertexColors;
                 }
             }
 
@@ -4194,11 +4450,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// </summary>
             /// <value>The uv.</value>
             private Vector2[] m_UVs;
-            public Vector2 [] UV { get { 
-                    if (m_UVs == null) {
+            public Vector2[] UV
+            {
+                get
+                {
+                    if (m_UVs == null)
+                    {
                         m_UVs = mesh.uv;
                     }
-                    return m_UVs; 
+                    return m_UVs;
                 }
             }
 
@@ -4207,12 +4467,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// Always at least one.
             /// None are missing materials (we replace missing materials with the default material).
             /// </summary>
-            public Material[] Materials { get ; private set; }
+            public Material[] Materials { get; private set; }
 
             /// <summary>
             /// Set up the MeshInfo with the given mesh and materials.
             /// </summary>
-            public MeshInfo (Mesh mesh, Material[] materials)
+            public MeshInfo(Mesh mesh, Material[] materials)
             {
                 this.mesh = mesh;
 
@@ -4224,31 +4484,39 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 this.m_vertexColors = null;
                 this.m_tangents = null;
 
-                if (materials == null) {
+                if (materials == null)
+                {
                     this.Materials = new Material[] { DefaultMaterial };
-                } else {
-                    this.Materials = materials.Select (mat => mat ? mat : DefaultMaterial).ToArray ();
-                    if (this.Materials.Length == 0) {
+                }
+                else
+                {
+                    this.Materials = materials.Select(mat => mat ? mat : DefaultMaterial).ToArray();
+                    if (this.Materials.Length == 0)
+                    {
                         this.Materials = new Material[] { DefaultMaterial };
                     }
                 }
             }
 
-            public bool HasValidNormals(){
+            public bool HasValidNormals()
+            {
                 return Normals != null && Normals.Length > 0;
             }
 
-            public bool HasValidBinormals(){
-                return HasValidNormals () &&
-                    HasValidTangents () &&
+            public bool HasValidBinormals()
+            {
+                return HasValidNormals() &&
+                    HasValidTangents() &&
                     Binormals != null;
             }
 
-            public bool HasValidTangents(){
+            public bool HasValidTangents()
+            {
                 return Tangents != null && Tangents.Length > 0;
             }
 
-            public bool HasValidVertexColors(){
+            public bool HasValidVertexColors()
+            {
                 return VertexColors != null && VertexColors.Length > 0;
             }
         }
@@ -4256,9 +4524,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Get the GameObject
         /// </summary>
-        internal static GameObject GetGameObject (Object obj)
+        internal static GameObject GetGameObject(Object obj)
         {
-            if (obj is UnityEngine.Transform) {
+            if (obj is UnityEngine.Transform)
+            {
                 var xform = obj as UnityEngine.Transform;
                 return xform.gameObject;
             }
@@ -4270,8 +4539,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             else if (obj is UnityEngine.GameObject)
             {
                 return obj as UnityEngine.GameObject;
-            } 
-            else if (obj is Behaviour) 
+            }
+            else if (obj is Behaviour)
             {
                 var behaviour = obj as Behaviour;
                 return behaviour.gameObject;
@@ -4299,12 +4568,12 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// already has one, unless 'replace' is set to true.
         /// </summary>
         internal static void RegisterMeshCallback<T>(GetMeshForComponent<T> callback, bool replace = false)
-            where T: UnityEngine.MonoBehaviour
+            where T : UnityEngine.MonoBehaviour
         {
             // Under the hood we lose type safety, but don't let the user notice!
-            RegisterMeshCallback (typeof(T),
+            RegisterMeshCallback(typeof(T),
                 (ModelExporter exporter, MonoBehaviour component, FbxNode fbxNode) =>
-                        callback (exporter, (T)component, fbxNode),
+                    callback(exporter, (T)component, fbxNode),
                 replace);
         }
 
@@ -4318,13 +4587,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// easier to use with reflection.
         /// </summary>
         internal static void RegisterMeshCallback(System.Type t,
-                GetMeshForComponent callback,
-                bool replace = false)
+            GetMeshForComponent callback,
+            bool replace = false)
         {
-            if (!t.IsSubclassOf(typeof(MonoBehaviour))) {
+            if (!t.IsSubclassOf(typeof(MonoBehaviour)))
+            {
                 throw new ModelExportException("Registering a callback for a type that isn't derived from MonoBehaviour: " + t);
             }
-            if (!replace && MeshForComponentCallbacks.ContainsKey(t)) {
+            if (!replace && MeshForComponentCallbacks.ContainsKey(t))
+            {
                 throw new ModelExportException("Replacing a callback for type " + t);
             }
             MeshForComponentCallbacks[t] = callback;
@@ -4353,7 +4624,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             MeshForComponentCallbacks.Clear();
         }
-        
+
         static List<GetMeshForObject> MeshForObjectCallbacks = new List<GetMeshForObject>();
 
         /// <summary>
@@ -4395,11 +4666,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// allow plugins to substitute their own meshes.
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        bool ExportMesh (GameObject gameObject, FbxNode fbxNode)
+        bool ExportMesh(GameObject gameObject, FbxNode fbxNode)
         {
             // First allow the object-based callbacks to have a hack at it.
-            foreach(var callback in MeshForObjectCallbacks) {
-                if (callback(this, gameObject, fbxNode)) {
+            foreach (var callback in MeshForObjectCallbacks)
+            {
+                if (callback(this, gameObject, fbxNode))
+                {
                     return true;
                 }
             }
@@ -4409,36 +4682,51 @@ namespace UnityEditor.Formats.Fbx.Exporter
             // potential of subclassing. While we're iterating we keep the
             // first MeshFilter or SkinnedMeshRenderer we find.
             Component defaultComponent = null;
-            foreach(var component in gameObject.GetComponents<Component>()) {
-                if (!component) {
+            foreach (var component in gameObject.GetComponents<Component>())
+            {
+                if (!component)
+                {
                     continue;
                 }
                 var monoBehaviour = component as MonoBehaviour;
-                if (!monoBehaviour) {
+                if (!monoBehaviour)
+                {
                     // Check for default handling. But don't commit yet.
-                    if (defaultComponent) {
+                    if (defaultComponent)
+                    {
                         continue;
-                    } else if (component is MeshFilter) {
-                        defaultComponent = component;
-                    } else if (component is SkinnedMeshRenderer) {
+                    }
+                    else if (component is MeshFilter)
+                    {
                         defaultComponent = component;
                     }
-                } else {
+                    else if (component is SkinnedMeshRenderer)
+                    {
+                        defaultComponent = component;
+                    }
+                }
+                else
+                {
                     // Check if we have custom behaviour for this component type, or
                     // one of its base classes.
-                    if (!monoBehaviour.enabled) {
+                    if (!monoBehaviour.enabled)
+                    {
                         continue;
                     }
-                    var componentType = monoBehaviour.GetType ();
-                    do {
+                    var componentType = monoBehaviour.GetType();
+                    do
+                    {
                         GetMeshForComponent callback;
-                        if (MeshForComponentCallbacks.TryGetValue (componentType, out callback)) {
-                            if (callback (this, monoBehaviour, fbxNode)) {
+                        if (MeshForComponentCallbacks.TryGetValue(componentType, out callback))
+                        {
+                            if (callback(this, monoBehaviour, fbxNode))
+                            {
                                 return true;
                             }
                         }
                         componentType = componentType.BaseType;
-                    } while(componentType.IsSubclassOf (typeof(MonoBehaviour)));
+                    }
+                    while (componentType.IsSubclassOf(typeof(MonoBehaviour)));
                 }
             }
 
@@ -4447,20 +4735,26 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // if user doesn't want to export mesh colliders, and this gameobject doesn't have a renderer
             // then don't export it.
-            if (!ExportOptions.ExportUnrendered && (!gameObject.GetComponent<Renderer>() || !gameObject.GetComponent<Renderer>().enabled)) {
+            if (!ExportOptions.ExportUnrendered && (!gameObject.GetComponent<Renderer>() || !gameObject.GetComponent<Renderer>().enabled))
+            {
                 return false;
             }
 
             var meshFilter = defaultComponent as MeshFilter;
-            if (meshFilter) {
+            if (meshFilter)
+            {
                 var renderer = gameObject.GetComponent<Renderer>();
                 var materials = renderer ? renderer.sharedMaterials : null;
                 return ExportMesh(new MeshInfo(meshFilter.sharedMesh, materials), fbxNode);
-            } else {
+            }
+            else
+            {
                 var smr = defaultComponent as SkinnedMeshRenderer;
-                if (smr) {
-                    var result = ExportSkinnedMesh (gameObject, fbxNode.GetScene (), fbxNode);
-                    if(!result){
+                if (smr)
+                {
+                    var result = ExportSkinnedMesh(gameObject, fbxNode.GetScene(), fbxNode);
+                    if (!result)
+                    {
                         // fall back to exporting as a static mesh
                         var mesh = new Mesh();
                         smr.BakeMesh(mesh);
@@ -4493,7 +4787,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <summary>
         /// Cleans up this class on garbage collection
         /// </summary>
-        public void Dispose ()
+        public void Dispose()
         {
             System.GC.SuppressFinalize(this);
         }
@@ -4508,15 +4802,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
         private string m_lastFilePath { get; set; }
 
         const string kFBXFileExtension = "fbx";
-			
-        private static string MakeFileName (string basename = "test", string extension = kFBXFileExtension)
+
+        private static string MakeFileName(string basename = "test", string extension = kFBXFileExtension)
         {
             return basename + "." + extension;
         }
-                
-        private static void OnExport ()
+
+        private static void OnExport()
         {
-            GameObject [] selectedGOs = Selection.GetFiltered<GameObject> (SelectionMode.TopLevel);
+            GameObject[] selectedGOs = Selection.GetFiltered<GameObject>(SelectionMode.TopLevel);
 
             var toExport = ModelExporter.RemoveRedundantObjects(selectedGOs);
             if (ExportSettings.instance.DisplayOptionsWindow)
@@ -4553,8 +4847,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         [SecurityPermission(SecurityAction.LinkDemand)]
-        internal static string ExportObject (
-            string filePath, 
+        internal static string ExportObject(
+            string filePath,
             UnityEngine.Object root,
             IExportOptions exportOptions = null
         )
@@ -4585,7 +4879,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// <param name="filePath">Absolute file path to use for the FBX file.</param>
         /// <param name="singleObject">The Unity GameObject to export.</param>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        public static string ExportObject (string filePath, UnityEngine.Object singleObject)
+        public static string ExportObject(string filePath, UnityEngine.Object singleObject)
         {
             return ExportObjects(filePath, new Object[] {singleObject}, exportOptions: null);
         }
@@ -4605,13 +4899,13 @@ namespace UnityEditor.Formats.Fbx.Exporter
         }
 
         /// <summary>
-        /// Exports a list of GameObjects to an FBX file. 
+        /// Exports a list of GameObjects to an FBX file.
         /// <para>
         /// Use the SaveFile panel to allow the user to enter a file name.
         /// </para>
         /// </summary>
         [SecurityPermission(SecurityAction.LinkDemand)]
-        internal static string ExportObjects (
+        internal static string ExportObjects(
             string filePath,
             UnityEngine.Object[] objects = null,
             IExportOptions exportOptions = null,
@@ -4620,12 +4914,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
         {
             LastFilePath = filePath;
 
-            using (var fbxExporter = Create ()) {
+            using (var fbxExporter = Create())
+            {
                 // ensure output directory exists
-                EnsureDirectory (filePath);
+                EnsureDirectory(filePath);
                 fbxExporter.ExportOptions = exportOptions;
 
-                if (objects == null) {
+                if (objects == null)
+                {
                     objects = Selection.objects;
                 }
 
@@ -4634,9 +4930,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     exportData = ModelExporter.GetExportData(objects, exportOptions);
                 }
 
-                if (fbxExporter.ExportAll (objects, exportData) > 0) {
-                    string message = string.Format ("Successfully exported: {0}", filePath);
-                    UnityEngine.Debug.Log (message);
+                if (fbxExporter.ExportAll(objects, exportData) > 0)
+                {
+                    string message = string.Format("Successfully exported: {0}", filePath);
+                    UnityEngine.Debug.Log(message);
 
                     return filePath;
                 }
@@ -4644,14 +4941,15 @@ namespace UnityEditor.Formats.Fbx.Exporter
             return null;
         }
 
-        private static void EnsureDirectory (string path)
+        private static void EnsureDirectory(string path)
         {
             //check to make sure the path exists, and if it doesn't then
             //create all the missing directories.
-            FileInfo fileInfo = new FileInfo (path);
+            FileInfo fileInfo = new FileInfo(path);
 
-            if (!fileInfo.Exists) {
-                Directory.CreateDirectory (fileInfo.Directory.FullName);
+            if (!fileInfo.Exists)
+            {
+                Directory.CreateDirectory(fileInfo.Directory.FullName);
             }
         }
 
@@ -4661,7 +4959,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         /// <returns>Text with accents removed.</returns>
         /// <param name="text">Text.</param>
-        private static string RemoveDiacritics(string text) 
+        private static string RemoveDiacritics(string text)
         {
             var normalizedString = text.Normalize(System.Text.NormalizationForm.FormD);
             var stringBuilder = new System.Text.StringBuilder();
@@ -4680,21 +4978,26 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         private static string ConvertToMayaCompatibleName(string name)
         {
-            if (string.IsNullOrEmpty(name)) {
+            if (string.IsNullOrEmpty(name))
+            {
                 return InvalidCharReplacement.ToString();
             }
-            string newName = RemoveDiacritics (name);
+            string newName = RemoveDiacritics(name);
 
-            if (char.IsDigit (newName [0])) {
-                newName = newName.Insert (0, InvalidCharReplacement.ToString());
+            if (char.IsDigit(newName[0]))
+            {
+                newName = newName.Insert(0, InvalidCharReplacement.ToString());
             }
 
-            for (int i = 0; i < newName.Length; i++) {
-                if (!char.IsLetterOrDigit (newName, i)) {
-                    if (i < newName.Length-1 && newName [i] == MayaNamespaceSeparator) {
+            for (int i = 0; i < newName.Length; i++)
+            {
+                if (!char.IsLetterOrDigit(newName, i))
+                {
+                    if (i < newName.Length - 1 && newName[i] == MayaNamespaceSeparator)
+                    {
                         continue;
                     }
-                    newName = newName.Replace (newName [i], InvalidCharReplacement);
+                    newName = newName.Replace(newName[i], InvalidCharReplacement);
                 }
             }
             return newName;
@@ -4702,7 +5005,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         internal static string ConvertToValidFilename(string filename)
         {
-            return System.Text.RegularExpressions.Regex.Replace (filename, 
+            return System.Text.RegularExpressions.Regex.Replace(filename,
                 RegexCharStart + new string(Path.GetInvalidFileNameChars()) + RegexCharEnd,
                 InvalidCharReplacement.ToString()
             );

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -1,4 +1,4 @@
-﻿#if ENABLE_FBX_RECORDER
+#if ENABLE_FBX_RECORDER
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -12,12 +12,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
     {
         protected override void RecordFrame(RecordingSession ctx)
         {
-
         }
 
         protected override void EndRecording(RecordingSession session)
         {
-            if(session == null)
+            if (session == null)
             {
                 throw new System.ArgumentNullException("session");
             }
@@ -26,7 +25,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             foreach (var input in m_Inputs)
             {
-
                 var aInput = (AnimationInput)input;
 
                 if (aInput.GameObjectRecorder == null)
@@ -38,7 +36,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 var absolutePath = FileNameGenerator.SanitizePath(settings.FileNameGenerator.BuildAbsolutePath(session));
                 var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
-                
+
 #if UNITY_2019_3_OR_NEWER
                 var options = new Animations.CurveFilterOptions();
                 options.keyframeReduction = false;
@@ -57,7 +55,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 if (!settings.ExportGeometry)
                 {
                     toInclude = ExportSettings.Include.Anim;
-                } 
+                }
                 exportSettings.SetModelAnimIncludeOption(toInclude);
 
                 var exportData = new AnimationOnlyExportData();

--- a/com.unity.formats.fbx/Tests/FbxTests/ConvertToModelTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ConvertToModelTest.cs
@@ -316,7 +316,7 @@ namespace FbxExporter.UnitTests
             childDup.transform.parent = newPrefab.transform;
             Assert.That(childObj);
             Assert.That(childDup); // duplicate so we have an object to compare against
-            
+
             var fbxPath = GetRandomFbxFilePath();
 
             // Convert it to a prefab
@@ -331,9 +331,11 @@ namespace FbxExporter.UnitTests
             PrefabUtility.UnloadPrefabContents(newPrefab);
         }
 
-        public static List<string> ChildNames(Transform a) {
+        public static List<string> ChildNames(Transform a)
+        {
             var names = new List<string>();
-            foreach(Transform child in a) {
+            foreach (Transform child in a)
+            {
                 names.Add(child.name);
             }
             return names;
@@ -344,26 +346,26 @@ namespace FbxExporter.UnitTests
         {
             // Test IncrementFileName
             {
-                var tempPath = Path.GetTempPath ();
-                var basename = Path.GetFileNameWithoutExtension (Path.GetRandomFileName ());
+                var tempPath = Path.GetTempPath();
+                var basename = Path.GetFileNameWithoutExtension(Path.GetRandomFileName());
                 basename = basename + "yo"; // add some non-numeric stuff
 
                 var filename1 = basename + ".fbx";
                 var filename2 = Path.Combine(tempPath, basename + " 1.fbx");
-                Assert.AreEqual (filename2, ConvertToNestedPrefab.IncrementFileName (tempPath, filename1));
+                Assert.AreEqual(filename2, ConvertToNestedPrefab.IncrementFileName(tempPath, filename1));
 
                 filename1 = basename + " 1.fbx";
                 filename2 = Path.Combine(tempPath, basename + " 2.fbx");
-                Assert.AreEqual (filename2, ConvertToNestedPrefab.IncrementFileName (tempPath, filename1));
+                Assert.AreEqual(filename2, ConvertToNestedPrefab.IncrementFileName(tempPath, filename1));
 
                 filename1 = basename + "1.fbx";
                 filename2 = Path.Combine(tempPath, basename + "2.fbx");
-                Assert.AreEqual (filename2, ConvertToNestedPrefab.IncrementFileName (tempPath, filename1));
+                Assert.AreEqual(filename2, ConvertToNestedPrefab.IncrementFileName(tempPath, filename1));
 
                 // UNI-25513: bug was that Cube01.fbx => Cube2.fbx
                 filename1 = basename + "01.fbx";
                 filename2 = Path.Combine(tempPath, basename + "02.fbx");
-                Assert.AreEqual (filename2, ConvertToNestedPrefab.IncrementFileName (tempPath, filename1));
+                Assert.AreEqual(filename2, ConvertToNestedPrefab.IncrementFileName(tempPath, filename1));
             }
 
             // Test EnforceUniqueNames
@@ -405,60 +407,60 @@ namespace FbxExporter.UnitTests
 
             // Test CopyComponents
             {
-                var a = GameObject.CreatePrimitive (PrimitiveType.Cube);
+                var a = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 a.name = "a";
-                var b = GameObject.CreatePrimitive (PrimitiveType.Sphere);
+                var b = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 b.name = "b";
                 a.AddComponent<BoxCollider>();
-                a.transform.localPosition += new Vector3(1,2,3);
+                a.transform.localPosition += new Vector3(1, 2, 3);
                 Assert.IsFalse(b.GetComponent<BoxCollider>());
                 Assert.AreEqual(Vector3.zero, b.transform.localPosition);
-                Assert.AreNotEqual (a.GetComponent<MeshFilter>().sharedMesh, b.GetComponent<MeshFilter> ().sharedMesh);
+                Assert.AreNotEqual(a.GetComponent<MeshFilter>().sharedMesh, b.GetComponent<MeshFilter>().sharedMesh);
                 ConvertToNestedPrefab.GatherSceneHierarchy(b);
                 ConvertToNestedPrefab.MapNameToSourceRecursive(b, a);
                 var fixSceneRefsMap = new Dictionary<Object, Object>();
                 ConvertToNestedPrefab.CopyComponents(b, a, a, fixSceneRefsMap);
                 Assert.IsTrue(b.GetComponent<BoxCollider>());
                 Assert.AreEqual(a.transform.localPosition, b.transform.localPosition);
-                Assert.AreNotEqual (a.GetComponent<MeshFilter>().sharedMesh, b.GetComponent<MeshFilter> ().sharedMesh);
+                Assert.AreNotEqual(a.GetComponent<MeshFilter>().sharedMesh, b.GetComponent<MeshFilter>().sharedMesh);
             }
 
             // Test UpdateFromSourceRecursive. Very similar but recursive.
             {
-                var a = GameObject.CreatePrimitive (PrimitiveType.Cube);
+                var a = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 a.name = "a";
-                var a1 = GameObject.CreatePrimitive (PrimitiveType.Cube);
+                var a1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 a1.name = "AA";
-                var a2 = GameObject.CreatePrimitive (PrimitiveType.Cube);
+                var a2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
                 a2.name = "BB";
                 a2.transform.parent = a.transform;
                 a1.transform.parent = a.transform; // out of alpha order!
-                var b = GameObject.CreatePrimitive (PrimitiveType.Sphere);
+                var b = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 b.name = "b";
-                var b1 = GameObject.CreatePrimitive (PrimitiveType.Sphere);
+                var b1 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 b1.name = "AA";
-                var b2 = GameObject.CreatePrimitive (PrimitiveType.Sphere);
+                var b2 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
                 b2.name = "BB";
                 b1.transform.parent = b.transform;
                 b2.transform.parent = b.transform; // in alpha order
-                a.AddComponent<BoxCollider> ();
-                a1.transform.localPosition = new Vector3 (1, 2, 3);
+                a.AddComponent<BoxCollider>();
+                a1.transform.localPosition = new Vector3(1, 2, 3);
                 a.transform.localPosition = new Vector3(4, 5, 6);
 
                 Assert.AreNotEqual(b.GetComponent<MeshFilter>().sharedMesh, a.GetComponent<MeshFilter>().sharedMesh);
-                Assert.IsFalse (b.GetComponent<BoxCollider> ());
-                Assert.AreEqual ("BB", b.transform.GetChild (1).name);
-                Assert.AreEqual (Vector3.zero, b1.transform.localPosition);
+                Assert.IsFalse(b.GetComponent<BoxCollider>());
+                Assert.AreEqual("BB", b.transform.GetChild(1).name);
+                Assert.AreEqual(Vector3.zero, b1.transform.localPosition);
 
                 ConvertToNestedPrefab.GatherSceneHierarchy(a);
-                ConvertToNestedPrefab.UpdateFromSourceRecursive (b, a);
+                ConvertToNestedPrefab.UpdateFromSourceRecursive(b, a);
 
                 // everything except the mesh + materials and child transforms should change
                 Assert.AreNotEqual(b.GetComponent<MeshFilter>().sharedMesh, a.GetComponent<MeshFilter>().sharedMesh);
-                Assert.IsTrue (b.GetComponent<BoxCollider> ());
-                Assert.AreEqual ("BB", b.transform.GetChild (1).name);
+                Assert.IsTrue(b.GetComponent<BoxCollider>());
+                Assert.AreEqual("BB", b.transform.GetChild(1).name);
                 Assert.AreEqual(a.transform.localPosition, b.transform.localPosition);
-                Assert.AreNotEqual (a1.transform.localPosition, b1.transform.localPosition);
+                Assert.AreNotEqual(a1.transform.localPosition, b1.transform.localPosition);
             }
 
             // Test GetFbxAssetOrNull
@@ -587,7 +589,8 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void ExhaustiveTests() {
+        public void ExhaustiveTests()
+        {
             // Try convert in every corner case we can imagine.
 
             // Test Convert on an object in the scene
@@ -760,10 +763,10 @@ namespace FbxExporter.UnitTests
             var cubePrefab = ConvertToNestedPrefab.Convert(cube,
                 fbxFullPath: path, prefabFullPath: Path.ChangeExtension(path, ".prefab"));
 
-            Assert.That (!cube);
-            Assert.That (cubePrefab);
+            Assert.That(!cube);
+            Assert.That(cubePrefab);
 
-            Assert.AreEqual (Path.GetFileNameWithoutExtension (path), cubePrefab.name);
+            Assert.AreEqual(Path.GetFileNameWithoutExtension(path), cubePrefab.name);
         }
 
         [Test]
@@ -785,7 +788,7 @@ namespace FbxExporter.UnitTests
 
             // Undo prefab convert
             Undo.PerformUndo();
-            
+
             // Make sure name is same as original
             Assert.AreEqual("cube 1", cube.name);
         }

--- a/com.unity.formats.fbx/Tests/FbxTests/DefaultSelectionTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/DefaultSelectionTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Autodesk.Fbx;
@@ -17,23 +17,24 @@ namespace FbxExporter.UnitTests
         internal ExportModelSettingsSerialize m_centerObjectsSetting;
 
         [SetUp]
-        public override void Init ()
+        public override void Init()
         {
             base.Init();
-            m_centerObjectsSetting = new ExportModelSettingsSerialize ();
+            m_centerObjectsSetting = new ExportModelSettingsSerialize();
         }
 
         [TearDown]
-        public override void Term ()
+        public override void Term()
         {
-            base.Term ();
-            if (m_root) {
-                UnityEngine.Object.DestroyImmediate (m_root);
+            base.Term();
+            if (m_root)
+            {
+                UnityEngine.Object.DestroyImmediate(m_root);
             }
         }
 
         [Test]
-        public void TestDefaultSelection ()
+        public void TestDefaultSelection()
         {
             // Default selection behavior:
             //  - Export descendants
@@ -54,8 +55,8 @@ namespace FbxExporter.UnitTests
             //    then export the translations so they are centered
             //    around the center of the union of the bounding boxes.
 
-            m_root = CreateHierarchy ();
-            Assert.IsNotNull (m_root);
+            m_root = CreateHierarchy();
+            Assert.IsNotNull(m_root);
 
             // test without centered objects
             m_centerObjectsSetting.SetObjectPosition(ExportSettings.ObjectPosition.WorldAbsolute);
@@ -63,55 +64,57 @@ namespace FbxExporter.UnitTests
             // test Export Root
             // Expected result: everything gets exported
             // Expected transform: all transforms unchanged
-            var exportedRoot = ExportSelection (m_root, m_centerObjectsSetting);
-            CompareHierarchies (m_root, exportedRoot, true, false);
-            CompareGlobalTransform (exportedRoot.transform, m_root.transform);
+            var exportedRoot = ExportSelection(m_root, m_centerObjectsSetting);
+            CompareHierarchies(m_root, exportedRoot, true, false);
+            CompareGlobalTransform(exportedRoot.transform, m_root.transform);
 
             // test Export Parent1, Child1
             // Expected result: Parent1, Child1, Child2
             // Expected transform: all transforms unchanged
-            var parent1 = m_root.transform.Find ("Parent1");
-            var child1 = parent1.Find ("Child1");
-            exportedRoot = ExportSelection (new Object[]{ parent1.gameObject, child1.gameObject }, m_centerObjectsSetting);
-            CompareHierarchies (parent1.gameObject, exportedRoot, true, false);
-            CompareGlobalTransform (exportedRoot.transform, parent1);
+            var parent1 = m_root.transform.Find("Parent1");
+            var child1 = parent1.Find("Child1");
+            exportedRoot = ExportSelection(new Object[] { parent1.gameObject, child1.gameObject }, m_centerObjectsSetting);
+            CompareHierarchies(parent1.gameObject, exportedRoot, true, false);
+            CompareGlobalTransform(exportedRoot.transform, parent1);
 
             // test Export Child2
             // Expected result: Child2
             // Expected transform: Child2 unchanged
-            var child2 = parent1.Find ("Child2").gameObject;
-            exportedRoot = ExportSelection (child2, m_centerObjectsSetting);
-            CompareHierarchies (child2, exportedRoot, true, false);
-            CompareGlobalTransform (exportedRoot.transform, child2.transform);
+            var child2 = parent1.Find("Child2").gameObject;
+            exportedRoot = ExportSelection(child2, m_centerObjectsSetting);
+            CompareHierarchies(child2, exportedRoot, true, false);
+            CompareGlobalTransform(exportedRoot.transform, child2.transform);
 
             // test Export Child2, Parent2
             // Expected result: Parent2, Child3, Child2
             // Expected transform: Child2 and Parent2 maintain global transform
-            var parent2 = m_root.transform.Find ("Parent2");
-            var exportSet = new Object[]{ child2, parent2 };
+            var parent2 = m_root.transform.Find("Parent2");
+            var exportSet = new Object[] { child2, parent2 };
             // for passing to FindCenter()
-            var goExportSet = new GameObject[]{ child2.gameObject, parent2.gameObject };
+            var goExportSet = new GameObject[] { child2.gameObject, parent2.gameObject };
 
             // test without centering objects
             m_centerObjectsSetting.SetObjectPosition(ExportSettings.ObjectPosition.WorldAbsolute);
 
-            exportedRoot = ExportSelection (exportSet, m_centerObjectsSetting);
-            List<GameObject> children = new List<GameObject> ();
-            foreach (Transform child in exportedRoot.transform) {
-                children.Add (child.gameObject);
+            exportedRoot = ExportSelection(exportSet, m_centerObjectsSetting);
+            List<GameObject> children = new List<GameObject>();
+            foreach (Transform child in exportedRoot.transform)
+            {
+                children.Add(child.gameObject);
             }
-            CompareHierarchies (new GameObject[]{ child2, parent2.gameObject }, children.ToArray ());
+            CompareHierarchies(new GameObject[] { child2, parent2.gameObject }, children.ToArray());
 
             // test with centered objects
             m_centerObjectsSetting.SetObjectPosition(ExportSettings.ObjectPosition.LocalCentered);
-            var newCenter = ModelExporter.FindCenter (goExportSet);
+            var newCenter = ModelExporter.FindCenter(goExportSet);
 
-            exportedRoot = ExportSelection (exportSet, m_centerObjectsSetting);
-            children = new List<GameObject> ();
-            foreach (Transform child in exportedRoot.transform) {
-                children.Add (child.gameObject);
+            exportedRoot = ExportSelection(exportSet, m_centerObjectsSetting);
+            children = new List<GameObject>();
+            foreach (Transform child in exportedRoot.transform)
+            {
+                children.Add(child.gameObject);
             }
-            CompareHierarchies (new GameObject[]{ child2, parent2.gameObject }, children.ToArray (), newCenter);
+            CompareHierarchies(new GameObject[] { child2, parent2.gameObject }, children.ToArray(), newCenter);
         }
 
         /// <summary>
@@ -122,14 +125,16 @@ namespace FbxExporter.UnitTests
         /// <param name="actual">Actual.</param>
         /// <param name="expected">Expected.</param>
         /// <param name="center">New center for expected transform, if present.</param>
-        private void CompareGlobalTransform (Transform actual, Transform expected = null, Vector3 center = default(Vector3))
+        private void CompareGlobalTransform(Transform actual, Transform expected = null, Vector3 center = default(Vector3))
         {
-            var actualMatrix = ConstructTRSMatrix (actual);
-            var expectedMatrix = expected == null ? new FbxAMatrix () : ConstructTRSMatrix (expected, false, center);
+            var actualMatrix = ConstructTRSMatrix(actual);
+            var expectedMatrix = expected == null ? new FbxAMatrix() : ConstructTRSMatrix(expected, false, center);
 
-            for (int i = 0; i < 4; i++) {
-                for (int j = 0; j < 4; j++) {
-                    Assert.That (actualMatrix [i] [j], Is.EqualTo (expectedMatrix [i] [j]).Within(0.0001));
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    Assert.That(actualMatrix[i][j], Is.EqualTo(expectedMatrix[i][j]).Within(0.0001));
                 }
             }
         }
@@ -141,15 +146,15 @@ namespace FbxExporter.UnitTests
         /// <param name="t">Transform.</param>
         /// <param name="local">If set to <c>true</c> use local transform.</param>
         /// <param name="center">New center for global transform.</param>
-        private FbxAMatrix ConstructTRSMatrix (Transform t, bool local = true, Vector3 center = default(Vector3))
+        private FbxAMatrix ConstructTRSMatrix(Transform t, bool local = true, Vector3 center = default(Vector3))
         {
-            var translation = local ? t.localPosition : ModelExporter.GetRecenteredTranslation (t, center);
+            var translation = local ? t.localPosition : ModelExporter.GetRecenteredTranslation(t, center);
             var rotation = local ? t.localEulerAngles : t.eulerAngles;
             var scale = local ? t.localScale : t.lossyScale;
-            return new FbxAMatrix (
-                new FbxVector4 (translation.x, translation.y, translation.z),
-                new FbxVector4 (rotation.x, rotation.y, rotation.z),
-                new FbxVector4 (scale.x, scale.y, scale.z)
+            return new FbxAMatrix(
+                new FbxVector4(translation.x, translation.y, translation.z),
+                new FbxVector4(rotation.x, rotation.y, rotation.z),
+                new FbxVector4(scale.x, scale.y, scale.z)
             );
         }
 
@@ -160,7 +165,7 @@ namespace FbxExporter.UnitTests
         /// <param name="pos">Position.</param>
         /// <param name="rot">Rotation.</param>
         /// <param name="scale">Scale.</param>
-        private void SetTransform (Transform t, Vector3 pos, Vector3 rot, Vector3 scale)
+        private void SetTransform(Transform t, Vector3 pos, Vector3 rot, Vector3 scale)
         {
             t.localPosition = pos;
             t.localEulerAngles = rot;
@@ -174,27 +179,30 @@ namespace FbxExporter.UnitTests
         /// <param name="actualHierarchy">Actual hierarchy.</param>
         /// <param name="ignoreName">If set to <c>true</c> ignore name.</param>
         /// <param name="compareTransform">If set to <c>true</c> compare transform.</param>
-        private void CompareHierarchies (
+        private void CompareHierarchies(
             GameObject expectedHierarchy, GameObject actualHierarchy,
             bool ignoreName = false, bool compareTransform = true)
         {
-            if (!ignoreName) {
-                Assert.AreEqual (expectedHierarchy.name, actualHierarchy.name);
+            if (!ignoreName)
+            {
+                Assert.AreEqual(expectedHierarchy.name, actualHierarchy.name);
             }
 
             var expectedTransform = expectedHierarchy.transform;
             var actualTransform = actualHierarchy.transform;
 
-            if (compareTransform) {
-                Assert.AreEqual (expectedTransform, actualTransform);
+            if (compareTransform)
+            {
+                Assert.AreEqual(expectedTransform, actualTransform);
             }
 
-            Assert.AreEqual (expectedTransform.childCount, actualTransform.childCount);
+            Assert.AreEqual(expectedTransform.childCount, actualTransform.childCount);
 
-            foreach (Transform expectedChild in expectedTransform) {
-                var actualChild = actualTransform.Find (expectedChild.name);
-                Assert.IsNotNull (actualChild);
-                CompareHierarchies (expectedChild.gameObject, actualChild.gameObject);
+            foreach (Transform expectedChild in expectedTransform)
+            {
+                var actualChild = actualTransform.Find(expectedChild.name);
+                Assert.IsNotNull(actualChild);
+                CompareHierarchies(expectedChild.gameObject, actualChild.gameObject);
             }
         }
 
@@ -204,22 +212,23 @@ namespace FbxExporter.UnitTests
         /// <param name="expectedHierarchy">Expected hierarchy.</param>
         /// <param name="actualHierarchy">Actual hierarchy.</param>
         /// <param name="center">New center for global transforms.</param>
-        private void CompareHierarchies (GameObject[] expectedHierarchy, GameObject[] actualHierarchy, Vector3 center = default(Vector3))
+        private void CompareHierarchies(GameObject[] expectedHierarchy, GameObject[] actualHierarchy, Vector3 center = default(Vector3))
         {
-            Assert.AreEqual (expectedHierarchy.Length, actualHierarchy.Length);
+            Assert.AreEqual(expectedHierarchy.Length, actualHierarchy.Length);
 
-            System.Array.Sort (expectedHierarchy, delegate (GameObject x, GameObject y) {
-                return x.name.CompareTo (y.name);
+            System.Array.Sort(expectedHierarchy, delegate(GameObject x, GameObject y) {
+                return x.name.CompareTo(y.name);
             });
-            System.Array.Sort (actualHierarchy, delegate (GameObject x, GameObject y) {
-                return x.name.CompareTo (y.name);
+            System.Array.Sort(actualHierarchy, delegate(GameObject x, GameObject y) {
+                return x.name.CompareTo(y.name);
             });
 
-            for (int i = 0; i < expectedHierarchy.Length; i++) {
-                CompareHierarchies (expectedHierarchy [i], actualHierarchy [i], false, false);
+            for (int i = 0; i < expectedHierarchy.Length; i++)
+            {
+                CompareHierarchies(expectedHierarchy[i], actualHierarchy[i], false, false);
                 // if we are Comparing lists of hierarchies, that means that the transforms
                 // should be the global transform of expected, as there is no zeroed out root
-                CompareGlobalTransform (actualHierarchy [i].transform, expectedHierarchy [i].transform, center);
+                CompareGlobalTransform(actualHierarchy[i].transform, expectedHierarchy[i].transform, center);
             }
         }
     }

--- a/com.unity.formats.fbx/Tests/FbxTests/ExportTimelineClipTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ExportTimelineClipTest.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using NUnit.Framework;
 using UnityEngine.Timeline;
 using UnityEngine.Playables;
@@ -22,19 +22,22 @@ namespace FbxExporter.UnitTests
             string filePath = null;
             var exportData = new Dictionary<GameObject, IExportData>();
 
-            PlayableDirector pd = myCube.GetComponent<PlayableDirector> ();
-            if (pd != null) {
-                foreach (PlayableBinding output in pd.playableAsset.outputs) {
+            PlayableDirector pd = myCube.GetComponent<PlayableDirector>();
+            if (pd != null)
+            {
+                foreach (PlayableBinding output in pd.playableAsset.outputs)
+                {
                     AnimationTrack at = output.sourceObject as AnimationTrack;
 
                     var atComponent = pd.GetGenericBinding(at) as Component;
-                    Assert.That (atComponent, Is.Not.Null);
+                    Assert.That(atComponent, Is.Not.Null);
 
                     var atObject = atComponent.gameObject;
 
                     // One file by animation clip
-                    foreach (TimelineClip timeLineClip in at.GetClips()) {
-                        Assert.That (timeLineClip.animationClip, Is.Not.Null);
+                    foreach (TimelineClip timeLineClip in at.GetClips())
+                    {
+                        Assert.That(timeLineClip.animationClip, Is.Not.Null);
 
                         filePath = $"{folderPath}/{atObject.name}@Recorded.fbx";
                         exportData[atObject] = ModelExporter.GetExportData(atObject, timeLineClip.animationClip);
@@ -42,10 +45,10 @@ namespace FbxExporter.UnitTests
                     }
                 }
             }
-            Assert.That (filePath, Is.Not.Null);
-            Assert.That (exportData, Is.Not.Null);
+            Assert.That(filePath, Is.Not.Null);
+            Assert.That(exportData, Is.Not.Null);
             ModelExporter.ExportObjects(filePath, new UnityEngine.Object[1] { myCube }, null, exportData);
-            FileAssert.Exists (filePath);
+            FileAssert.Exists(filePath);
         }
 
         [Test]

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
@@ -13,95 +13,116 @@ using UnityEditor.Formats.Fbx.Exporter.CustomExtensions;
 
 namespace FbxExporter.UnitTests
 {
-    public enum RotationCurveType {
-        kEuler=3,
-        kQuaternion=4
+    public enum RotationCurveType
+    {
+        kEuler = 3,
+        kQuaternion = 4
     };
 
     public class AnimationTestDataClass
     {
         // TODO: remove items that become supported by exporter
-        public static IEnumerable<System.Type> m_exceptionTypes = new List<System.Type> ()
+        public static IEnumerable<System.Type> m_exceptionTypes = new List<System.Type>()
         {
             typeof(MeshFilter),
             typeof(SkinnedMeshRenderer),
             typeof(Transform),              // NOTE: has it's own special tests
         };
 
-        public static IEnumerable<System.Type> m_componentTypes = 
-            typeof (Component).Assembly.GetTypes ().
-            Where (t => typeof (Component).IsAssignableFrom (t) && 
-                   ModelExporter.MapsToFbxObject.ContainsKey(t)).Except(m_exceptionTypes);
+        public static IEnumerable<System.Type> m_componentTypes =
+            typeof(Component).Assembly.GetTypes().
+                Where(t => typeof(Component).IsAssignableFrom(t) &&
+                    ModelExporter.MapsToFbxObject.ContainsKey(t)).Except(m_exceptionTypes);
 
-        public static string [] m_rotationQuaternionNames = new string [4] { "m_LocalRotation.x", "m_LocalRotation.y", "m_LocalRotation.z", "m_LocalRotation.w" };
-        public static string [] m_rotationEulerNames = new string [3] { "localEulerAnglesRaw.x", "localEulerAnglesRaw.y", "localEulerAnglesRaw.z" };
-        public static string [] m_translationNames = new string [3] { "m_LocalPosition.x", "m_LocalPosition.y", "m_LocalPosition.z"};
+        public static string[] m_rotationQuaternionNames = new string[4] { "m_LocalRotation.x", "m_LocalRotation.y", "m_LocalRotation.z", "m_LocalRotation.w" };
+        public static string[] m_rotationEulerNames = new string[3] { "localEulerAnglesRaw.x", "localEulerAnglesRaw.y", "localEulerAnglesRaw.z" };
+        public static string[] m_translationNames = new string[3] { "m_LocalPosition.x", "m_LocalPosition.y", "m_LocalPosition.z"};
 
-        public static IEnumerable TransformIndependantComponentTestCases {
-            get {
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (Transform), "m_LocalScale.x").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (Transform), "m_LocalScale.y").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (Transform), "m_LocalScale.z").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 0f, 100f, 0f }, typeof (Transform), "m_LocalPosition.x").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 0f, 100f, 0f }, typeof (Transform), "m_LocalPosition.y").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 0f, 100f, 0f }, typeof (Transform), "m_LocalPosition.z").Returns (1);
+        public static IEnumerable TransformIndependantComponentTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(Transform), "m_LocalScale.x").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(Transform), "m_LocalScale.y").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(Transform), "m_LocalScale.z").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 0f, 100f, 0f }, typeof(Transform), "m_LocalPosition.x").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 0f, 100f, 0f }, typeof(Transform), "m_LocalPosition.y").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 0f, 100f, 0f }, typeof(Transform), "m_LocalPosition.z").Returns(1);
             }
         }
-        public static IEnumerable BlendshapeAnimationTestCases {
-            get {
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (SkinnedMeshRenderer), "blendShape.Cube").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (SkinnedMeshRenderer), "blendShape.CubeAndCylinder").Returns (1);
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new float [3] { 1f, 100f, 1f }, typeof (SkinnedMeshRenderer), "blendShape.Cylinder").Returns (1);
+        public static IEnumerable BlendshapeAnimationTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(SkinnedMeshRenderer), "blendShape.Cube").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(SkinnedMeshRenderer), "blendShape.CubeAndCylinder").Returns(1);
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new float[3] { 1f, 100f, 1f }, typeof(SkinnedMeshRenderer), "blendShape.Cylinder").Returns(1);
             }
         }
-        public static IEnumerable QuaternionTestCases {
-            get {
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new Vector3 [3]{new Vector3 (0f, 80f, 0f), new Vector3 (80f, 0f, 0f),new Vector3 (0f, 0f, 80f)}, typeof (Transform), m_rotationQuaternionNames ).Returns (3);
+        public static IEnumerable QuaternionTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new Vector3[3] {new Vector3(0f, 80f, 0f), new Vector3(80f, 0f, 0f), new Vector3(0f, 0f, 80f)}, typeof(Transform), m_rotationQuaternionNames).Returns(3);
             }
         }
         // specify gimbal conditions for rotation
-        public static IEnumerable GimbalTestCases {
-            get {
-                yield return new TestCaseData (new float [3] { 1f, 2f, 3f }, new Vector3 [3] { new Vector3 (90f, 0f, 0f), new Vector3 (90f, 30f, 0f), new Vector3 (90f, 0f, 30f) }, typeof (Transform), m_rotationQuaternionNames ).Returns (3);
+        public static IEnumerable GimbalTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new float[3] { 1f, 2f, 3f }, new Vector3[3] { new Vector3(90f, 0f, 0f), new Vector3(90f, 30f, 0f), new Vector3(90f, 0f, 30f) }, typeof(Transform), m_rotationQuaternionNames).Returns(3);
             }
         }
         // specify one of each component type
-        public static IEnumerable ComponentTestCases { 
-            get {
+        public static IEnumerable ComponentTestCases
+        {
+            get
+            {
                 foreach (var cType in m_componentTypes)
-                    yield return new TestCaseData (cType).Returns(1);
+                    yield return new TestCaseData(cType).Returns(1);
             }
         }
         // specify continuous rotations
-        public static IEnumerable ContinuousRotationTestCases {
-            get {
-                yield return new TestCaseData (RotationCurveType.kEuler, new float [5] { 0f, 30f, 60f, 90f, 120f }, new Vector3 [5]{new Vector3 (0f, 0f, 0f), new Vector3 (0f, -90f, 0f), new Vector3 (0f, -180f, 0f), new Vector3 (0f, -270f, 0f), new Vector3 (0f, -360f, 0f)}).Returns (3);
-                yield return new TestCaseData (RotationCurveType.kQuaternion, new float [5] { 0f, 30f, 60f, 90f, 120f }, new Vector3 [5]{new Vector3 (0f, 0f, 0f), new Vector3 (0f, -90f, 0f), new Vector3 (0f, -180f, 0f), new Vector3 (0f, -270f, 0f), new Vector3 (0f, -360f, 0f)}).Returns (3);
+        public static IEnumerable ContinuousRotationTestCases
+        {
+            get
+            {
+                yield return new TestCaseData(RotationCurveType.kEuler, new float[5] { 0f, 30f, 60f, 90f, 120f }, new Vector3[5] {new Vector3(0f, 0f, 0f), new Vector3(0f, -90f, 0f), new Vector3(0f, -180f, 0f), new Vector3(0f, -270f, 0f), new Vector3(0f, -360f, 0f)}).Returns(3);
+                yield return new TestCaseData(RotationCurveType.kQuaternion, new float[5] { 0f, 30f, 60f, 90f, 120f }, new Vector3[5] {new Vector3(0f, 0f, 0f), new Vector3(0f, -90f, 0f), new Vector3(0f, -180f, 0f), new Vector3(0f, -270f, 0f), new Vector3(0f, -360f, 0f)}).Returns(3);
             }
         }
 
-        public static IEnumerable SkinnedMeshTestCases {
-            get {
+        public static IEnumerable SkinnedMeshTestCases
+        {
+            get
+            {
                 yield return "Models/DefaultMale/Male_DyingHitFromBack_Blend_T3_Cut01_James.fbx";
             }
         }
 
-        public static IEnumerable BlendShapeTestCases {
-            get {
+        public static IEnumerable BlendShapeTestCases
+        {
+            get
+            {
                 yield return "Models/blendshape.fbx";
                 yield return "Models/blendshape_with_skinning.fbx";
             }
         }
 
-        public static IEnumerable AnimOnlyTestCases {
-            get {
-                yield return new TestCaseData ("Models/DefaultMale/DefaultMale.prefab");
+        public static IEnumerable AnimOnlyTestCases
+        {
+            get
+            {
+                yield return new TestCaseData("Models/DefaultMale/DefaultMale.prefab");
             }
         }
 
-        public static IEnumerable RotationCurveTestCases {
-            get {
-                yield return new TestCaseData ("Models/Player/Player.prefab");
+        public static IEnumerable RotationCurveTestCases
+        {
+            get
+            {
+                yield return new TestCaseData("Models/Player/Player.prefab");
             }
         }
     }
@@ -110,82 +131,83 @@ namespace FbxExporter.UnitTests
     public class FbxAnimationTest : ExporterTestBase
     {
         // map imported clips with alt property name to property name used for instantiated prefabs
-        protected static Dictionary<string, string> MapEulerToQuaternionPropertyName = new Dictionary<string, string> {
+        protected static Dictionary<string, string> MapEulerToQuaternionPropertyName = new Dictionary<string, string>
+        {
             { "localEulerAnglesRaw.x", "m_LocalRotation.x" },
             { "localEulerAnglesRaw.y", "m_LocalRotation.y" },
             { "localEulerAnglesRaw.z", "m_LocalRotation.z" },
         };
 
         [TearDown]
-        public override void Term ()
+        public override void Term()
         {
             #if (!DEBUG_UNITTEST)
-            base.Term ();
+            base.Term();
             #endif
         }
 
-       public class KeyData
+        public class KeyData
         {
-            public float [] keyTimes;
+            public float[] keyTimes;
             public System.Type componentType;
             public GameObject targetObject;
             public object importSettings;
-            public bool compareOriginalKeys = false;    // should we compare against the original data or evaluate the 
+            public bool compareOriginalKeys = false;    // should we compare against the original data or evaluate the
                                                         // actual curve against the original curve?
 
             public virtual int NumKeys { get { return 0; } }
             public virtual int NumProperties { get { return 0; } }
             public virtual float[] GetKeyValues(int id) { return null; }
-            public virtual float [] GetAltKeyValues (int id) { return GetKeyValues(id); }
-            public virtual string GetPropertyName (int id) { return null; }
-            public virtual int GetIndexOf (string name) { return -1; }
-
+            public virtual float[] GetAltKeyValues(int id) { return GetKeyValues(id); }
+            public virtual string GetPropertyName(int id) { return null; }
+            public virtual int GetIndexOf(string name) { return -1; }
         }
 
         public class PropertyKeyData : KeyData
         {
             public string propertyName;
-            public float [] keyFloatValues;
+            public float[] keyFloatValues;
 
-            public override int     NumKeys { get { return Mathf.Min (keyTimes.Length, keyFloatValues.Length); } }
+            public override int     NumKeys { get { return Mathf.Min(keyTimes.Length, keyFloatValues.Length); } }
             public override int     NumProperties { get { return 1; } }
-            public override float[] GetKeyValues (int id) { return keyFloatValues; }
-            public override string  GetPropertyName (int id) { return propertyName; }
-            public override int     GetIndexOf (string name) { return (name == propertyName) ? 0 : -1; }
+            public override float[] GetKeyValues(int id) { return keyFloatValues; }
+            public override string  GetPropertyName(int id) { return propertyName; }
+            public override int     GetIndexOf(string name) { return (name == propertyName) ? 0 : -1; }
         }
 
         public class MultiPropertyKeyData : KeyData
         {
             public string[] propertyNames;
-            public System.Single [] keyValues;
+            public System.Single[] keyValues;
 
-            public override int NumKeys { get { return Mathf.Min (keyTimes.Length, keyValues.Length); } }
+            public override int NumKeys { get { return Mathf.Min(keyTimes.Length, keyValues.Length); } }
             public override int NumProperties { get { return propertyNames.Length; } }
-            public override float [] GetKeyValues (int id) { return keyValues; }
-            public override string GetPropertyName (int id) { return propertyNames[id]; }
-            public override int GetIndexOf (string name) { return System.Array.IndexOf (propertyNames, name); }
+            public override float[] GetKeyValues(int id) { return keyValues; }
+            public override string GetPropertyName(int id) { return propertyNames[id]; }
+            public override int GetIndexOf(string name) { return System.Array.IndexOf(propertyNames, name); }
         }
 
         public class QuaternionKeyData : KeyData
         {
             public string[] propertyNames;
-            public Vector3 [] keyEulerValues;
+            public Vector3[] keyEulerValues;
 
-            public override int NumKeys { get { return Mathf.Min (keyTimes.Length, keyEulerValues.Length); } }
+            public override int NumKeys { get { return Mathf.Min(keyTimes.Length, keyEulerValues.Length); } }
             public override int NumProperties { get { return propertyNames.Length; } }
-            public override float [] GetKeyValues (int id)
+            public override float[] GetKeyValues(int id)
             {
-                return (from e in keyEulerValues select Quaternion.Euler(e)[id]).ToArray ();
-            }
-            public override float [] GetAltKeyValues (int id)
-            {
-                return (from e in keyEulerValues select e[id]).ToArray ();
+                return (from e in keyEulerValues select Quaternion.Euler(e)[id]).ToArray();
             }
 
-            public override string GetPropertyName (int id) { return propertyNames[id]; }
-            public override int GetIndexOf (string name)
+            public override float[] GetAltKeyValues(int id)
             {
-                return System.Array.IndexOf (propertyNames, name);
+                return (from e in keyEulerValues select e[id]).ToArray();
+            }
+
+            public override string GetPropertyName(int id) { return propertyNames[id]; }
+            public override int GetIndexOf(string name)
+            {
+                return System.Array.IndexOf(propertyNames, name);
             }
         }
 
@@ -194,25 +216,25 @@ namespace FbxExporter.UnitTests
             public RotationCurveType RotationType = RotationCurveType.kEuler;
 
             public string[] propertyNames;
-            public Vector3 [] keyPosValues; 
-            public Vector3 [] keyEulerValues; 
-            private Quaternion [] keyQuatValues;
+            public Vector3[] keyPosValues;
+            public Vector3[] keyEulerValues;
+            private Quaternion[] keyQuatValues;
 
             public bool IsRotation(int id) { return id < (int)RotationType; }
 
             public override int NumKeys { get { return keyTimes.Length; } }
             public override int NumProperties { get { return propertyNames.Length; } }
-            public override float [] GetKeyValues (int id)
+            public override float[] GetKeyValues(int id)
             {
-                if (RotationType==RotationCurveType.kEuler) 
+                if (RotationType == RotationCurveType.kEuler)
                     return GetAltKeyValues(id);
 
                 // compute continous rotations
-                if (keyQuatValues==null)
+                if (keyQuatValues == null)
                 {
                     keyQuatValues = new Quaternion[NumKeys];
 
-                    for (int idx=0;  idx < NumKeys; idx++)
+                    for (int idx = 0; idx < NumKeys; idx++)
                     {
                         keyQuatValues[idx] = Quaternion.Euler(keyEulerValues[idx]);
                     }
@@ -220,33 +242,34 @@ namespace FbxExporter.UnitTests
 
                 float[] result = new float[NumKeys];
 
-                for (int idx=0;  idx < NumKeys; idx++)
+                for (int idx = 0; idx < NumKeys; idx++)
                 {
                     if (IsRotation(id))
                     {
                         switch (RotationType)
                         {
-                        case (RotationCurveType.kEuler):
-                            result[idx] = keyEulerValues[idx][id];
-                            break;
-                        case (RotationCurveType.kQuaternion):
-                            result[idx] = keyQuatValues[idx][id];
-                            break;
+                            case (RotationCurveType.kEuler):
+                                result[idx] = keyEulerValues[idx][id];
+                                break;
+                            case (RotationCurveType.kQuaternion):
+                                result[idx] = keyQuatValues[idx][id];
+                                break;
                         }
                     }
                     else
                     {
-                        result[idx] = keyPosValues[idx][id-(int)RotationType];
+                        result[idx] = keyPosValues[idx][id - (int)RotationType];
                     }
                 }
 
                 return result;
             }
-            public override float [] GetAltKeyValues (int id)
+
+            public override float[] GetAltKeyValues(int id)
             {
                 float[] result = new float[NumKeys];
 
-                for (int idx=0;  idx < NumKeys; idx++)
+                for (int idx = 0; idx < NumKeys; idx++)
                 {
                     // kQuaternion
                     //     0..3 quarternion XYZW
@@ -261,17 +284,17 @@ namespace FbxExporter.UnitTests
                     }
                     else
                     {
-                        result[idx] = keyPosValues[idx][id-(int)RotationType];
+                        result[idx] = keyPosValues[idx][id - (int)RotationType];
                     }
                 }
 
                 return result;
             }
 
-            public override string GetPropertyName (int id) { return propertyNames[id]; }
-            public override int GetIndexOf (string name)
+            public override string GetPropertyName(int id) { return propertyNames[id]; }
+            public override int GetIndexOf(string name)
             {
-                return System.Array.IndexOf (propertyNames, name);
+                return System.Array.IndexOf(propertyNames, name);
             }
         }
 
@@ -285,20 +308,20 @@ namespace FbxExporter.UnitTests
 
                 result &= a.time.Equals(b.time);
                 #if DEBUG_UNITTEST
-                Debug.Log(string.Format("{2} a.time: {0}, b.time: {1}", a.time, b.time,result));
+                Debug.Log(string.Format("{2} a.time: {0}, b.time: {1}", a.time, b.time, result));
                 #endif
 
                 result &= (Mathf.Abs(a.value - b.value) <= Epsilon);
                 #if DEBUG_UNITTEST
-                Debug.Log(string.Format("{2} a.value: {0}, b.value: {1}", a.value, b.value,result));
+                Debug.Log(string.Format("{2} a.value: {0}, b.value: {1}", a.value, b.value, result));
                 #endif
 
-                return  result ? 0 : 1;
+                return result ? 0 : 1;
             }
 
             public virtual int Compare(Keyframe a, Keyframe b)
             {
-                return CompareKeyValue(a,b);
+                return CompareKeyValue(a, b);
             }
         }
 
@@ -309,9 +332,12 @@ namespace FbxExporter.UnitTests
             public string path;
             public IComparer<Keyframe> keyComparer;
             private IExportOptions m_exportOptions;
-            internal IExportOptions exportOptions {
-                get {
-                    if (m_exportOptions == null) {
+            internal IExportOptions exportOptions
+            {
+                get
+                {
+                    if (m_exportOptions == null)
+                    {
                         // get default settings;
                         m_exportOptions = new ExportModelSettingsSerialize();
                     }
@@ -320,131 +346,134 @@ namespace FbxExporter.UnitTests
                 set { m_exportOptions = value; }
             }
 
-            public int DoIt ()
+            public int DoIt()
             {
                 return Main(keyData, testName, path);
             }
 
             public static void ConfigureImportSettings(string filename, object customSettings = null)
             {
-                if (customSettings==null)
+                if (customSettings == null)
                 {
                     customSettings = new {
                         resampleCurves = false,
                         animationType = ModelImporterAnimationType.Legacy,
                         animationCompression = ModelImporterAnimationCompression.Off,
                         importConstraints = true
-                    };                 
+                    };
                 }
 
-                ModelImporter modelImporter = AssetImporter.GetAtPath (filename) as ModelImporter;
-                modelImporter.resampleCurves = (bool)customSettings.GetType().GetProperty("resampleCurves").GetValue(customSettings,null);
-                AssetDatabase.ImportAsset (filename);
-                modelImporter.animationType = (ModelImporterAnimationType)customSettings.GetType().GetProperty("animationType").GetValue(customSettings,null);
-                modelImporter.animationCompression = (ModelImporterAnimationCompression)customSettings.GetType().GetProperty("animationCompression").GetValue(customSettings,null);
+                ModelImporter modelImporter = AssetImporter.GetAtPath(filename) as ModelImporter;
+                modelImporter.resampleCurves = (bool)customSettings.GetType().GetProperty("resampleCurves").GetValue(customSettings, null);
+                AssetDatabase.ImportAsset(filename);
+                modelImporter.animationType = (ModelImporterAnimationType)customSettings.GetType().GetProperty("animationType").GetValue(customSettings, null);
+                modelImporter.animationCompression = (ModelImporterAnimationCompression)customSettings.GetType().GetProperty("animationCompression").GetValue(customSettings, null);
                 modelImporter.importConstraints = (bool)customSettings.GetType().GetProperty("importConstraints").GetValue(customSettings, null);
-                AssetDatabase.ImportAsset (filename);
+                AssetDatabase.ImportAsset(filename);
             }
 
-            public static GameObject CreateTargetObject (string name, System.Type componentType)
+            public static GameObject CreateTargetObject(string name, System.Type componentType)
             {
-                GameObject goModel = new GameObject ();
+                GameObject goModel = new GameObject();
                 goModel.name = "model_" + name;
 
                 // check for component and add if missing
-                var goComponent = goModel.GetComponent (componentType);
+                var goComponent = goModel.GetComponent(componentType);
                 if (!goComponent)
-                    goModel.AddComponent (componentType);
+                    goModel.AddComponent(componentType);
 
                 return goModel;
             }
 
-            public int Main (KeyData keyData, string testName, string path)
+            public int Main(KeyData keyData, string testName, string path)
             {
                 if (!keyData.targetObject)
-                    keyData.targetObject = CreateTargetObject (testName, keyData.componentType);
+                    keyData.targetObject = CreateTargetObject(testName, keyData.componentType);
 
-                Animation animOrig = keyData.targetObject.AddComponent (typeof (Animation)) as Animation;
+                Animation animOrig = keyData.targetObject.AddComponent(typeof(Animation)) as Animation;
 
-                AnimationClip animClipOriginal = new AnimationClip ();
+                AnimationClip animClipOriginal = new AnimationClip();
                 var animCurvesOriginal = new AnimationCurve[keyData.NumProperties];
-                    
+
                 animClipOriginal.legacy = true;
                 animClipOriginal.name = "anim_" + testName;
 
-                for (int id = 0; id < keyData.NumProperties; id++) {
+                for (int id = 0; id < keyData.NumProperties; id++)
+                {
                     // initialize keys
-                    Keyframe [] keys = new Keyframe [keyData.NumKeys];
+                    Keyframe[] keys = new Keyframe[keyData.NumKeys];
 
-                    for (int idx = 0; idx < keyData.NumKeys; idx++) {
-                        keys [idx].time = keyData.keyTimes [idx];
-                        keys [idx].value = keyData.GetKeyValues (id) [idx];
+                    for (int idx = 0; idx < keyData.NumKeys; idx++)
+                    {
+                        keys[idx].time = keyData.keyTimes[idx];
+                        keys[idx].value = keyData.GetKeyValues(id)[idx];
                     }
-                    animCurvesOriginal[id] = new AnimationCurve (keys);
+                    animCurvesOriginal[id] = new AnimationCurve(keys);
 
-                    animClipOriginal.SetCurve ("", keyData.componentType, keyData.GetPropertyName (id), animCurvesOriginal[id]);
+                    animClipOriginal.SetCurve("", keyData.componentType, keyData.GetPropertyName(id), animCurvesOriginal[id]);
                 }
 
-                animOrig.AddClip (animClipOriginal, animClipOriginal.name);
+                animOrig.AddClip(animClipOriginal, animClipOriginal.name);
                 animOrig.clip = animClipOriginal;
 
                 // NOTE: when we first cached the curves the tangents wheren't set.
-                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings (animOrig.clip))
+                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings(animOrig.clip))
                 {
-                    int id = keyData.GetIndexOf (curveBinding.propertyName);
-                    if (id==-1) continue;
+                    int id = keyData.GetIndexOf(curveBinding.propertyName);
+                    if (id == -1) continue;
 
-                    animCurvesOriginal[id] = AnimationUtility.GetEditorCurve (animOrig.clip, curveBinding);
+                    animCurvesOriginal[id] = AnimationUtility.GetEditorCurve(animOrig.clip, curveBinding);
                 }
 
                 // TODO: add extra parent so that we can test export/import of transforms
-                var goRoot = new GameObject ();
+                var goRoot = new GameObject();
                 goRoot.name = "Root_" + testName;
                 keyData.targetObject.transform.parent = goRoot.transform;
 
                 //export the object
-                var exportedFilePath = ModelExporter.ExportObject (path, goRoot, exportOptions);
-                Assert.That (exportedFilePath, Is.EqualTo (path));
+                var exportedFilePath = ModelExporter.ExportObject(path, goRoot, exportOptions);
+                Assert.That(exportedFilePath, Is.EqualTo(path));
 
-                // TODO: Uni-34492 change importer settings of (newly exported model) 
+                // TODO: Uni-34492 change importer settings of (newly exported model)
                 // so that it's not resampled and it is legacy animation
                 AnimTester.ConfigureImportSettings(path, keyData.importSettings);
 
                 // create a scene GO so we can compare.
                 #if DEBUG_UNITTEST
-                GameObject prefabGO = AssetDatabase.LoadMainAssetAtPath (path) as GameObject;
+                GameObject prefabGO = AssetDatabase.LoadMainAssetAtPath(path) as GameObject;
                 GameObject sceneGO = Object.Instantiate(prefabGO, keyData.targetObject.transform.localPosition, keyData.targetObject.transform.localRotation);
                 sceneGO.name = "Imported_" + testName;
-                #endif 
+                #endif
 
                 //acquire imported object from exported file
-                AnimationClip animClipImported = GetClipFromFbx (path);
+                AnimationClip animClipImported = GetClipFromFbx(path);
 
-                ClipPropertyTest (animClipOriginal, animClipImported);
+                ClipPropertyTest(animClipOriginal, animClipImported);
 
                 int result = 0;
 
-                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings (animClipImported)) {
-                    AnimationCurve animCurveImported = AnimationUtility.GetEditorCurve (animClipImported, curveBinding);
-                    Assert.That (animCurveImported, Is.Not.Null);
+                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings(animClipImported))
+                {
+                    AnimationCurve animCurveImported = AnimationUtility.GetEditorCurve(animClipImported, curveBinding);
+                    Assert.That(animCurveImported, Is.Not.Null);
 
                     string propertyBinding = curveBinding.propertyName;
-                    int id = keyData.GetIndexOf (propertyBinding);
+                    int id = keyData.GetIndexOf(propertyBinding);
 
-                    bool hasQuatBinding = 
-                        MapEulerToQuaternionPropertyName.TryGetValue (propertyBinding, out propertyBinding);
+                    bool hasQuatBinding =
+                        MapEulerToQuaternionPropertyName.TryGetValue(propertyBinding, out propertyBinding);
 
                     bool isRotation = AnimationTestDataClass.m_rotationEulerNames.Contains(curveBinding.propertyName) ||
                         AnimationTestDataClass.m_rotationQuaternionNames.Contains(curveBinding.propertyName);
 
-                    if (id==-1)
-                        id = keyData.GetIndexOf (propertyBinding);
+                    if (id == -1)
+                        id = keyData.GetIndexOf(propertyBinding);
 
                     #if DEBUG_UNITTEST
                     Debug.Log(string.Format("propertyBinding={0} mappedBinding={1} id={2}", curveBinding.propertyName, propertyBinding, id));
                     #endif
 
-                    if (id != -1) 
+                    if (id != -1)
                     {
                         if (keyData.compareOriginalKeys)
                         {
@@ -452,21 +481,21 @@ namespace FbxExporter.UnitTests
                             if (!hasQuatBinding)
                             {
                                 // compare against original keydata
-                                KeysTest (keyData.keyTimes, keyData.GetKeyValues (id), animCurveImported, curveBinding.propertyName);
+                                KeysTest(keyData.keyTimes, keyData.GetKeyValues(id), animCurveImported, curveBinding.propertyName);
 
                                 // compare against original animCurve
-                                KeysTest (animCurvesOriginal[id], animCurveImported, curveBinding.propertyName, keyComparer);
+                                KeysTest(animCurvesOriginal[id], animCurveImported, curveBinding.propertyName, keyComparer);
                             }
                             else
                             {
                                 // compare by sampled keyvalues against original keydata
-                                KeyValuesTest (keyData.keyTimes, keyData.GetAltKeyValues (id), animCurveImported, curveBinding.propertyName, isRotation);
+                                KeyValuesTest(keyData.keyTimes, keyData.GetAltKeyValues(id), animCurveImported, curveBinding.propertyName, isRotation);
                             }
                         }
                         else
                         {
                             // compare by sampled keyvalues against original animCurve
-                            KeyValuesTest (animCurvesOriginal[id], animCurveImported, curveBinding.propertyName, isRotation);
+                            KeyValuesTest(animCurvesOriginal[id], animCurveImported, curveBinding.propertyName, isRotation);
                         }
                         result++;
                     }
@@ -475,15 +504,15 @@ namespace FbxExporter.UnitTests
                 return result;
             }
 
-            public static void ClipPropertyTest (AnimationClip animClipExpected, AnimationClip animClipActual)
+            public static void ClipPropertyTest(AnimationClip animClipExpected, AnimationClip animClipActual)
             {
-                Assert.That (animClipActual.name, Is.EqualTo (animClipExpected.name).Or.EqualTo(animClipExpected.name));
-                Assert.That (animClipActual.legacy, Is.EqualTo (animClipExpected.legacy));
-                Assert.That (animClipActual.isLooping, Is.EqualTo (animClipExpected.isLooping));
-                Assert.That (animClipActual.wrapMode, Is.EqualTo (animClipExpected.wrapMode));
+                Assert.That(animClipActual.name, Is.EqualTo(animClipExpected.name).Or.EqualTo(animClipExpected.name));
+                Assert.That(animClipActual.legacy, Is.EqualTo(animClipExpected.legacy));
+                Assert.That(animClipActual.isLooping, Is.EqualTo(animClipExpected.isLooping));
+                Assert.That(animClipActual.wrapMode, Is.EqualTo(animClipExpected.wrapMode));
 
                 // TODO: Uni-34489
-                Assert.That (animClipActual.length, Is.EqualTo (animClipExpected.length).Within (0.0001f), "animClip length doesn't match");
+                Assert.That(animClipActual.length, Is.EqualTo(animClipExpected.length).Within(0.0001f), "animClip length doesn't match");
             }
 
             /// <summary>
@@ -491,13 +520,15 @@ namespace FbxExporter.UnitTests
             /// </summary>
             /// <param name="animClipsOriginal">Animation clips original.</param>
             /// <param name="animClipsImported">Animation clips imported.</param>
-            public static void MultiClipTest(AnimationClip[] animClipsOriginal, Dictionary<string, AnimationClip> animClipsImported){
-                Assert.That (animClipsImported.Count, Is.EqualTo (animClipsOriginal.Length));
+            public static void MultiClipTest(AnimationClip[] animClipsOriginal, Dictionary<string, AnimationClip> animClipsImported)
+            {
+                Assert.That(animClipsImported.Count, Is.EqualTo(animClipsOriginal.Length));
 
-                foreach (var clip in animClipsOriginal) {
-                    Assert.That (animClipsImported.ContainsKey (clip.name));
-                    var fbxClip = animClipsImported [clip.name];
-                    AnimTester.ClipTest (clip, fbxClip);
+                foreach (var clip in animClipsOriginal)
+                {
+                    Assert.That(animClipsImported.ContainsKey(clip.name));
+                    var fbxClip = animClipsImported[clip.name];
+                    AnimTester.ClipTest(clip, fbxClip);
                 }
             }
 
@@ -506,29 +537,32 @@ namespace FbxExporter.UnitTests
             /// </summary>
             /// <param name="animClipOriginal">Animation clip original.</param>
             /// <param name="animClipImported">Animation clip imported.</param>
-            public static void ClipTest(AnimationClip animClipOriginal, AnimationClip animClipImported){
+            public static void ClipTest(AnimationClip animClipOriginal, AnimationClip animClipImported)
+            {
                 // check clip properties match
-                AnimTester.ClipPropertyTest (animClipOriginal, animClipImported);
+                AnimTester.ClipPropertyTest(animClipOriginal, animClipImported);
 
-                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings (animClipOriginal)) {
-                    foreach(EditorCurveBinding impCurveBinding in AnimationUtility.GetCurveBindings (animClipImported)) {
-
+                foreach (EditorCurveBinding curveBinding in AnimationUtility.GetCurveBindings(animClipOriginal))
+                {
+                    foreach (EditorCurveBinding impCurveBinding in AnimationUtility.GetCurveBindings(animClipImported))
+                    {
                         // only compare if the path and property names match
-                        if (curveBinding.path != impCurveBinding.path || curveBinding.propertyName != impCurveBinding.propertyName) {
+                        if (curveBinding.path != impCurveBinding.path || curveBinding.propertyName != impCurveBinding.propertyName)
+                        {
                             continue;
                         }
 
                         bool isRotation = AnimationTestDataClass.m_rotationEulerNames.Contains(curveBinding.propertyName) ||
-                        AnimationTestDataClass.m_rotationQuaternionNames.Contains(curveBinding.propertyName);
+                            AnimationTestDataClass.m_rotationQuaternionNames.Contains(curveBinding.propertyName);
 
-                        AnimationCurve animCurveOrig = AnimationUtility.GetEditorCurve (animClipOriginal, curveBinding);
-                        Assert.That (animCurveOrig, Is.Not.Null);
+                        AnimationCurve animCurveOrig = AnimationUtility.GetEditorCurve(animClipOriginal, curveBinding);
+                        Assert.That(animCurveOrig, Is.Not.Null);
 
-                        AnimationCurve animCurveImported = AnimationUtility.GetEditorCurve (animClipImported, impCurveBinding);
-                        Assert.That (animCurveImported, Is.Not.Null);
+                        AnimationCurve animCurveImported = AnimationUtility.GetEditorCurve(animClipImported, impCurveBinding);
+                        Assert.That(animCurveImported, Is.Not.Null);
 
                         AnimTester.KeyValuesTest(
-                            animCurveImported, 
+                            animCurveImported,
                             animCurveOrig,
                             string.Format("path: {0}, property: {1}", curveBinding.path, curveBinding.propertyName),
                             isRotation);
@@ -536,25 +570,25 @@ namespace FbxExporter.UnitTests
                 }
             }
 
-            public static void KeysTest (AnimationCurve expectedAnimCurve, AnimationCurve actualAnimCurve, string message, IComparer<Keyframe> keyComparer = null)
+            public static void KeysTest(AnimationCurve expectedAnimCurve, AnimationCurve actualAnimCurve, string message, IComparer<Keyframe> keyComparer = null)
             {
-                if (keyComparer==null)
+                if (keyComparer == null)
                     keyComparer = new BasicKeyComparer();
-                
-                Assert.That (actualAnimCurve.length, Is.EqualTo(expectedAnimCurve.length), string.Format("{0} number of keys doesn't match", message));
+
+                Assert.That(actualAnimCurve.length, Is.EqualTo(expectedAnimCurve.length), string.Format("{0} number of keys doesn't match", message));
 
                 Assert.That(actualAnimCurve.keys, Is.EqualTo(expectedAnimCurve.keys).Using<Keyframe>(keyComparer), string.Format("{0} key doesn't match", message));
             }
 
-            public static void KeysTest (float [] expectedKeyTimes, float [] expectedKeyValues, AnimationCurve actualAnimCurve, string message, IComparer<Keyframe> keyComparer=null)
+            public static void KeysTest(float[] expectedKeyTimes, float[] expectedKeyValues, AnimationCurve actualAnimCurve, string message, IComparer<Keyframe> keyComparer = null)
             {
-                if (keyComparer==null)
+                if (keyComparer == null)
                     keyComparer = new BasicKeyComparer();
-                
+
                 int numKeysExpected = expectedKeyTimes.Length;
 
                 // NOTE : Uni-34492 number of keys don't match
-                Assert.That (actualAnimCurve.length, Is.EqualTo(numKeysExpected), string.Format("{0} number of keys doesn't match",message));
+                Assert.That(actualAnimCurve.length, Is.EqualTo(numKeysExpected), string.Format("{0} number of keys doesn't match", message));
 
                 // check actual animation against expected
                 // NOTE: if I check the key values explicitly they match but when I compare using this ListMapper the float values
@@ -569,12 +603,12 @@ namespace FbxExporter.UnitTests
 
                 Assert.That(actualAnimCurve.keys, Is.EqualTo(keysExpected).Using<Keyframe>(keyComparer), string.Format("{0} key doesn't match", message));
 
-                return ;
+                return;
             }
 
-            public static void KeyValuesTest (float [] expectedKeyTimes, float [] expectedKeyValues, AnimationCurve actualAnimCurve, string message, bool isRotationCurve = false)
+            public static void KeyValuesTest(float[] expectedKeyTimes, float[] expectedKeyValues, AnimationCurve actualAnimCurve, string message, bool isRotationCurve = false)
             {
-                for (var i=0; i < expectedKeyTimes.Length; ++i)
+                for (var i = 0; i < expectedKeyTimes.Length; ++i)
                 {
                     float expectedKeyTime = expectedKeyTimes[i];
                     float expectedKeyValue = expectedKeyValues[i];
@@ -582,7 +616,7 @@ namespace FbxExporter.UnitTests
                     float actualKeyValue = actualAnimCurve.Evaluate(expectedKeyTime);
 
 #if DEBUG_UNITTEST
-                    Debug.Log(string.Format("key time={0} expected={1} actual={2} delta={3}", expectedKeyTime.ToString(), expectedKeyValue.ToString(), actualKeyValue.ToString(), Mathf.Abs(expectedKeyValue-actualKeyValue).ToString()));
+                    Debug.Log(string.Format("key time={0} expected={1} actual={2} delta={3}", expectedKeyTime.ToString(), expectedKeyValue.ToString(), actualKeyValue.ToString(), Mathf.Abs(expectedKeyValue - actualKeyValue).ToString()));
 #endif
                     // also handles values that are equal but different signs (i.e. -90 == 270)
                     if (isRotationCurve)
@@ -598,14 +632,14 @@ namespace FbxExporter.UnitTests
                 }
             }
 
-            public static void KeyValuesTest (AnimationCurve expectedAnimCurve, AnimationCurve actualAnimCurve, string message, bool isRotationCurve = false)
+            public static void KeyValuesTest(AnimationCurve expectedAnimCurve, AnimationCurve actualAnimCurve, string message, bool isRotationCurve = false)
             {
                 foreach (var key in expectedAnimCurve.keys)
                 {
                     float actualKeyValue = actualAnimCurve.Evaluate(key.time);
 
 #if DEBUG_UNITTEST
-                    Debug.Log(string.Format("key time={0} actual={1} expected={2} delta={3}", key.time.ToString(), key.value.ToString(), actualKeyValue.ToString(), Mathf.Abs(key.value-actualKeyValue).ToString()));
+                    Debug.Log(string.Format("key time={0} actual={1} expected={2} delta={3}", key.time.ToString(), key.value.ToString(), actualKeyValue.ToString(), Mathf.Abs(key.value - actualKeyValue).ToString()));
 #endif
                     var expectedKeyValue = key.value;
 
@@ -628,52 +662,56 @@ namespace FbxExporter.UnitTests
                 // TODO : Uni-34492 number of keys don't match
                 //Assert.That (animCurveActual.length, Is.EqualTo (animCurveImported.length), "animcurve number of keys doesn't match");
 
-                var actualTimeKeys = new ListMapper (animCurveActual.keys).Property ("time");
-                var actualValueKeys = new ListMapper (animCurveActual.keys).Property ("value");
+                var actualTimeKeys = new ListMapper(animCurveActual.keys).Property("time");
+                var actualValueKeys = new ListMapper(animCurveActual.keys).Property("value");
 
-                var importedTimeKeys = new ListMapper (animCurveImported.keys).Property ("time");
-                var importedValueKeys = new ListMapper (animCurveImported.keys).Property ("value");
+                var importedTimeKeys = new ListMapper(animCurveImported.keys).Property("time");
+                var importedValueKeys = new ListMapper(animCurveImported.keys).Property("value");
 
                 //check imported animation against original
-                Assert.That(actualTimeKeys, Is.EqualTo(importedTimeKeys), string.Format("{0} key time doesn't match",message));
+                Assert.That(actualTimeKeys, Is.EqualTo(importedTimeKeys), string.Format("{0} key time doesn't match", message));
                 Assert.That(actualValueKeys, Is.EqualTo(importedValueKeys), string.Format("{0} key value doesn't match", message));
             }
 
-
-            public static Dictionary<string, AnimationClip> GetClipsFromFbx(string path, bool setLegacy = false){
+            public static Dictionary<string, AnimationClip> GetClipsFromFbx(string path, bool setLegacy = false)
+            {
                 //acquire imported object from exported file
-                Object [] goAssetImported = AssetDatabase.LoadAllAssetsAtPath (path);
-                Assert.That (goAssetImported, Is.Not.Null);
+                Object[] goAssetImported = AssetDatabase.LoadAllAssetsAtPath(path);
+                Assert.That(goAssetImported, Is.Not.Null);
 
                 // TODO : configure object so that it imports w Legacy Animation
 
-                var animClips = new Dictionary<string, AnimationClip> ();
-                foreach (Object o in goAssetImported) {
+                var animClips = new Dictionary<string, AnimationClip>();
+                foreach (Object o in goAssetImported)
+                {
                     var animClipImported = o as AnimationClip;
-                    if (animClipImported && !animClipImported.name.StartsWith("__preview__")) {
+                    if (animClipImported && !animClipImported.name.StartsWith("__preview__"))
+                    {
                         // TODO : configure import settings so we don't need to force legacy
                         animClipImported.legacy = setLegacy;
-                        animClips.Add (animClipImported.name, animClipImported);
+                        animClips.Add(animClipImported.name, animClipImported);
                     }
                 }
-                Assert.That (animClips, Is.Not.Empty, "expected imported clips");
+                Assert.That(animClips, Is.Not.Empty, "expected imported clips");
 
                 return animClips;
             }
 
-            public static AnimationClip GetClipFromFbx(string path){
+            public static AnimationClip GetClipFromFbx(string path)
+            {
                 //acquire imported object from exported file
-                Object [] goAssetImported = AssetDatabase.LoadAllAssetsAtPath (path);
-                Assert.That (goAssetImported, Is.Not.Null);
+                Object[] goAssetImported = AssetDatabase.LoadAllAssetsAtPath(path);
+                Assert.That(goAssetImported, Is.Not.Null);
 
                 // TODO : configure object so that it imports w Legacy Animation
 
                 AnimationClip animClipImported = null;
-                foreach (Object o in goAssetImported) {
+                foreach (Object o in goAssetImported)
+                {
                     animClipImported = o as AnimationClip;
                     if (animClipImported && !animClipImported.name.StartsWith("__preview__")) break;
                 }
-                Assert.That (animClipImported, Is.Not.Null, "expected imported clip");
+                Assert.That(animClipImported, Is.Not.Null, "expected imported clip");
 
                 // TODO : configure import settings so we don't need to force legacy
                 animClipImported.legacy = true;
@@ -683,63 +721,64 @@ namespace FbxExporter.UnitTests
         }
 
         [Ignore("Uni-34804 gimbal conditions, and Uni-34492 number of keys don't match")]
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "SkinnedMeshTestCases")]
-        public void LegacySkinnedMeshAnimTest (string fbxPath)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "SkinnedMeshTestCases")]
+        public void LegacySkinnedMeshAnimTest(string fbxPath)
         {
-            fbxPath = FindPathInUnitTests (fbxPath);
-            Assert.That (fbxPath, Is.Not.Null);
+            fbxPath = FindPathInUnitTests(fbxPath);
+            Assert.That(fbxPath, Is.Not.Null);
 
             // add fbx to scene
             GameObject originalGO = AddAssetToScene(fbxPath);
 
             // get clip
             AnimationClip animClipOriginal = originalGO.GetComponentInChildren<Animation>().clip;
-            Assert.That (animClipOriginal, Is.Not.Null);
+            Assert.That(animClipOriginal, Is.Not.Null);
 
             // export fbx
             // get GameObject
             string filename = AssetDatabase.GetAssetPath(ExportToFbx(originalGO));
 
-            // TODO: Uni-34492 change importer settings of (newly exported model) 
+            // TODO: Uni-34492 change importer settings of (newly exported model)
             // so that it's not resampled and it is legacy animation
             AnimTester.ConfigureImportSettings(filename);
 
-            var animClipImported = AnimTester.GetClipFromFbx (filename);
+            var animClipImported = AnimTester.GetClipFromFbx(filename);
 
-            AnimTester.ClipTest (animClipOriginal, animClipImported);
+            AnimTester.ClipTest(animClipOriginal, animClipImported);
         }
 
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "TransformIndependantComponentTestCases")]
-        public int SimplePropertyAnimTest (float [] keyTimesInSeconds, float [] keyValues, System.Type componentType, string componentName)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "TransformIndependantComponentTestCases")]
+        public int SimplePropertyAnimTest(float[] keyTimesInSeconds, float[] keyValues, System.Type componentType, string componentName)
         {
             KeyData keyData = new PropertyKeyData { propertyName = componentName, componentType = componentType, keyTimes = keyTimesInSeconds, keyFloatValues = keyValues };
 
-            var tester = new AnimTester {keyData=keyData, testName=componentName, path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = componentName, path = GetRandomFbxFilePath()};
             return tester.DoIt();
         }
 
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "BlendshapeAnimationTestCases")]
-        public int BlendshapeAnimTest (float [] keyTimesInSeconds, float [] keyValues, System.Type componentType, string componentName)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "BlendshapeAnimationTestCases")]
+        public int BlendshapeAnimTest(float[] keyTimesInSeconds, float[] keyValues, System.Type componentType, string componentName)
         {
-            var prefabPath = FindPathInUnitTests ("Models/blendshape.fbx");
-            Assert.That (prefabPath, Is.Not.Null);
+            var prefabPath = FindPathInUnitTests("Models/blendshape.fbx");
+            Assert.That(prefabPath, Is.Not.Null);
 
             // add prefab to scene
             GameObject originalGO = AddAssetToScene(prefabPath);
 
-            KeyData keyData = new PropertyKeyData {
-                targetObject = originalGO, 
+            KeyData keyData = new PropertyKeyData
+            {
+                targetObject = originalGO,
                 propertyName = componentName,
                 componentType = componentType,
                 keyTimes = keyTimesInSeconds,
                 keyFloatValues = keyValues
             };
 
-            var tester = new AnimTester {keyData=keyData, testName=componentName, path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = componentName, path = GetRandomFbxFilePath()};
 
-            var exportOptions = new ExportModelSettingsSerialize ();
+            var exportOptions = new ExportModelSettingsSerialize();
             exportOptions.SetAnimatedSkinnedMesh(true);
-            
+
             tester.exportOptions = exportOptions;
             return tester.DoIt();
         }
@@ -774,173 +813,184 @@ namespace FbxExporter.UnitTests
             return tester.DoIt();
         }
 
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "QuaternionTestCases")]
-        public int QuaternionPropertyAnimTest (float [] keyTimesInSeconds, Vector3 [] keyValues, System.Type componentType, string[] componentNames)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "QuaternionTestCases")]
+        public int QuaternionPropertyAnimTest(float[] keyTimesInSeconds, Vector3[] keyValues, System.Type componentType, string[] componentNames)
         {
-            KeyData keyData = new QuaternionKeyData { compareOriginalKeys=true, propertyNames = componentNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyEulerValues = keyValues };
+            KeyData keyData = new QuaternionKeyData { compareOriginalKeys = true, propertyNames = componentNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyEulerValues = keyValues };
 
-            var tester = new AnimTester {keyData=keyData, testName=(componentType.ToString() + "_Quaternion"), path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = (componentType.ToString() + "_Quaternion"), path = GetRandomFbxFilePath()};
             return tester.DoIt();
         }
 
         [Ignore("Uni-34804 gimbal conditions")]
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "GimbalTestCases")]
-        public int GimbalConditionsAnimTest (float [] keyTimesInSeconds, Vector3 [] keyValues, System.Type componentType, string [] componentNames)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "GimbalTestCases")]
+        public int GimbalConditionsAnimTest(float[] keyTimesInSeconds, Vector3[] keyValues, System.Type componentType, string[] componentNames)
         {
             KeyData keyData = new QuaternionKeyData { propertyNames = componentNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyEulerValues = keyValues };
 
-            var tester = new AnimTester {keyData=keyData, testName=componentType.ToString () + "_Gimbal", path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = componentType.ToString() + "_Gimbal", path = GetRandomFbxFilePath()};
             return tester.DoIt();
         }
 
         [Description("Uni-35616 continuous rotations")]
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "ContinuousRotationTestCases")]
-        public int ContinuousRotationAnimTest (RotationCurveType rotCurveType, float [] keyTimesInSeconds, Vector3 [] keyEulerValues)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "ContinuousRotationTestCases")]
+        public int ContinuousRotationAnimTest(RotationCurveType rotCurveType, float[] keyTimesInSeconds, Vector3[] keyEulerValues)
         {
             System.Type componentType = typeof(Transform);
 
             string[] propertyNames = null;
-            string testName = componentType.ToString () + "_ContinuousRotations";
+            string testName = componentType.ToString() + "_ContinuousRotations";
             bool compareOriginalKeys = false;
 
             switch (rotCurveType)
             {
-            case RotationCurveType.kEuler:
-                testName += "_Euler";
-                propertyNames=AnimationTestDataClass.m_rotationEulerNames.ToArray();
-                break;
-            case RotationCurveType.kQuaternion:
-                compareOriginalKeys=true;
-                testName += "_Quaternion";
-                propertyNames=AnimationTestDataClass.m_rotationQuaternionNames.ToArray();
-                break;
+                case RotationCurveType.kEuler:
+                    testName += "_Euler";
+                    propertyNames = AnimationTestDataClass.m_rotationEulerNames.ToArray();
+                    break;
+                case RotationCurveType.kQuaternion:
+                    compareOriginalKeys = true;
+                    testName += "_Quaternion";
+                    propertyNames = AnimationTestDataClass.m_rotationQuaternionNames.ToArray();
+                    break;
             }
 
-            KeyData keyData = new TransformKeyData { 
-                importSettings = new {resampleCurves = false, animationType= ModelImporterAnimationType.Legacy, animationCompression = ModelImporterAnimationCompression.Off, importConstraints = true},
-                compareOriginalKeys=compareOriginalKeys, RotationType = rotCurveType, propertyNames = propertyNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyEulerValues = keyEulerValues };
+            KeyData keyData = new TransformKeyData
+            {
+                importSettings = new {resampleCurves = false, animationType = ModelImporterAnimationType.Legacy, animationCompression = ModelImporterAnimationCompression.Off, importConstraints = true},
+                compareOriginalKeys = compareOriginalKeys, RotationType = rotCurveType, propertyNames = propertyNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyEulerValues = keyEulerValues
+            };
 
-            var tester = new AnimTester {keyData=keyData, testName=testName, path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = testName, path = GetRandomFbxFilePath()};
             return tester.DoIt();
         }
 
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "ComponentTestCases")]
-        public int ComponentAnimTest (System.Type componentType)
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "ComponentTestCases")]
+        public int ComponentAnimTest(System.Type componentType)
         {
             #if DEBUG_UNITTEST
-            Debug.Log (string.Format ("ComponentAnimTest {0}", componentType.ToString()));
-            #endif 
+            Debug.Log(string.Format("ComponentAnimTest {0}", componentType.ToString()));
+            #endif
 
             if (!ModelExporter.MapsToFbxObject.ContainsKey(componentType))
             {
                 #if DEBUG_UNITTEST
-                Debug.Log (string.Format ("skipping {0}; fbx export not supported", componentType.ToString()));
-                #endif 
-                return 1;                
+                Debug.Log(string.Format("skipping {0}; fbx export not supported", componentType.ToString()));
+                #endif
+                return 1;
             }
 
-            string testName = "ComponentAnimTest_" + componentType.ToString ();
-            GameObject targetObject = AnimTester.CreateTargetObject (testName, componentType);
+            string testName = "ComponentAnimTest_" + componentType.ToString();
+            GameObject targetObject = AnimTester.CreateTargetObject(testName, componentType);
 
-            string [] propertyNames = 
-                (from b in AnimationUtility.GetAnimatableBindings (targetObject, targetObject) 
-                 where b.type==componentType select b.propertyName).ToArray();
+            string[] propertyNames =
+                (from b in AnimationUtility.GetAnimatableBindings(targetObject, targetObject)
+                    where b.type == componentType select b.propertyName).ToArray();
 
             if (propertyNames.Length == 0)
             {
                 #if DEBUG_UNITTEST
-                Debug.Log (string.Format ("skipping {0}; no animatable Single properties found", componentType.ToString()));
-                #endif 
-                return 1;                
+                Debug.Log(string.Format("skipping {0}; no animatable Single properties found", componentType.ToString()));
+                #endif
+                return 1;
             }
 
-            float [] keyTimesInSeconds = new float [3] { 1f, 2f, 3f };
+            float[] keyTimesInSeconds = new float[3] { 1f, 2f, 3f };
             var ran = new System.Random();
-            float [] keyValues = Enumerable.Range(1, keyTimesInSeconds.Length).Select(x =>(float)ran.NextDouble()).ToArray();
+            float[] keyValues = Enumerable.Range(1, keyTimesInSeconds.Length).Select(x => (float)ran.NextDouble()).ToArray();
 
             KeyData keyData = new MultiPropertyKeyData { propertyNames = propertyNames, componentType = componentType, keyTimes = keyTimesInSeconds, keyValues = keyValues, targetObject = targetObject };
 
-            var tester = new AnimTester {keyData=keyData, testName=testName, path=GetRandomFbxFilePath ()};
+            var tester = new AnimTester {keyData = keyData, testName = testName, path = GetRandomFbxFilePath()};
             return tester.DoIt() <= propertyNames.Length ? 1 : 0;
         }
 
-        [Test, TestCaseSource (typeof (AnimationTestDataClass), "AnimOnlyTestCases")]
+        [Test, TestCaseSource(typeof(AnimationTestDataClass), "AnimOnlyTestCases")]
         public void AnimOnlyExportTest(string prefabPath)
         {
-            prefabPath = FindPathInUnitTests (prefabPath);
-            Assert.That (prefabPath, Is.Not.Null);
+            prefabPath = FindPathInUnitTests(prefabPath);
+            Assert.That(prefabPath, Is.Not.Null);
 
             // add prefab to scene
             GameObject originalGO = AddAssetToScene(prefabPath);
 
             // get clips
-            var animator = originalGO.GetComponentInChildren<Animator> ();
-            var animClips = GetClipsFromAnimator (animator);
+            var animator = originalGO.GetComponentInChildren<Animator>();
+            var animClips = GetClipsFromAnimator(animator);
 
             // get the set of GameObject transforms to be exported with the clip
-            var animatedObjects = GetAnimatedGameObjects (animClips, animator.gameObject);
+            var animatedObjects = GetAnimatedGameObjects(animClips, animator.gameObject);
 
             // export fbx
             // get GameObject
             GameObject fbxObj = ExportToFbx(originalGO, true);
-            Assert.IsTrue (fbxObj);
+            Assert.IsTrue(fbxObj);
 
             // compare hierarchy matches animated objects
-            var s = new Stack<Transform> ();
+            var s = new Stack<Transform>();
 
             // don't check the root since it probably won't have the same name anyway
-            foreach (Transform child in fbxObj.transform) {
-                s.Push (child);
+            foreach (Transform child in fbxObj.transform)
+            {
+                s.Push(child);
             }
-            while (s.Count > 0) {
-                var transform = s.Pop ();
+            while (s.Count > 0)
+            {
+                var transform = s.Pop();
 
-                Assert.That (animatedObjects.Contains(transform.name));
-                animatedObjects.Remove (transform.name);
+                Assert.That(animatedObjects.Contains(transform.name));
+                animatedObjects.Remove(transform.name);
 
-                foreach (Transform child in transform) {
-                    s.Push (child);
+                foreach (Transform child in transform)
+                {
+                    s.Push(child);
                 }
             }
 
             // compare clips
-            var fbxAnimClips = AnimTester.GetClipsFromFbx (AssetDatabase.GetAssetPath(fbxObj));
-            AnimTester.MultiClipTest (animClips, fbxAnimClips);
+            var fbxAnimClips = AnimTester.GetClipsFromFbx(AssetDatabase.GetAssetPath(fbxObj));
+            AnimTester.MultiClipTest(animClips, fbxAnimClips);
         }
 
-        public static AnimationClip[] GetClipsFromAnimator(Animator animator){
-            Assert.That (animator, Is.Not.Null);
+        public static AnimationClip[] GetClipsFromAnimator(Animator animator)
+        {
+            Assert.That(animator, Is.Not.Null);
 
             var controller = animator.runtimeAnimatorController;
-            Assert.That (controller, Is.Not.Null);
+            Assert.That(controller, Is.Not.Null);
 
             var animClips = controller.animationClips;
-            Assert.That (animClips, Is.Not.Null);
+            Assert.That(animClips, Is.Not.Null);
 
             return animClips;
         }
 
-        private HashSet<string> GetAnimatedGameObjects(AnimationClip[] animClips, GameObject animatorObject){
+        private HashSet<string> GetAnimatedGameObjects(AnimationClip[] animClips, GameObject animatorObject)
+        {
             var animatedObjects = new HashSet<string>();
-            foreach (var clip in animClips) {
-                foreach (EditorCurveBinding uniCurveBinding in AnimationUtility.GetCurveBindings (clip)) {
-                    Object uniObj = AnimationUtility.GetAnimatedObject (animatorObject, uniCurveBinding);
-                    if (!uniObj) {
+            foreach (var clip in animClips)
+            {
+                foreach (EditorCurveBinding uniCurveBinding in AnimationUtility.GetCurveBindings(clip))
+                {
+                    Object uniObj = AnimationUtility.GetAnimatedObject(animatorObject, uniCurveBinding);
+                    if (!uniObj)
+                    {
                         continue;
                     }
 
                     GameObject unityGo = ModelExporter.GetGameObject(uniObj);
-                    if (!unityGo) {
+                    if (!unityGo)
+                    {
                         continue;
                     }
 
                     // also it's parents up until but excluding the root (the root will have a different name)
                     var parent = unityGo.transform;
-                    while (parent != null && parent.parent != null) {
-                        animatedObjects.Add (parent.name);
+                    while (parent != null && parent.parent != null)
+                    {
+                        animatedObjects.Add(parent.name);
                         parent = parent.parent;
                     }
-
                 }
             }
             return animatedObjects;

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
@@ -22,33 +22,33 @@ namespace FbxExporter.UnitTests
         static System.Reflection.FieldInfo s_InstanceField; // static
         static System.Reflection.FieldInfo s_SavePathField; // member
 
-        static FbxExportSettingsTest ()
+        static FbxExportSettingsTest()
         {
             // all names, private or public, instance or static
             var privates = System.Reflection.BindingFlags.NonPublic
                 | System.Reflection.BindingFlags.Public
                 | System.Reflection.BindingFlags.Static
                 | System.Reflection.BindingFlags.Instance;
-            var t = typeof (ExportSettings);
+            var t = typeof(ExportSettings);
 
-            s_SavePathField = t.GetField ("maxStoredSavePaths", privates);
-            Assert.IsNotNull (s_SavePathField, "maxStoredSavePaths");
+            s_SavePathField = t.GetField("maxStoredSavePaths", privates);
+            Assert.IsNotNull(s_SavePathField, "maxStoredSavePaths");
 
             // static fields can't be found through inheritance with GetField.
             // if we change the inheritance diagram, we have to change t.BaseType here.
-            s_InstanceField = t.GetField ("s_Instance", privates);
-            Assert.IsNotNull (s_InstanceField, "s_Instance");
+            s_InstanceField = t.GetField("s_Instance", privates);
+            Assert.IsNotNull(s_InstanceField, "s_Instance");
         }
 
         [NUnit.Framework.SetUp]
-        public void SetUp ()
+        public void SetUp()
         {
-            var settings = (ExportSettings)s_InstanceField.GetValue (null);
+            var settings = (ExportSettings)s_InstanceField.GetValue(null);
             m_originalSettings = settings;
 
             // Clear out the current instance and create a new one (but keep the original around).
-            s_InstanceField.SetValue (null, null);
-            s_InstanceField.SetValue (null, ScriptableObject.CreateInstance<ExportSettings> ());
+            s_InstanceField.SetValue(null, null);
+            s_InstanceField.SetValue(null, ScriptableObject.CreateInstance<ExportSettings>());
 
             // keep track of any existing default presets to reset them once tests finish
             var exportPresetType = new PresetType(ExportSettings.instance.ExportModelSettings);
@@ -57,189 +57,188 @@ namespace FbxExporter.UnitTests
             m_convertSettingsDefaultPresets = Preset.GetDefaultPresetsForType(convertPresetType);
 
             // clear default presets
-            Preset.SetDefaultPresetsForType(exportPresetType, new DefaultPreset[] { });
-            Preset.SetDefaultPresetsForType(convertPresetType, new DefaultPreset[] { });
+            Preset.SetDefaultPresetsForType(exportPresetType, new DefaultPreset[] {});
+            Preset.SetDefaultPresetsForType(convertPresetType, new DefaultPreset[] {});
         }
 
         [NUnit.Framework.TearDown]
-        public void TearDown ()
+        public void TearDown()
         {
             // Destroy the test settings and restore the original.
             // The original might be null -- not a problem.
-            var settings = (ExportSettings)s_InstanceField.GetValue (null);
-            ScriptableObject.DestroyImmediate (settings);
+            var settings = (ExportSettings)s_InstanceField.GetValue(null);
+            ScriptableObject.DestroyImmediate(settings);
 
-            s_InstanceField.SetValue (null, m_originalSettings);
+            s_InstanceField.SetValue(null, m_originalSettings);
 
             Preset.SetDefaultPresetsForType(new PresetType(ExportSettings.instance.ExportModelSettings), m_exportSettingsDefaultPresets);
             Preset.SetDefaultPresetsForType(new PresetType(ExportSettings.instance.ConvertToPrefabSettings), m_convertSettingsDefaultPresets);
         }
 
-
         [Test]
-        public void TestNormalizePath ()
+        public void TestNormalizePath()
         {
             // Test slashes in both directions, and leading and trailing slashes.
             var path = "/a\\b/c/\\";
-            var norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("a/b/c", norm);
-            norm = ExportSettings.NormalizePath (path, isRelative: false);
-            Assert.AreEqual ("/a/b/c", norm);
+            var norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("a/b/c", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: false);
+            Assert.AreEqual("/a/b/c", norm);
 
             // Test empty path. Not actually absolute, so it's treated as a relative path.
             path = "";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual (".", norm);
-            norm = ExportSettings.NormalizePath (path, isRelative: false);
-            Assert.AreEqual (".", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual(".", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: false);
+            Assert.AreEqual(".", norm);
 
             // Test just a bunch of slashes. Root or . depending on whether it's abs or rel.
             path = "///";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual (".", norm);
-            norm = ExportSettings.NormalizePath (path, isRelative: false);
-            Assert.AreEqual ("/", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual(".", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: false);
+            Assert.AreEqual("/", norm);
 
             // Test handling of .
             path = "/a/./b/././c/.";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("a/b/c", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("a/b/c", norm);
 
             // Test handling of leading ..
             path = "..";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("..", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("..", norm);
 
             path = "../a";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("../a", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("../a", norm);
 
             // Test two leading ..
             path = "../../a";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("../../a", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("../../a", norm);
 
             // Test .. in the middle and effect on leading /
             path = "/a/../b";
-            norm = ExportSettings.NormalizePath (path, isRelative: true);
-            Assert.AreEqual ("b", norm);
-            norm = ExportSettings.NormalizePath (path, isRelative: false);
-            Assert.AreEqual ("/b", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: true);
+            Assert.AreEqual("b", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: false);
+            Assert.AreEqual("/b", norm);
 
             // Test that we can change the separator
-            norm = ExportSettings.NormalizePath (path, isRelative: false, separator: '\\');
-            Assert.AreEqual ("\\b", norm);
+            norm = ExportSettings.NormalizePath(path, isRelative: false, separator: '\\');
+            Assert.AreEqual("\\b", norm);
         }
 
         [Test]
-        public void TestGetRelativePath ()
+        public void TestGetRelativePath()
         {
             var from = "//a/b/c";
             var to = "///a/b/c/d/e";
-            var relative = ExportSettings.GetRelativePath (from, to);
-            Assert.AreEqual ("d/e", relative);
+            var relative = ExportSettings.GetRelativePath(from, to);
+            Assert.AreEqual("d/e", relative);
 
             from = "///a/b/c/";
             to = "///a/b/c/d/e/";
-            relative = ExportSettings.GetRelativePath (from, to);
-            Assert.AreEqual ("d/e", relative);
+            relative = ExportSettings.GetRelativePath(from, to);
+            Assert.AreEqual("d/e", relative);
 
             from = "///aa/bb/cc/dd/ee";
             to = "///aa/bb/cc";
-            relative = ExportSettings.GetRelativePath (from, to);
-            Assert.AreEqual ("../..", relative);
+            relative = ExportSettings.GetRelativePath(from, to);
+            Assert.AreEqual("../..", relative);
 
             from = "///a/b/c/d/e/";
             to = "///a/b/c/";
-            relative = ExportSettings.GetRelativePath (from, to);
-            Assert.AreEqual ("../..", relative);
+            relative = ExportSettings.GetRelativePath(from, to);
+            Assert.AreEqual("../..", relative);
 
             from = "///a/b/c/d/e/";
             to = "///a/b/c/";
-            relative = ExportSettings.GetRelativePath (from, to, separator: ':');
-            Assert.AreEqual ("..:..", relative);
+            relative = ExportSettings.GetRelativePath(from, to, separator: ':');
+            Assert.AreEqual("..:..", relative);
 
-            from = Path.Combine (Application.dataPath, "foo");
+            from = Path.Combine(Application.dataPath, "foo");
             to = Application.dataPath;
-            relative = ExportSettings.GetRelativePath (from, to);
-            Assert.AreEqual ("..", relative);
+            relative = ExportSettings.GetRelativePath(from, to);
+            Assert.AreEqual("..", relative);
 
-            to = Path.Combine (Application.dataPath, "foo");
-            relative = ExportSettings.ConvertToAssetRelativePath (to);
-            Assert.AreEqual ("foo", relative);
+            to = Path.Combine(Application.dataPath, "foo");
+            relative = ExportSettings.ConvertToAssetRelativePath(to);
+            Assert.AreEqual("foo", relative);
 
-            relative = ExportSettings.ConvertToAssetRelativePath ("/path/to/somewhere/else");
-            Assert.AreEqual ("", relative);
+            relative = ExportSettings.ConvertToAssetRelativePath("/path/to/somewhere/else");
+            Assert.AreEqual("", relative);
 
-            relative = ExportSettings.ConvertToAssetRelativePath ("/path/to/somewhere/else", requireSubdirectory: false);
-            Assert.IsTrue (relative.StartsWith ("../"));
-            Assert.IsFalse (relative.Contains ("\\"));
+            relative = ExportSettings.ConvertToAssetRelativePath("/path/to/somewhere/else", requireSubdirectory: false);
+            Assert.IsTrue(relative.StartsWith("../"));
+            Assert.IsFalse(relative.Contains("\\"));
         }
 
         [Test]
-        public void TestGetSetFields ()
+        public void TestGetSetFields()
         {
             // the path to Assets but with platform-dependent separators
-            var appDataPath = Application.dataPath.Replace (Path.AltDirectorySeparatorChar,
-                    Path.DirectorySeparatorChar);
+            var appDataPath = Application.dataPath.Replace(Path.AltDirectorySeparatorChar,
+                Path.DirectorySeparatorChar);
 
             var defaultAbsolutePath = ExportSettings.FbxAbsoluteSavePath;
-            var dataPath = Path.GetFullPath (Path.Combine (appDataPath, ExportSettings.kDefaultSavePath));
-            Assert.AreEqual (dataPath, defaultAbsolutePath);
+            var dataPath = Path.GetFullPath(Path.Combine(appDataPath, ExportSettings.kDefaultSavePath));
+            Assert.AreEqual(dataPath, defaultAbsolutePath);
 
             var prefabDefaultAbsPath = ExportSettings.PrefabAbsoluteSavePath;
-            Assert.AreEqual (dataPath, prefabDefaultAbsPath);
+            Assert.AreEqual(dataPath, prefabDefaultAbsPath);
 
             // set; check that the saved value is platform-independent,
             // that the relative path uses / like in unity,
             // and that the absolute path is platform-specific
-            ExportSettings.AddFbxSavePath ("/a\\b/c/\\");
-            ExportSettings.AddPrefabSavePath ("/a\\b/c/\\");
+            ExportSettings.AddFbxSavePath("/a\\b/c/\\");
+            ExportSettings.AddPrefabSavePath("/a\\b/c/\\");
 
             string forwardSlash = " \u2044 "; // special unicode forward slash
-            Assert.That (ExportSettings.GetRelativeFbxSavePaths () [0], Is.EqualTo (string.Format("Assets{0}a{0}b{0}c", forwardSlash)));
-            Assert.That (ExportSettings.GetRelativePrefabSavePaths () [0], Is.EqualTo (string.Format("Assets{0}a{0}b{0}c", forwardSlash)));
+            Assert.That(ExportSettings.GetRelativeFbxSavePaths()[0], Is.EqualTo(string.Format("Assets{0}a{0}b{0}c", forwardSlash)));
+            Assert.That(ExportSettings.GetRelativePrefabSavePaths()[0], Is.EqualTo(string.Format("Assets{0}a{0}b{0}c", forwardSlash)));
 
-            var platformPath = Path.Combine ("a", Path.Combine ("b", "c"));
-            Assert.AreEqual (Path.Combine (appDataPath, platformPath), ExportSettings.FbxAbsoluteSavePath);
-            Assert.AreEqual (Path.Combine (appDataPath, platformPath), ExportSettings.PrefabAbsoluteSavePath);
+            var platformPath = Path.Combine("a", Path.Combine("b", "c"));
+            Assert.AreEqual(Path.Combine(appDataPath, platformPath), ExportSettings.FbxAbsoluteSavePath);
+            Assert.AreEqual(Path.Combine(appDataPath, platformPath), ExportSettings.PrefabAbsoluteSavePath);
 
-            ExportSettings.AddFbxSavePath ("test");
-            ExportSettings.AddPrefabSavePath ("test2");
+            ExportSettings.AddFbxSavePath("test");
+            ExportSettings.AddPrefabSavePath("test2");
 
             // 3 including the default path
-            Assert.That (ExportSettings.GetRelativeFbxSavePaths ().Length, Is.EqualTo (3));
-            Assert.That (ExportSettings.GetRelativePrefabSavePaths ().Length, Is.EqualTo (3));
+            Assert.That(ExportSettings.GetRelativeFbxSavePaths().Length, Is.EqualTo(3));
+            Assert.That(ExportSettings.GetRelativePrefabSavePaths().Length, Is.EqualTo(3));
         }
 
         [Test]
-        public void TestFindPreferredProgram ()
+        public void TestFindPreferredProgram()
         {
             //Add a number of fake programs to the list, including some garbage ones
-            List<string> testList = new List<string> ();
-            testList.Add (null);
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMaxOptionName + "2000"));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMayaOptionName + "2016"));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMayaOptionName + "2017"));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMaxOptionName + "2017"));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (""));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (null));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMayaLtOptionName));
-            testList.Add (ExportSettings.GetUniqueDCCOptionName (ExportSettings.kMayaOptionName + "2017"));
+            List<string> testList = new List<string>();
+            testList.Add(null);
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMaxOptionName + "2000"));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMayaOptionName + "2016"));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMayaOptionName + "2017"));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMaxOptionName + "2017"));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(""));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(null));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMayaLtOptionName));
+            testList.Add(ExportSettings.GetUniqueDCCOptionName(ExportSettings.kMayaOptionName + "2017"));
 
-            ExportSettings.instance.SetDCCOptionNames (testList);
+            ExportSettings.instance.SetDCCOptionNames(testList);
 
             int preferred = ExportSettings.instance.PreferredDCCApp;
             //While Maya 2017 and 3ds Max 2017 are tied for most recent, Maya 2017 (index 8) should win because we prefer Maya.
-            Assert.AreEqual (preferred, 8);
+            Assert.AreEqual(preferred, 8);
 
-            ExportSettings.instance.ClearDCCOptionNames ();
+            ExportSettings.instance.ClearDCCOptionNames();
             //Try running it with an empty list
             preferred = ExportSettings.instance.PreferredDCCApp;
 
-            Assert.AreEqual (preferred, -1);
+            Assert.AreEqual(preferred, -1);
 
-            ExportSettings.instance.SetDCCOptionNames (null);
+            ExportSettings.instance.SetDCCOptionNames(null);
             //Try running it with a null list
             preferred = ExportSettings.instance.PreferredDCCApp;
 
@@ -271,7 +270,7 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void TestGetDCCOptions ()
+        public void TestGetDCCOptions()
         {
             //Our.exe file
             string executableName = "/maya.exe";
@@ -281,63 +280,66 @@ namespace FbxExporter.UnitTests
             string secondSubFolder = "/maya 3001";
 
             //Make a folder structure to mimic an 'autodesk' type hierarchy
-            string testFolder = Path.GetRandomFileName ();
-            var firstPath = Directory.CreateDirectory (testFolder + firstSubFolder);
-            var secondPath = Directory.CreateDirectory (testFolder + secondSubFolder);
+            string testFolder = Path.GetRandomFileName();
+            var firstPath = Directory.CreateDirectory(testFolder + firstSubFolder);
+            var secondPath = Directory.CreateDirectory(testFolder + secondSubFolder);
 
-            try {
+            try
+            {
                 //Create any files we need within the folders
-                FileInfo firstExe = new FileInfo (firstPath.FullName + executableName);
-                using (FileStream s = firstExe.Create ()) { }
+                FileInfo firstExe = new FileInfo(firstPath.FullName + executableName);
+                using (FileStream s = firstExe.Create()) {}
 
                 //Add the paths which will be copied to DCCOptionPaths
-                List<string> testPathList = new List<string> ();
-                testPathList.Add (firstPath.FullName + executableName); //this path is valid!
-                testPathList.Add (secondPath.FullName + executableName);
-                testPathList.Add (null);
-                testPathList.Add ("cookies/milk/foo/bar");
+                List<string> testPathList = new List<string>();
+                testPathList.Add(firstPath.FullName + executableName);  //this path is valid!
+                testPathList.Add(secondPath.FullName + executableName);
+                testPathList.Add(null);
+                testPathList.Add("cookies/milk/foo/bar");
 
                 //Add the names which will be copied to DCCOptionNames
-                List<string> testNameList = new List<string> ();
-                testNameList.Add (firstSubFolder.TrimStart ('/'));
-                testNameList.Add (secondSubFolder.TrimStart ('/'));
-                testNameList.Add (null);
-                testNameList.Add ("Cookies & Milk");
+                List<string> testNameList = new List<string>();
+                testNameList.Add(firstSubFolder.TrimStart('/'));
+                testNameList.Add(secondSubFolder.TrimStart('/'));
+                testNameList.Add(null);
+                testNameList.Add("Cookies & Milk");
 
-                ExportSettings.instance.SetDCCOptionNames (testNameList);
-                ExportSettings.instance.SetDCCOptionPaths (testPathList);
+                ExportSettings.instance.SetDCCOptionNames(testNameList);
+                ExportSettings.instance.SetDCCOptionPaths(testPathList);
 
-                GUIContent [] options = ExportSettings.GetDCCOptions ();
+                GUIContent[] options = ExportSettings.GetDCCOptions();
 
                 //We expect 1, as the others are purposefully bogus
-                Assert.AreEqual (options.Length, 1);
+                Assert.AreEqual(options.Length, 1);
 
-                Assert.IsTrue (options [0].text == "maya 3000");
-            } finally {
-                Directory.Delete (testFolder, true);
+                Assert.IsTrue(options[0].text == "maya 3000");
+            }
+            finally
+            {
+                Directory.Delete(testFolder, true);
             }
         }
 
-        private string MayaPath (string rootDir, string version, bool fullPath = true)
+        private string MayaPath(string rootDir, string version, bool fullPath = true)
         {
             string result;
 
-            if (Application.platform == RuntimePlatform.OSXEditor) 
+            if (Application.platform == RuntimePlatform.OSXEditor)
             {
-                result = string.Format ("{0}/maya{1}/Maya.app/Contents{2}", rootDir, version, (fullPath ? "/MacOS/Maya" : ""));
-            } 
-            else if (Application.platform == RuntimePlatform.WindowsEditor) 
-            {
-                result = string.Format ("{0}/Maya{1}{2}", rootDir, version, (fullPath ? "/bin/maya.exe" : ""));
+                result = string.Format("{0}/maya{1}/Maya.app/Contents{2}", rootDir, version, (fullPath ? "/MacOS/Maya" : ""));
             }
-            else 
-                throw new System.NotImplementedException ();
+            else if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                result = string.Format("{0}/Maya{1}{2}", rootDir, version, (fullPath ? "/bin/maya.exe" : ""));
+            }
+            else
+                throw new System.NotImplementedException();
 
             return result;
         }
 
         [Test]
-        public void VendorLocationInstallationTest1 ()
+        public void VendorLocationInstallationTest1()
         {
             /*
              * different directory roots denoted by ' (eg.) (maya 2017 in rootDir1) = a (maya 2017 in rootDir2) = a'
@@ -356,34 +358,34 @@ namespace FbxExporter.UnitTests
             // case 1.5: VL=e ML=b' result=2
             // case 1.6: VL=e ML=d' result=2
 
-            string rootDir1 = GetRandomFileNamePath (extName: "");
-            string rootDir2 = GetRandomFileNamePath (extName: "");
+            string rootDir1 = GetRandomFileNamePath(extName: "");
+            string rootDir2 = GetRandomFileNamePath(extName: "");
 
-            var data = new List<Dictionary<string, List<string>>> ()
-             {
+            var data = new List<Dictionary<string, List<string>>>()
+            {
                 #region valid test case 1 data (unique locations, one in vendor, one for maya_loc)
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ MayaPath(rootDir1, "2017"), MayaPath(rootDir2, "2018")} },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
                     {"MAYA_LOCATION", new List<string>(){ MayaPath(rootDir2, "2018", false) } },
                     {"expectedResult", new List<string>(){ 2.ToString() }}
                 },
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ MayaPath(rootDir1, "2017"), MayaPath(rootDir2, "LT2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
                     {"MAYA_LOCATION", new List<string>(){ MayaPath(rootDir2, "LT2018", false) } },
                     {"expectedResult", new List<string>(){ 2.ToString() }}
                 },
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ MayaPath(rootDir1, "LT2017"), MayaPath(rootDir2, "2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
                     {"MAYA_LOCATION", new List<string>(){ MayaPath(rootDir2, "2018", false) } },
                     {"expectedResult", new List<string>(){ 2.ToString() }}
                 },
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ MayaPath(rootDir1, "LT2017"), MayaPath(rootDir2, "LT2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
@@ -391,14 +393,14 @@ namespace FbxExporter.UnitTests
                     {"expectedResult", new List<string>(){ 2.ToString() }}
                 },
 #if UNITY_EDITOR_WIN
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ rootDir1 + "/3ds Max 2017/3dsmax.exe", MayaPath(rootDir2, "2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
                     {"MAYA_LOCATION", new List<string>(){ MayaPath(rootDir2, "2018", false) } },
                     {"expectedResult", new List<string>(){ 2.ToString() }}
                 },
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
                     {"VENDOR_INSTALLS", new List<string>(){ rootDir1 + "/3ds Max 2017/3dsmax.exe", MayaPath(rootDir2, "LT2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
@@ -408,11 +410,11 @@ namespace FbxExporter.UnitTests
 #endif
                 #endregion
                 #region case 3 data (EMPTY vendor locations, one for maya location)
-                new Dictionary<string,List<string>>()
+                new Dictionary<string, List<string>>()
                 {
-                    {"VENDOR_INSTALLS", new List<string>(){ MayaPath (rootDir2, "LT2018") } },
+                    {"VENDOR_INSTALLS", new List<string>(){ MayaPath(rootDir2, "LT2018") } },
                     {"VENDOR_LOCATIONS", new List<string>(){ rootDir1 } },
-                    {"MAYA_LOCATION", new List<string>(){ MayaPath (rootDir2, "LT2018", false) } },
+                    {"MAYA_LOCATION", new List<string>(){ MayaPath(rootDir2, "LT2018", false) } },
                     {"expectedResult", new List<string>(){ 1.ToString () }},
                     {"expected3DApp", new List<string>(){ 0.ToString() }}
                 },
@@ -421,7 +423,7 @@ namespace FbxExporter.UnitTests
 
             for (int idx = 0; idx < data.Count; idx++)
             {
-                List<string> vendorInstallFolders = data [idx] ["VENDOR_INSTALLS"];
+                List<string> vendorInstallFolders = data[idx]["VENDOR_INSTALLS"];
                 //SetUp
                 //make the hierarchy for the single app path we need
                 VendorLocations_Setup(vendorInstallFolders);
@@ -434,20 +436,21 @@ namespace FbxExporter.UnitTests
         }
 
         // Setup fake installation directories
-        private void VendorLocations_Setup (List<string> paths)
+        private void VendorLocations_Setup(List<string> paths)
         {
             //Preserve our environment variables for later
-            originalVendorLocation = System.Environment.GetEnvironmentVariable ("UNITY_3DAPP_VENDOR_LOCATIONS");
-            originalMayaLocation = System.Environment.GetEnvironmentVariable ("MAYA_LOCATION");
+            originalVendorLocation = System.Environment.GetEnvironmentVariable("UNITY_3DAPP_VENDOR_LOCATIONS");
+            originalMayaLocation = System.Environment.GetEnvironmentVariable("MAYA_LOCATION");
 
-            foreach (var pathToExe in paths) {
+            foreach (var pathToExe in paths)
+            {
                 //make the directory
-                Directory.CreateDirectory (Path.GetDirectoryName (pathToExe));
-                if (Path.GetFileName (pathToExe) != null) {
-
+                Directory.CreateDirectory(Path.GetDirectoryName(pathToExe));
+                if (Path.GetFileName(pathToExe) != null)
+                {
                     //make the file (if we can)
-                    FileInfo newExe = new FileInfo (pathToExe);
-                    using (FileStream s = newExe.Create ()) { }
+                    FileInfo newExe = new FileInfo(pathToExe);
+                    using (FileStream s = newExe.Create()) {}
                 }
             }
         }
@@ -465,29 +468,31 @@ namespace FbxExporter.UnitTests
                 Directory.Delete(Directory.GetParent(Path.GetDirectoryName(vendorLocation)).FullName, true);
             }
         }
-        
+
         /// <summary>
         /// Sets environment variables to what is passed in, resets the dccOptionNames & dccOptionPaths, and calls FindDCCInstalls()
         /// </summary>
         /// <param name="vendorLocations"></param>
         /// <param name="mayaLocationPath"></param>
-        private void SetEnvironmentVariables (string vendorLocation, string mayaLocationPath)
+        private void SetEnvironmentVariables(string vendorLocation, string mayaLocationPath)
         {
-            if (!string.IsNullOrEmpty (vendorLocation)) {
+            if (!string.IsNullOrEmpty(vendorLocation))
+            {
                 //if the given vendor location isn't null, set the environment variable to it.
-                System.Environment.SetEnvironmentVariable ("UNITY_3DAPP_VENDOR_LOCATIONS", vendorLocation);
+                System.Environment.SetEnvironmentVariable("UNITY_3DAPP_VENDOR_LOCATIONS", vendorLocation);
             }
-            if (mayaLocationPath != null) {
+            if (mayaLocationPath != null)
+            {
                 //if the given MAYA_LOCATION isn't null, set the environment variable to it
-                System.Environment.SetEnvironmentVariable ("MAYA_LOCATION", mayaLocationPath);
+                System.Environment.SetEnvironmentVariable("MAYA_LOCATION", mayaLocationPath);
             }
         }
 
-        private void TestLocations(Dictionary<string,List<string>> data)
+        private void TestLocations(Dictionary<string, List<string>> data)
         {
-            string envVendorLocations = string.Join (";", data ["VENDOR_LOCATIONS"].ToArray ());
-            string envMayaLocation = data ["MAYA_LOCATION"] [0];
-            int expectedResult = int.Parse (data ["expectedResult"] [0]);
+            string envVendorLocations = string.Join(";", data["VENDOR_LOCATIONS"].ToArray());
+            string envMayaLocation = data["MAYA_LOCATION"][0];
+            int expectedResult = int.Parse(data["expectedResult"][0]);
 
             //Mayalocation should remain a List because we want to keep using the dictionary which must be of lists (maybe should make an overload)
 
@@ -503,7 +508,7 @@ namespace FbxExporter.UnitTests
             if (data.ContainsKey("expected3DApp"))
             {
                 int preferred = ExportSettings.instance.PreferredDCCApp;
-                Assert.AreEqual(preferred, int.Parse(data["expected3DApp"][0]) );
+                Assert.AreEqual(preferred, int.Parse(data["expected3DApp"][0]));
             }
         }
 
@@ -548,7 +553,7 @@ namespace FbxExporter.UnitTests
             Assert.That(instance.DisplayOptionsWindow, Is.False);
 
             var preset = new Preset(ExportSettings.instance);
-            
+
             instance.DisplayOptionsWindow = true;
             Assert.That(instance.DisplayOptionsWindow, Is.True);
 
@@ -753,6 +758,7 @@ namespace FbxExporter.UnitTests
 
             exportWindow.Close();
         }
+
         [Test]
         public void TestExportOptionsReset()
         {

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxRecorderTest.cs
@@ -15,7 +15,7 @@ namespace FbxExporter.UnitTests
         };
 
         [Test, TestCaseSource(typeof(FbxRecorderTest), "RecorderTestCases")]
-        public void TransferAnimationTest(string prefabPath) 
+        public void TransferAnimationTest(string prefabPath)
         {
             prefabPath = FindPathInUnitTests(prefabPath);
             Assert.That(prefabPath, Is.Not.Null);

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -14,22 +14,23 @@ namespace FbxExporter.UnitTests
     public class ModelExporterTest : ExporterTestBase
     {
         [TearDown]
-        public override void Term ()
+        public override void Term()
         {
             #if (!DEBUG_UNITTEST)
-            base.Term ();
+            base.Term();
             #endif
             ModelExporter.UnRegisterAllMeshCallbacks();
             ModelExporter.UnRegisterAllMeshObjectCallbacks();
         }
-        
+
         [Test]
-        public void TestBasics ()
+        public void TestBasics()
         {
             Assert.That(!string.IsNullOrEmpty(ModelExporter.GetVersionFromReadme()));
 
             // Test GetOrCreateLayer
-            using (var fbxManager = FbxManager.Create()) {
+            using (var fbxManager = FbxManager.Create())
+            {
                 var fbxMesh = FbxMesh.Create(fbxManager, "name");
                 var layer0 = ModelExporter.GetOrCreateLayer(fbxMesh);
                 Assert.That(layer0, Is.Not.Null);
@@ -41,26 +42,27 @@ namespace FbxExporter.UnitTests
 
             // Test axis conversion: a x b in left-handed is the same as b x a
             // in right-handed (that's why we need to flip the winding order).
-            var a = new Vector3(1,0,0);
-            var b = new Vector3(0,0,1);
-            var crossLeft = Vector3.Cross(a,b);
+            var a = new Vector3(1, 0, 0);
+            var b = new Vector3(0, 0, 1);
+            var crossLeft = Vector3.Cross(a, b);
 
             Assert.That(ModelExporter.DefaultMaterial);
 
             // Test non-static functions.
-            using (var fbxManager = FbxManager.Create()) {
+            using (var fbxManager = FbxManager.Create())
+            {
                 var fbxScene = FbxScene.Create(fbxManager, "scene");
-                var fbxNode = FbxNode.Create (fbxScene, "node");
+                var fbxNode = FbxNode.Create(fbxScene, "node");
                 var exporter = new ModelExporter();
 
                 // Test ExportMaterial: it exports and it re-exports
                 bool result = exporter.ExportMaterial(ModelExporter.DefaultMaterial, fbxScene, fbxNode);
-                Assert.IsTrue (result);
-                var fbxMaterial = fbxNode.GetMaterial (0);
+                Assert.IsTrue(result);
+                var fbxMaterial = fbxNode.GetMaterial(0);
                 Assert.That(fbxMaterial, Is.Not.Null);
 
                 result = exporter.ExportMaterial(ModelExporter.DefaultMaterial, fbxScene, fbxNode);
-                var fbxMaterial2 = fbxNode.GetMaterial (1);
+                var fbxMaterial2 = fbxNode.GetMaterial(1);
                 Assert.AreEqual(fbxMaterial, fbxMaterial2);
 
                 // Test ExportTexture: it finds the same texture for the default-material (it doesn't create a new one)
@@ -110,7 +112,7 @@ namespace FbxExporter.UnitTests
                 FbxAMatrix m = new FbxAMatrix();
                 m.SetR(fbxV);
                 var actualQuat = m.GetQ();
-                
+
                 // since this quaternion is XYZ instead of ZXY, it should not match the quaternion
                 // created with EulerToQuaternionZXY
                 Assert.That(xyzQuat, Is.Not.EqualTo(quat));
@@ -119,19 +121,19 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void TestFindCenter ()
+        public void TestFindCenter()
         {
             // Create 3 objects
-            var cube = CreateGameObject ("cube");
-            var cube1 = CreateGameObject ("cube1");
-            var cube2 = CreateGameObject ("cube2");
+            var cube = CreateGameObject("cube");
+            var cube1 = CreateGameObject("cube1");
+            var cube2 = CreateGameObject("cube2");
 
             // Set their transforms
-            cube.transform.localPosition = new Vector3 (23, -5, 10);
-            cube1.transform.localPosition = new Vector3 (23, -5, 4);
-            cube1.transform.localScale = new Vector3 (1, 1, 2);
-            cube2.transform.localPosition = new Vector3 (28, 0, 10);
-            cube2.transform.localScale = new Vector3 (3, 1, 1);
+            cube.transform.localPosition = new Vector3(23, -5, 10);
+            cube1.transform.localPosition = new Vector3(23, -5, 4);
+            cube1.transform.localScale = new Vector3(1, 1, 2);
+            cube2.transform.localPosition = new Vector3(28, 0, 10);
+            cube2.transform.localScale = new Vector3(3, 1, 1);
 
             // Find the center
             var center = ModelExporter.FindCenter(new GameObject[] { cube, cube1, cube2 });
@@ -141,38 +143,38 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void TestRemoveRedundantObjects ()
+        public void TestRemoveRedundantObjects()
         {
-            var root = CreateGameObject ("root");
-            var child1 = CreateGameObject ("child1", root.transform);
-            var child2 = CreateGameObject ("child2", root.transform);
-            var root2 = CreateGameObject ("root2");
+            var root = CreateGameObject("root");
+            var child1 = CreateGameObject("child1", root.transform);
+            var child2 = CreateGameObject("child2", root.transform);
+            var root2 = CreateGameObject("root2");
 
             // test set: root
             // expected result: root
             var result = ModelExporter.RemoveRedundantObjects(new Object[] { root });
-            Assert.AreEqual (1, result.Count);
-            Assert.IsTrue (result.Contains (root));
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.Contains(root));
 
             // test set: root, child1
             // expected result: root
             result = ModelExporter.RemoveRedundantObjects(new Object[] { root, child1 });
-            Assert.AreEqual (1, result.Count);
-            Assert.IsTrue (result.Contains (root));
+            Assert.AreEqual(1, result.Count);
+            Assert.IsTrue(result.Contains(root));
 
             // test set: root, child1, child2, root2
             // expected result: root, root2
             result = ModelExporter.RemoveRedundantObjects(new Object[] { root, root2, child2, child1 });
-            Assert.AreEqual (2, result.Count);
-            Assert.IsTrue (result.Contains (root));
-            Assert.IsTrue (result.Contains (root2));
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.Contains(root));
+            Assert.IsTrue(result.Contains(root2));
 
             // test set: child1, child2
             // expected result: child1, child2
             result = ModelExporter.RemoveRedundantObjects(new Object[] { child2, child1 });
-            Assert.AreEqual (2, result.Count);
-            Assert.IsTrue (result.Contains (child1));
-            Assert.IsTrue (result.Contains (child2));
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.Contains(child1));
+            Assert.IsTrue(result.Contains(child2));
         }
 
         [Test]
@@ -181,31 +183,32 @@ namespace FbxExporter.UnitTests
             // test already valid filenames
             var filename = "foobar.fbx";
             var result = ModelExporter.ConvertToValidFilename(filename);
-            Assert.AreEqual (filename, result);
+            Assert.AreEqual(filename, result);
 
             filename = "foo_bar 1.fbx";
             result = ModelExporter.ConvertToValidFilename(filename);
-            Assert.AreEqual (filename, result);
+            Assert.AreEqual(filename, result);
 
             // test invalid filenames
             filename = "?foo**bar///.fbx";
             result = ModelExporter.ConvertToValidFilename(filename);
 #if UNITY_EDITOR_WIN
-            Assert.AreEqual ("_foo__bar___.fbx", result);
+            Assert.AreEqual("_foo__bar___.fbx", result);
 #else
-            Assert.AreEqual ("?foo**bar___.fbx", result);
+            Assert.AreEqual("?foo**bar___.fbx", result);
 #endif
 
             filename = "foo$?ba%r 2.fbx";
             result = ModelExporter.ConvertToValidFilename(filename);
 #if UNITY_EDITOR_WIN
-            Assert.AreEqual ("foo$_ba%r 2.fbx", result);
+            Assert.AreEqual("foo$_ba%r 2.fbx", result);
 #else
-            Assert.AreEqual ("foo$?ba%r 2.fbx", result);
+            Assert.AreEqual("foo$?ba%r 2.fbx", result);
 #endif
         }
 
-        class CallbackTester {
+        class CallbackTester
+        {
             public string filename;
             public Transform tree;
 
@@ -213,22 +216,26 @@ namespace FbxExporter.UnitTests
             int objectCalls;
             bool objectResult;
 
-            public CallbackTester(Transform t, string f) {
+            public CallbackTester(Transform t, string f)
+            {
                 filename = f;
                 tree = t;
             }
 
-            public bool CallbackForFbxPrefab(ModelExporter exporter, FbxPrefab component, FbxNode fbxNode) {
+            public bool CallbackForFbxPrefab(ModelExporter exporter, FbxPrefab component, FbxNode fbxNode)
+            {
                 componentCalls++;
                 return true;
             }
 
-            public bool CallbackForObject(ModelExporter exporter, GameObject go, FbxNode fbxNode) {
+            public bool CallbackForObject(ModelExporter exporter, GameObject go, FbxNode fbxNode)
+            {
                 objectCalls++;
                 return objectResult;
             }
 
-            public void Verify(int cCalls, int goCalls, bool objectResult = false) {
+            public void Verify(int cCalls, int goCalls, bool objectResult = false)
+            {
                 componentCalls = 0;
                 objectCalls = 0;
                 this.objectResult = objectResult;
@@ -269,8 +276,8 @@ namespace FbxExporter.UnitTests
             // Make sure we can't register for a component twice, but we can
             // for an object.  Register twice for an object means two calls per
             // object.
-            Assert.That( () => ModelExporter.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab),
-                    Throws.Exception);
+            Assert.That(() => ModelExporter.RegisterMeshCallback<FbxPrefab>(tester.CallbackForFbxPrefab),
+                Throws.Exception);
             ModelExporter.RegisterMeshObjectCallback(tester.CallbackForObject);
             tester.Verify(1, 2 * nbTransforms);
 
@@ -310,9 +317,9 @@ namespace FbxExporter.UnitTests
 
             GetMeshForComponent<FbxPrefab> prefabCallback =
                 (ModelExporter exporter, FbxPrefab component, FbxNode node) => {
-                    exporter.ExportMesh(sphereMesh, node);
-                    return true;
-                };
+                exporter.ExportMesh(sphereMesh, node);
+                return true;
+            };
             ModelExporter.RegisterMeshCallback(prefabCallback);
             filename = GetRandomFbxFilePath();
             ModelExporter.ExportObject(filename, tree);
@@ -331,13 +338,16 @@ namespace FbxExporter.UnitTests
             filename = GetRandomFbxFilePath();
             GetMeshForObject callback =
                 (ModelExporter exporter, GameObject gameObject, FbxNode node) => {
-                    if (gameObject.name == "Parent2") {
-                        exporter.ExportMesh(sphereMesh, node);
-                        return true;
-                    } else {
-                        return false;
-                    }
-                };
+                if (gameObject.name == "Parent2")
+                {
+                    exporter.ExportMesh(sphereMesh, node);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            };
             ModelExporter.RegisterMeshObjectCallback(callback);
             ModelExporter.ExportObject(filename, tree);
             ModelExporter.UnRegisterMeshObjectCallback(callback);
@@ -351,8 +361,9 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        [Ignore("Ignore a camera orthographic test (Uni-48092)")]        
-        public void TestExportCamera2(){
+        [Ignore("Ignore a camera orthographic test (Uni-48092)")]
+        public void TestExportCamera2()
+        {
             // NOTE: even though the aspect ratio is exported,
             //       it does not get imported back into Unity.
             //       Therefore don't modify or check if camera.aspect is the same
@@ -360,7 +371,7 @@ namespace FbxExporter.UnitTests
 
             // create a Unity camera
             GameObject cameraObj = new GameObject("TestCamera");
-            Camera camera = cameraObj.AddComponent<Camera> ();
+            Camera camera = cameraObj.AddComponent<Camera>();
 
             // test export orthographic camera
             camera.orthographic = true;
@@ -368,14 +379,15 @@ namespace FbxExporter.UnitTests
             camera.nearClipPlane = 19;
             camera.farClipPlane = 500.6f;
 
-            var filename = GetRandomFbxFilePath (); // export to a different file
-            var fbxCamera = ExportCamera (filename, cameraObj);
-            CompareCameraValues (camera, fbxCamera);
-            Assert.AreEqual (camera.orthographicSize, fbxCamera.orthographicSize);
+            var filename = GetRandomFbxFilePath();  // export to a different file
+            var fbxCamera = ExportCamera(filename, cameraObj);
+            CompareCameraValues(camera, fbxCamera);
+            Assert.AreEqual(camera.orthographicSize, fbxCamera.orthographicSize);
         }
 
         [Test]
-        public void TestExportCamera1(){
+        public void TestExportCamera1()
+        {
             // NOTE: even though the aspect ratio is exported,
             //       it does not get imported back into Unity.
             //       Therefore don't modify or check if camera.aspect is the same
@@ -383,7 +395,7 @@ namespace FbxExporter.UnitTests
 
             // create a Unity camera
             GameObject cameraObj = new GameObject("TestCamera");
-            Camera camera = cameraObj.AddComponent<Camera> ();
+            Camera camera = cameraObj.AddComponent<Camera>();
 
             // change some of the default settings
             camera.orthographic = false;
@@ -393,8 +405,8 @@ namespace FbxExporter.UnitTests
 
             // export the camera
             string filename = GetRandomFbxFilePath();
-            var fbxCamera = ExportCamera (filename, cameraObj);
-            CompareCameraValues (camera, fbxCamera);
+            var fbxCamera = ExportCamera(filename, cameraObj);
+            CompareCameraValues(camera, fbxCamera);
         }
 
         /// <summary>
@@ -403,8 +415,9 @@ namespace FbxExporter.UnitTests
         /// <returns>The exported camera.</returns>
         /// <param name="filename">Filename.</param>
         /// <param name="cameraObj">Camera object.</param>
-        private Camera ExportCamera(string filename, GameObject cameraObj){
-            return ExportComponent<Camera> (filename, cameraObj);
+        private Camera ExportCamera(string filename, GameObject cameraObj)
+        {
+            return ExportComponent<Camera>(filename, cameraObj);
         }
 
         /// <summary>
@@ -414,8 +427,9 @@ namespace FbxExporter.UnitTests
         /// <param name="filename">Filename.</param>
         /// <param name="obj">Object.</param>
         /// <typeparam name="T">The component type.</typeparam>
-        private T ExportComponent<T>(string filename, GameObject obj) where T : Component {
-            ModelExporter.ExportObject (filename, obj);
+        private T ExportComponent<T>(string filename, GameObject obj) where T : Component
+        {
+            ModelExporter.ExportObject(filename, obj);
 
             var importer = AssetImporter.GetAtPath(filename) as ModelImporter;
 #if UNITY_2019_1_OR_NEWER
@@ -427,17 +441,18 @@ namespace FbxExporter.UnitTests
             importer.SaveAndReimport();
 
             GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
-            var fbxComponent = fbxObj.GetComponent<T> ();
+            var fbxComponent = fbxObj.GetComponent<T>();
 
-            Assert.IsNotNull (fbxComponent);
+            Assert.IsNotNull(fbxComponent);
             return fbxComponent;
         }
 
-        private void CompareCameraValues(Camera camera, Camera fbxCamera, float delta=0.001f){
-            Assert.AreEqual (camera.orthographic, fbxCamera.orthographic);
-            Assert.AreEqual (camera.fieldOfView, fbxCamera.fieldOfView, delta);
-            Assert.AreEqual (camera.nearClipPlane, fbxCamera.nearClipPlane, delta);
-            Assert.AreEqual (camera.farClipPlane, fbxCamera.farClipPlane, delta);
+        private void CompareCameraValues(Camera camera, Camera fbxCamera, float delta = 0.001f)
+        {
+            Assert.AreEqual(camera.orthographic, fbxCamera.orthographic);
+            Assert.AreEqual(camera.fieldOfView, fbxCamera.fieldOfView, delta);
+            Assert.AreEqual(camera.nearClipPlane, fbxCamera.nearClipPlane, delta);
+            Assert.AreEqual(camera.farClipPlane, fbxCamera.farClipPlane, delta);
         }
 
         [Test]
@@ -445,7 +460,7 @@ namespace FbxExporter.UnitTests
         {
             // create a Unity light
             GameObject lightObj = new GameObject("TestLight");
-            Light light = lightObj.AddComponent<Light> ();
+            Light light = lightObj.AddComponent<Light>();
 
             light.type = LightType.Spot;
             light.spotAngle = 55.4f;
@@ -454,9 +469,9 @@ namespace FbxExporter.UnitTests
             light.range = 45;
             light.shadows = LightShadows.Soft;
 
-            string filename = GetRandomFbxFilePath ();
-            var fbxLight = ExportComponent<Light> (filename, lightObj);
-            CompareLightValues (light, fbxLight);
+            string filename = GetRandomFbxFilePath();
+            var fbxLight = ExportComponent<Light>(filename, lightObj);
+            CompareLightValues(light, fbxLight);
 
             light.type = LightType.Point;
             light.color = Color.red;
@@ -464,29 +479,34 @@ namespace FbxExporter.UnitTests
             light.range = 120;
             light.shadows = LightShadows.Hard;
 
-            filename = GetRandomFbxFilePath ();
-            fbxLight = ExportComponent<Light> (filename, lightObj);
-            CompareLightValues (light, fbxLight);
+            filename = GetRandomFbxFilePath();
+            fbxLight = ExportComponent<Light>(filename, lightObj);
+            CompareLightValues(light, fbxLight);
         }
 
-        private void CompareLightValues(Light light, Light fbxLight, float delta=0.001f){
-            Assert.AreEqual (light.type, fbxLight.type);
-            if (light.type == LightType.Spot) {
-                Assert.AreEqual (light.spotAngle, fbxLight.spotAngle, delta);
+        private void CompareLightValues(Light light, Light fbxLight, float delta = 0.001f)
+        {
+            Assert.AreEqual(light.type, fbxLight.type);
+            if (light.type == LightType.Spot)
+            {
+                Assert.AreEqual(light.spotAngle, fbxLight.spotAngle, delta);
             }
-            Assert.AreEqual (light.color, fbxLight.color);
-            Assert.AreEqual (light.intensity, fbxLight.intensity, delta);
-            Assert.AreEqual (light.range, fbxLight.range, delta);
+            Assert.AreEqual(light.color, fbxLight.color);
+            Assert.AreEqual(light.intensity, fbxLight.intensity, delta);
+            Assert.AreEqual(light.range, fbxLight.range, delta);
 
             // compare shadows
             // make sure that if we exported without shadows, don't import with shadows
-            if (light.shadows == LightShadows.None) {
-                Assert.AreEqual (LightShadows.None, fbxLight.shadows);
-            } else {
-                Assert.AreNotEqual (LightShadows.None, fbxLight.shadows);
+            if (light.shadows == LightShadows.None)
+            {
+                Assert.AreEqual(LightShadows.None, fbxLight.shadows);
+            }
+            else
+            {
+                Assert.AreNotEqual(LightShadows.None, fbxLight.shadows);
             }
 
-            Assert.IsTrue (light.transform.rotation == fbxLight.transform.rotation);
+            Assert.IsTrue(light.transform.rotation == fbxLight.transform.rotation);
         }
 
         [Test]
@@ -495,8 +515,8 @@ namespace FbxExporter.UnitTests
             // test exporting of normals, tangents, uvs, and vertex colors
             // Note: won't test binormals as they are not imported into Unity
 
-            var quad = GameObject.CreatePrimitive (PrimitiveType.Quad);
-            var quadMeshFilter = quad.GetComponent<MeshFilter> ();
+            var quad = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            var quadMeshFilter = quad.GetComponent<MeshFilter>();
             var quadMesh = quadMeshFilter.sharedMesh;
 
             // create a simple mesh (just a quad)
@@ -511,15 +531,15 @@ namespace FbxExporter.UnitTests
             mesh.normals = quadMesh.normals;
             mesh.colors = quadMesh.colors;
 
-            Assert.IsNotNull (mesh.tangents);
-            Assert.IsNotNull (mesh.vertices);
-            Assert.IsNotNull (mesh.triangles);
-            Assert.IsNotNull (mesh.normals);
-            Assert.IsNotNull (mesh.colors);
+            Assert.IsNotNull(mesh.tangents);
+            Assert.IsNotNull(mesh.vertices);
+            Assert.IsNotNull(mesh.triangles);
+            Assert.IsNotNull(mesh.normals);
+            Assert.IsNotNull(mesh.colors);
 
-            var gameObject = new GameObject ();
-            var meshFilter = gameObject.AddComponent<MeshFilter> ();
-            gameObject.AddComponent<MeshRenderer> ();
+            var gameObject = new GameObject();
+            var meshFilter = gameObject.AddComponent<MeshFilter>();
+            gameObject.AddComponent<MeshRenderer>();
 
             meshFilter.sharedMesh = mesh;
 
@@ -528,44 +548,44 @@ namespace FbxExporter.UnitTests
 
             // try exporting default values
             string filename = GetRandomFbxFilePath();
-            var fbxMeshFilter = ExportComponent<MeshFilter> (filename, gameObject);
+            var fbxMeshFilter = ExportComponent<MeshFilter>(filename, gameObject);
             var fbxMesh = fbxMeshFilter.sharedMesh;
-            CompareMeshComponentAttributes (mesh, fbxMesh);
+            CompareMeshComponentAttributes(mesh, fbxMesh);
 
             // try exporting mesh without vertex colors
-            mesh.colors = new Color[]{ };
+            mesh.colors = new Color[] {};
 
             filename = GetRandomFbxFilePath();
-            fbxMeshFilter = ExportComponent<MeshFilter> (filename, gameObject);
+            fbxMeshFilter = ExportComponent<MeshFilter>(filename, gameObject);
             fbxMesh = fbxMeshFilter.sharedMesh;
-            CompareMeshComponentAttributes (mesh, fbxMesh);
+            CompareMeshComponentAttributes(mesh, fbxMesh);
 
-            Object.DestroyImmediate (mesh);
+            Object.DestroyImmediate(mesh);
         }
 
         private void CompareMeshComponentAttributes(Mesh mesh, Mesh fbxMesh)
         {
-            Assert.IsNotNull (fbxMesh);
-            Assert.IsNotNull (fbxMesh.vertices);
-            Assert.IsNotNull (fbxMesh.triangles);
-            Assert.IsNotNull (fbxMesh.normals);
-            Assert.IsNotNull (fbxMesh.colors);
-            Assert.IsNotNull (fbxMesh.tangents);
+            Assert.IsNotNull(fbxMesh);
+            Assert.IsNotNull(fbxMesh.vertices);
+            Assert.IsNotNull(fbxMesh.triangles);
+            Assert.IsNotNull(fbxMesh.normals);
+            Assert.IsNotNull(fbxMesh.colors);
+            Assert.IsNotNull(fbxMesh.tangents);
 
-            Assert.AreEqual (mesh.vertices, fbxMesh.vertices);
-            Assert.AreEqual (mesh.triangles, fbxMesh.triangles);
-            Assert.AreEqual (mesh.normals, fbxMesh.normals);
-            Assert.AreEqual (mesh.colors, fbxMesh.colors);
-            Assert.AreEqual (mesh.tangents, fbxMesh.tangents);
+            Assert.AreEqual(mesh.vertices, fbxMesh.vertices);
+            Assert.AreEqual(mesh.triangles, fbxMesh.triangles);
+            Assert.AreEqual(mesh.normals, fbxMesh.normals);
+            Assert.AreEqual(mesh.colors, fbxMesh.colors);
+            Assert.AreEqual(mesh.tangents, fbxMesh.tangents);
         }
 
         private delegate void SetImportSettings(ModelImporter importer);
         private (string filename, SkinnedMeshRenderer originalSkinnedMesh, SkinnedMeshRenderer exportedSkinnedMesh) ExportSkinnedMesh(
-            string fileToExport, 
+            string fileToExport,
             SetImportSettings setImportSettings = null)
         {
             // change import settings of original FBX
-            if(setImportSettings != null)
+            if (setImportSettings != null)
             {
                 var origImporter = AssetImporter.GetAtPath(fileToExport) as ModelImporter;
                 setImportSettings(origImporter);
@@ -574,14 +594,14 @@ namespace FbxExporter.UnitTests
 
             // add fbx to scene
             GameObject originalFbxObj = AssetDatabase.LoadMainAssetAtPath(fileToExport) as GameObject;
-            Assert.IsNotNull (originalFbxObj);
-            GameObject originalGO = GameObject.Instantiate (originalFbxObj);
-            Assert.IsTrue (originalGO);
+            Assert.IsNotNull(originalFbxObj);
+            GameObject originalGO = GameObject.Instantiate(originalFbxObj);
+            Assert.IsTrue(originalGO);
 
             // export fbx
             // get GameObject
             string filename = GetRandomFbxFilePath();
-            ModelExporter.ExportObject (filename, originalGO);
+            ModelExporter.ExportObject(filename, originalGO);
 
             if (setImportSettings != null)
             {
@@ -591,21 +611,23 @@ namespace FbxExporter.UnitTests
             }
 
             GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
-            Assert.IsTrue (fbxObj);
+            Assert.IsTrue(fbxObj);
 
-            var originalSkinnedMesh = originalGO.GetComponentInChildren<SkinnedMeshRenderer> ();
-            Assert.IsNotNull (originalSkinnedMesh);
+            var originalSkinnedMesh = originalGO.GetComponentInChildren<SkinnedMeshRenderer>();
+            Assert.IsNotNull(originalSkinnedMesh);
 
-            var exportedSkinnedMesh = fbxObj.GetComponentInChildren<SkinnedMeshRenderer> ();
-            Assert.IsNotNull (exportedSkinnedMesh);
+            var exportedSkinnedMesh = fbxObj.GetComponentInChildren<SkinnedMeshRenderer>();
+            Assert.IsNotNull(exportedSkinnedMesh);
 
             return (filename, originalSkinnedMesh, exportedSkinnedMesh);
         }
 
         public class SkinnedMeshTestDataClass
         {
-            public static System.Collections.IEnumerable SkinnedMeshCases {
-                get {
+            public static System.Collections.IEnumerable SkinnedMeshCases
+            {
+                get
+                {
                     // Basic Rig with one mesh and one standard hierarchy
                     yield return "Models/MultiRootCharacters/BasicSeparateBind.fbx";
                     // Basic Rig with one mesh and one standard hierarchy, with the Mesh parenting the bone structure
@@ -614,7 +636,7 @@ namespace FbxExporter.UnitTests
                     yield return "Models/MultiRootCharacters/LocatorsInHierachy.fbx";
                     // Root-Level Locators included in the fbx.
                     yield return "Models/MultiRootCharacters/LooseLocators.fbx";
-                    // Root-Level Null Objects included in the fbx. 
+                    // Root-Level Null Objects included in the fbx.
                     yield return "Models/MultiRootCharacters/LooseNulls.fbx";
                     // Basic Rig with additional floating joints independant in hierarchy and skinned to the mesh.
                     yield return "Models/MultiRootCharacters/LooseSkinnedJoints.fbx";
@@ -635,9 +657,10 @@ namespace FbxExporter.UnitTests
         }
 
         [Test, TestCaseSource(typeof(SkinnedMeshTestDataClass), "SkinnedMeshCases")]
-        public void TestSkinnedMeshes (string fbxPath) {
-            fbxPath = FindPathInUnitTests (fbxPath);
-            Assert.That (fbxPath, Is.Not.Null);
+        public void TestSkinnedMeshes(string fbxPath)
+        {
+            fbxPath = FindPathInUnitTests(fbxPath);
+            Assert.That(fbxPath, Is.Not.Null);
 
             SkinnedMeshRenderer originalSkinnedMesh, exportedSkinnedMesh;
 
@@ -654,11 +677,11 @@ namespace FbxExporter.UnitTests
 #endif // UNITY_2021_2_OR_NEWER
             };
 
-            var exportResult = ExportSkinnedMesh (fbxPath, setImportSettings);
+            var exportResult = ExportSkinnedMesh(fbxPath, setImportSettings);
             originalSkinnedMesh = exportResult.originalSkinnedMesh;
             exportedSkinnedMesh = exportResult.exportedSkinnedMesh;
 
-            Assert.IsTrue (originalSkinnedMesh.name == exportedSkinnedMesh.name ||
+            Assert.IsTrue(originalSkinnedMesh.name == exportedSkinnedMesh.name ||
                 (originalSkinnedMesh.transform.parent == null && exportedSkinnedMesh.transform.parent == null));
 
             // check if skeletons match
@@ -666,17 +689,18 @@ namespace FbxExporter.UnitTests
             var originalBones = originalSkinnedMesh.bones;
             var exportedBones = exportedSkinnedMesh.bones;
 
-            Assert.IsNotNull (originalBones);
-            Assert.IsNotNull (exportedBones);
+            Assert.IsNotNull(originalBones);
+            Assert.IsNotNull(exportedBones);
 
-            Assert.AreEqual (originalBones.Length, exportedBones.Length);
+            Assert.AreEqual(originalBones.Length, exportedBones.Length);
 
-            for(int i = 0; i < originalBones.Length; i++){
-                var originalBone = originalBones [i];
-                var exportedBone = exportedBones [i];
+            for (int i = 0; i < originalBones.Length; i++)
+            {
+                var originalBone = originalBones[i];
+                var exportedBone = exportedBones[i];
 
-                Assert.AreEqual (originalBone.name, exportedBone.name);
-                Assert.AreEqual (originalBone.parent, exportedBone.parent);
+                Assert.AreEqual(originalBone.name, exportedBone.name);
+                Assert.AreEqual(originalBone.parent, exportedBone.parent);
 
                 // NOTE: not comparing transforms as the exported transforms are taken from
                 //       the bind pose whereas the originals are not necessarily.
@@ -684,29 +708,33 @@ namespace FbxExporter.UnitTests
 
             // compare bind poses
             var origMesh = originalSkinnedMesh.sharedMesh;
-            Assert.IsNotNull (origMesh);
+            Assert.IsNotNull(origMesh);
             var exportedMesh = exportedSkinnedMesh.sharedMesh;
-            Assert.IsNotNull (exportedMesh);
+            Assert.IsNotNull(exportedMesh);
 
             var origBindposes = origMesh.bindposes;
-            Assert.IsNotNull (origBindposes);
+            Assert.IsNotNull(origBindposes);
             var exportedBindposes = exportedMesh.bindposes;
-            Assert.IsNotNull (exportedBindposes);
+            Assert.IsNotNull(exportedBindposes);
 
             Assert.That(origBindposes.Length == exportedBindposes.Length);
 
-            for (int i = 0; i < origBindposes.Length; i++) {
-                var origBp = origBindposes [i];
-                var expBp = exportedBindposes [i];
+            for (int i = 0; i < origBindposes.Length; i++)
+            {
+                var origBp = origBindposes[i];
+                var expBp = exportedBindposes[i];
 
-				// TODO: (UNI-34293) fix so bones with negative scale export with correct bind pose
-				if (originalBones [i].name == "EyeL") {
-					continue;
-				}
+                // TODO: (UNI-34293) fix so bones with negative scale export with correct bind pose
+                if (originalBones[i].name == "EyeL")
+                {
+                    continue;
+                }
 
-                for (int j = 0; j < 4; j++) {
-                    for (int k = 0; k < 4; k++) {
-                        Assert.That (origBp.GetColumn (j)[k], Is.EqualTo(expBp.GetColumn (j)[k]).Within(0.001f), string.Format("bind pose doesn't match {0},{1}", j, k));
+                for (int j = 0; j < 4; j++)
+                {
+                    for (int k = 0; k < 4; k++)
+                    {
+                        Assert.That(origBp.GetColumn(j)[k], Is.EqualTo(expBp.GetColumn(j)[k]).Within(0.001f), string.Format("bind pose doesn't match {0},{1}", j, k));
                     }
                 }
             }
@@ -714,10 +742,10 @@ namespace FbxExporter.UnitTests
             // Test Bone Weights
 
             var origVerts = originalSkinnedMesh.sharedMesh.vertices;
-            Assert.That (origVerts, Is.Not.Null);
+            Assert.That(origVerts, Is.Not.Null);
 
             var expVerts = exportedSkinnedMesh.sharedMesh.vertices;
-            Assert.That (expVerts, Is.Not.Null);
+            Assert.That(expVerts, Is.Not.Null);
 
             var origBones = originalSkinnedMesh.bones;
             var expBones = exportedSkinnedMesh.bones;
@@ -832,7 +860,7 @@ namespace FbxExporter.UnitTests
                         continue;
                     }
 
-                    for(int j = 0; j < blendshape.GetBlendShapeChannelCount(); j++)
+                    for (int j = 0; j < blendshape.GetBlendShapeChannelCount(); j++)
                     {
                         var blendShapeChannel = blendshape.GetBlendShapeChannel(j);
                         for (int k = 0; k < blendShapeChannel.GetTargetShapeCount(); k++)
@@ -860,7 +888,7 @@ namespace FbxExporter.UnitTests
                 // Configure the IO settings.
                 fbxManager.SetIOSettings(fbxIOSettings);
 
-                // Create the importer 
+                // Create the importer
                 var fbxImporter = FbxImporter.Create(fbxManager, "Importer");
 
                 // Initialize the importer.
@@ -887,7 +915,7 @@ namespace FbxExporter.UnitTests
                 status = fbxImporter.Import(fbxScene);
                 fbxStatus = fbxImporter.GetStatus();
                 Assert.That(status, Is.True, fbxStatus.GetErrorString());
-                
+
                 // Get blendshapes and check that the FbxShapes all have names
                 var rootNode = fbxScene.GetRootNode();
                 TestFbxShapeNamesNotEmpty(rootNode);
@@ -899,8 +927,8 @@ namespace FbxExporter.UnitTests
         {
             const float epsilon = 0.001f;
 
-            fbxPath = FindPathInUnitTests (fbxPath);
-            Assert.That (fbxPath, Is.Not.Null);
+            fbxPath = FindPathInUnitTests(fbxPath);
+            Assert.That(fbxPath, Is.Not.Null);
 
             SkinnedMeshRenderer originalSMR, exportedSMR;
             SetImportSettings setImportSettings = (importer) =>
@@ -930,7 +958,7 @@ namespace FbxExporter.UnitTests
                 importer.weldVertices = true;
             };
 
-            var exportResult = ExportSkinnedMesh (fbxPath, setImportSettings);
+            var exportResult = ExportSkinnedMesh(fbxPath, setImportSettings);
             var exportedFbxPath = exportResult.filename;
             originalSMR = exportResult.originalSkinnedMesh;
             exportedSMR = exportResult.exportedSkinnedMesh;
@@ -989,7 +1017,8 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void LODExportTest(){
+        public void LODExportTest()
+        {
             // Create the following test hierarchy:
             //  LODGroup
             //  -- Sphere_LOD0
@@ -1000,55 +1029,55 @@ namespace FbxExporter.UnitTests
             // where sphere + capsule renderers are both in LOD0, and cylinder is in LOD1
             // but not parented under the LOD group
 
-            var lodGroup = new GameObject ("LODGroup");
-            var sphereLOD0 = GameObject.CreatePrimitive (PrimitiveType.Sphere);
+            var lodGroup = new GameObject("LODGroup");
+            var sphereLOD0 = GameObject.CreatePrimitive(PrimitiveType.Sphere);
             sphereLOD0.name = "Sphere_LOD0";
-            var capsuleLOD0 = GameObject.CreatePrimitive (PrimitiveType.Capsule);
+            var capsuleLOD0 = GameObject.CreatePrimitive(PrimitiveType.Capsule);
             capsuleLOD0.name = "Capsule_LOD0";
-            var cubeLOD2 = GameObject.CreatePrimitive (PrimitiveType.Cube);
+            var cubeLOD2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             cubeLOD2.name = "Cube_LOD2";
-            var cylinderLOD1 = GameObject.CreatePrimitive (PrimitiveType.Cylinder);
+            var cylinderLOD1 = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
             cylinderLOD1.name = "Cylinder_LOD1";
 
-            sphereLOD0.transform.SetParent (lodGroup.transform);
-            capsuleLOD0.transform.SetParent (lodGroup.transform);
-            cubeLOD2.transform.SetParent (lodGroup.transform);
-            cylinderLOD1.transform.SetParent (null);
+            sphereLOD0.transform.SetParent(lodGroup.transform);
+            capsuleLOD0.transform.SetParent(lodGroup.transform);
+            cubeLOD2.transform.SetParent(lodGroup.transform);
+            cylinderLOD1.transform.SetParent(null);
 
             // add LOD group
             var lodGroupComp = lodGroup.AddComponent<LODGroup>();
-            Assert.That (lodGroupComp, Is.Not.Null);
+            Assert.That(lodGroupComp, Is.Not.Null);
 
             LOD[] lods = new LOD[3];
-            lods [0] = new LOD (1, new Renderer[]{ sphereLOD0.GetComponent<Renderer>(), capsuleLOD0.GetComponent<Renderer>() });
-            lods [1] = new LOD (0.75f, new Renderer[] { cylinderLOD1.GetComponent<Renderer>() });
-            lods [2] = new LOD (0.5f, new Renderer[] { cubeLOD2.GetComponent<Renderer>() });
-            lodGroupComp.SetLODs (lods);
-            lodGroupComp.RecalculateBounds ();
+            lods[0] = new LOD(1, new Renderer[] { sphereLOD0.GetComponent<Renderer>(), capsuleLOD0.GetComponent<Renderer>() });
+            lods[1] = new LOD(0.75f, new Renderer[] { cylinderLOD1.GetComponent<Renderer>() });
+            lods[2] = new LOD(0.5f, new Renderer[] { cubeLOD2.GetComponent<Renderer>() });
+            lodGroupComp.SetLODs(lods);
+            lodGroupComp.RecalculateBounds();
 
             // test export all
             // expected LODs exported: Sphere_LOD0, Capsule_LOD0, Cube_LOD2
-            GameObject fbxObj = ExportToFbx(lodGroup, lodExportType:ExportSettings.LODExportType.All);
-            Assert.IsTrue (fbxObj);
+            GameObject fbxObj = ExportToFbx(lodGroup, lodExportType: ExportSettings.LODExportType.All);
+            Assert.IsTrue(fbxObj);
 
-            HashSet<string> expectedChildren = new HashSet<string> () { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
-            CompareGameObjectChildren (fbxObj, expectedChildren);
+            HashSet<string> expectedChildren = new HashSet<string>() { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
+            CompareGameObjectChildren(fbxObj, expectedChildren);
 
             // test export highest
             // expected LODs exported: Sphere_LOD0, Capsule_LOD0
-            fbxObj = ExportToFbx(lodGroup, lodExportType:ExportSettings.LODExportType.Highest);
-            Assert.IsTrue (fbxObj);
+            fbxObj = ExportToFbx(lodGroup, lodExportType: ExportSettings.LODExportType.Highest);
+            Assert.IsTrue(fbxObj);
 
-            expectedChildren = new HashSet<string> () { sphereLOD0.name, capsuleLOD0.name };
-            CompareGameObjectChildren (fbxObj, expectedChildren);
+            expectedChildren = new HashSet<string>() { sphereLOD0.name, capsuleLOD0.name };
+            CompareGameObjectChildren(fbxObj, expectedChildren);
 
             // test export lowest
             // expected LODs exported: Cube_LOD2
-            fbxObj = ExportToFbx(lodGroup, lodExportType:ExportSettings.LODExportType.Lowest);
-            Assert.IsTrue (fbxObj);
+            fbxObj = ExportToFbx(lodGroup, lodExportType: ExportSettings.LODExportType.Lowest);
+            Assert.IsTrue(fbxObj);
 
-            expectedChildren = new HashSet<string> () { cubeLOD2.name };
-            CompareGameObjectChildren (fbxObj, expectedChildren);
+            expectedChildren = new HashSet<string>() { cubeLOD2.name };
+            CompareGameObjectChildren(fbxObj, expectedChildren);
 
 #if !UNITY_2018_3_OR_NEWER
             // test convert to prefab
@@ -1056,22 +1085,21 @@ namespace FbxExporter.UnitTests
             // expected LODs exported: Sphere_LOD0, Capsule_LOD0, Cube_LOD2
             // NOTE: Cylinder_LOD1 is not exported as it is not under the LODGroup hierarchy being exported
             var convertedHierarchy = ConvertToModel.Convert(lodGroup,
-                    fbxFullPath: GetRandomFbxFilePath(),
-                    prefabFullPath: GetRandomPrefabAssetPath());
-            Assert.That (convertedHierarchy, Is.Not.Null);
+                fbxFullPath: GetRandomFbxFilePath(),
+                prefabFullPath: GetRandomPrefabAssetPath());
+            Assert.That(convertedHierarchy, Is.Not.Null);
 
             // check both converted hierarchy and fbx
-            expectedChildren = new HashSet<string> () { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
-            CompareGameObjectChildren (convertedHierarchy, expectedChildren);
+            expectedChildren = new HashSet<string>() { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
+            CompareGameObjectChildren(convertedHierarchy, expectedChildren);
 
             fbxObj = convertedHierarchy.GetComponent<FbxPrefab>().FbxModel;
-            Assert.IsTrue (fbxObj);
+            Assert.IsTrue(fbxObj);
 
-            expectedChildren = new HashSet<string> () { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
-            CompareGameObjectChildren (fbxObj, expectedChildren);
+            expectedChildren = new HashSet<string>() { sphereLOD0.name, capsuleLOD0.name, cubeLOD2.name };
+            CompareGameObjectChildren(fbxObj, expectedChildren);
 #endif
         }
-
 
         /// <summary>
         /// Compares obj's children to the expected children in the hashset.
@@ -1079,12 +1107,14 @@ namespace FbxExporter.UnitTests
         /// </summary>
         /// <param name="obj">Object.</param>
         /// <param name="expectedChildren">Expected children.</param>
-        private void CompareGameObjectChildren(GameObject obj, HashSet<string> expectedChildren){
-            Assert.That (obj.transform.childCount, Is.EqualTo (expectedChildren.Count));
+        private void CompareGameObjectChildren(GameObject obj, HashSet<string> expectedChildren)
+        {
+            Assert.That(obj.transform.childCount, Is.EqualTo(expectedChildren.Count));
 
-            foreach (Transform child in obj.transform) {
-                Assert.That (expectedChildren.Contains (child.name));
-                expectedChildren.Remove (child.name);
+            foreach (Transform child in obj.transform)
+            {
+                Assert.That(expectedChildren.Contains(child.name));
+                expectedChildren.Remove(child.name);
             }
         }
 
@@ -1213,11 +1243,12 @@ namespace FbxExporter.UnitTests
             Assert.That(fbxSphere2, Is.Not.Null);
 
             // The exported spheres should match the originals
-            Assert.That(AreEqual(fbxSphere1.position, sphere1.transform.position), 
+            Assert.That(AreEqual(fbxSphere1.position, sphere1.transform.position),
                 string.Format("Positions do not match.\nActual: {0}\nExpected: {1}", fbxSphere1.position, sphere1.transform.position));
             Assert.That(AreEqual(fbxSphere2.position, sphere2.transform.position),
                 string.Format("Positions do not match.\nActual: {0}\nExpected: {1}", fbxSphere2.position, sphere2.transform.position));
         }
+
         // Test that export does not fail if the mesh is missing or null
         [Test]
         public void TestMissingMeshExport()
@@ -1231,11 +1262,11 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        public void TestMaterialScaleAndOffset() 
+        public void TestMaterialScaleAndOffset()
         {
             string matClampGuid = "e6598d8bd228e5940988877e9eddd594";
             string matRepeatGuid = "f07bd71d1d87a7b41acfc483bf06be3f";
-            
+
             var filename = GetRandomFbxFilePath();
 
             var clampMat = AssetDatabase.LoadAssetAtPath<Material>(AssetDatabase.GUIDToAssetPath(matClampGuid));
@@ -1262,7 +1293,7 @@ namespace FbxExporter.UnitTests
                 modelImporter.AddRemap(new AssetImporter.SourceAssetIdentifier(tex), tex);
             }
             AssetDatabase.ImportAsset(modelImporter.assetPath, ImportAssetOptions.ForceUpdate);
-            
+
             GameObject fbxObj = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             var importedClampMat = fbxObj.transform.Find("Clamp").GetComponent<MeshRenderer>().sharedMaterial;
             var importedRepeatMat = fbxObj.transform.Find("Repeat").GetComponent<MeshRenderer>().sharedMaterial;
@@ -1273,16 +1304,15 @@ namespace FbxExporter.UnitTests
             Assert.AreNotSame(clampMat.mainTexture, importedClampMat.mainTexture);
             Assert.AreNotSame(repeatMat.mainTexture, importedRepeatMat.mainTexture);
             Assert.AreNotSame(importedClampMat.mainTexture, importedRepeatMat.mainTexture);
-            
+
             // (Case 1416726) This fails since texture wrap mode is not correctly set when extracting textures from FBX files
             // Assert.AreEqual(clampMat.mainTexture.wrapMode, importedClampMat.mainTexture.wrapMode);
             // Assert.AreEqual(repeatMat.mainTexture.wrapMode, importedRepeatMat.mainTexture.wrapMode);
-            
+
             Assert.AreEqual(clampMat.mainTextureOffset, importedClampMat.mainTextureOffset);
             Assert.AreEqual(clampMat.mainTextureScale, importedClampMat.mainTextureScale);
             Assert.AreEqual(repeatMat.mainTextureOffset, importedRepeatMat.mainTextureOffset);
             Assert.AreEqual(repeatMat.mainTextureScale, importedRepeatMat.mainTextureScale);
-
         }
     }
 }

--- a/com.unity.formats.fbx/Tests/Scripts/ExporterTestBase.cs
+++ b/com.unity.formats.fbx/Tests/Scripts/ExporterTestBase.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEditor;
 using NUnit.Framework;
 using System.IO;
@@ -12,7 +12,7 @@ namespace FbxExporter.UnitTests
         bool isAutoUpdaterOn;
 
         [TearDown]
-        public override void Term ()
+        public override void Term()
         {
             base.Term();
         }
@@ -32,39 +32,41 @@ namespace FbxExporter.UnitTests
         {
             // export selected to a file, then return the root
             var filename = GetRandomFileNamePath();
-            return ExportSelection (filename, selected, exportOptions);
+            return ExportSelection(filename, selected, exportOptions);
         }
 
-        internal virtual GameObject ExportSelection(Object[] selected, IExportOptions exportOptions = null){
+        internal virtual GameObject ExportSelection(Object[] selected, IExportOptions exportOptions = null)
+        {
             var filename = GetRandomFileNamePath();
-            return ExportSelection (filename, selected, exportOptions);
+            return ExportSelection(filename, selected, exportOptions);
         }
 
         internal virtual GameObject ExportSelection(string filename, Object selected, IExportOptions exportOptions = null)
         {
             // export selected to a file, then return the root
-            return ExportSelection (filename, new Object[]{selected}, exportOptions);
+            return ExportSelection(filename, new Object[] {selected}, exportOptions);
         }
 
-        internal virtual GameObject ExportSelection(string filename, Object[] selected, IExportOptions exportOptions = null){
+        internal virtual GameObject ExportSelection(string filename, Object[] selected, IExportOptions exportOptions = null)
+        {
             Debug.unityLogger.logEnabled = false;
-            var fbxFileName = ModelExporter.ExportObjects (filename, selected, exportOptions) as string;
+            var fbxFileName = ModelExporter.ExportObjects(filename, selected, exportOptions) as string;
             Debug.unityLogger.logEnabled = true;
 
-            Assert.IsNotNull (fbxFileName);
+            Assert.IsNotNull(fbxFileName);
 
             // make filepath relative to project folder
-            if (fbxFileName.StartsWith (Application.dataPath, System.StringComparison.CurrentCulture))
+            if (fbxFileName.StartsWith(Application.dataPath, System.StringComparison.CurrentCulture))
             {
-                fbxFileName = "Assets" + fbxFileName.Substring (Application.dataPath.Length);
+                fbxFileName = "Assets" + fbxFileName.Substring(Application.dataPath.Length);
             }
             // refresh the assetdata base so that we can query for the model
-            AssetDatabase.Refresh ();
+            AssetDatabase.Refresh();
 
-            Object unityMainAsset = AssetDatabase.LoadMainAssetAtPath (fbxFileName);
+            Object unityMainAsset = AssetDatabase.LoadMainAssetAtPath(fbxFileName);
             var fbxRoot = unityMainAsset as GameObject;
 
-            Assert.IsNotNull (fbxRoot);
+            Assert.IsNotNull(fbxRoot);
             return fbxRoot;
         }
 
@@ -74,23 +76,24 @@ namespace FbxExporter.UnitTests
         /// <returns>The exported fbx file path.</returns>
         /// <param name="hierarchy">Hierarchy.</param>
         /// <param name="animOnly">If set to <c>true</c> export animation only.</param>
-        internal GameObject ExportToFbx (
+        internal GameObject ExportToFbx(
             GameObject hierarchy, bool animOnly = false,
             ExportSettings.LODExportType lodExportType = ExportSettings.LODExportType.All
-        ){
-            string filename = GetRandomFbxFilePath ();
-            var exportOptions = new ExportModelSettingsSerialize ();
+        )
+        {
+            string filename = GetRandomFbxFilePath();
+            var exportOptions = new ExportModelSettingsSerialize();
             exportOptions.SetLODExportType(lodExportType);
-            if (animOnly) {
+            if (animOnly)
+            {
                 exportOptions.SetModelAnimIncludeOption(ExportSettings.Include.Anim);
             }
-            var exportedFilePath = ModelExporter.ExportObject (
+            var exportedFilePath = ModelExporter.ExportObject(
                 filename, hierarchy, exportOptions
             );
-            Assert.That (exportedFilePath, Is.EqualTo (filename));
+            Assert.That(exportedFilePath, Is.EqualTo(filename));
             var exported = AssetDatabase.LoadMainAssetAtPath(filename) as GameObject;
             return exported;
         }
-
     }
 }


### PR DESCRIPTION
Use count and length properties instead of LINQ call.
Array/List can not be under 0.
Use TryGetComponent to reduce memory allocation when no component is found.
GetComponent Mesh will always return null. Get MeshFilter.mesh instead.
Simplify string comparison.