### PR TITLE
Nojira/fix fbxrecorder with 4.0.0 recorder

### DIFF
--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -43,6 +43,11 @@ namespace UnityEditor.Formats.Fbx.Exporter
 #else
                     aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);
 #endif
+                    if (settings.AnimationInputSettings.ClampedTangents)
+                    {
+                        FilterClip(clip);
+                    }
+
                     var root = ((AnimationInputSettings)aInput.settings).gameObject;
                     clip.name = "recorded_clip";
 
@@ -68,6 +73,20 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 }
             }
             base.EndRecording(session);
+        }
+
+        void FilterClip(AnimationClip clip)
+        {
+            foreach (var bind in AnimationUtility.GetCurveBindings(clip))
+            {
+                var curve = AnimationUtility.GetEditorCurve(clip, bind);
+                for (var i = 0; i < curve.keys.Length; ++i)
+                {
+                    AnimationUtility.SetKeyLeftTangentMode(curve, i, AnimationUtility.TangentMode.ClampedAuto);
+                    AnimationUtility.SetKeyRightTangentMode(curve, i, AnimationUtility.TangentMode.ClampedAuto);
+                }
+                AnimationUtility.SetEditorCurve(clip, bind, curve);
+            }
         }
     }
 }

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -1,51 +1,13 @@
 #if ENABLE_FBX_RECORDER
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor.Recorder;
 using UnityEditor.Recorder.Input;
-using UnityEditor;
-using UnityEditor.Animations;
-using System;
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
     class FbxRecorder : GenericRecorder<FbxRecorderSettings>
     {
-        static readonly CurveFilterOptions DefaultCurveFilterOptions = new CurveFilterOptions()
-        {
-            keyframeReduction = true,
-            positionError = 0.5f,
-            rotationError = 0.5f,
-            scaleError = 0.5f,
-            floatError = 0.5f
-        };
-
-        static readonly CurveFilterOptions RegularCurveFilterOptions = new CurveFilterOptions
-        {
-            keyframeReduction = true
-        };
-
-        static readonly CurveFilterOptions NoCurveFilterOptions = new CurveFilterOptions
-        {
-            keyframeReduction = false
-        };
-
-        internal CurveFilterOptions GetCurveFilterOptions(AnimationInputSettings.CurveSimplificationOptions options)
-        {
-            switch (options)
-            {
-                case AnimationInputSettings.CurveSimplificationOptions.Lossy:
-                    return DefaultCurveFilterOptions;
-                case AnimationInputSettings.CurveSimplificationOptions.Lossless:
-                    return RegularCurveFilterOptions;
-                case AnimationInputSettings.CurveSimplificationOptions.Disabled:
-                    return NoCurveFilterOptions;
-                default:
-                    throw new NotImplementedException();
-            }
-        }
-
         protected override void RecordFrame(RecordingSession ctx)
         {
         }
@@ -76,7 +38,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
 
 #if UNITY_2019_3_OR_NEWER
-                    var options = GetCurveFilterOptions(settings.AnimationInputSettings.SimplyCurves);
+                    var options = settings.GetCurveFilterOptions(settings.AnimationInputSettings.SimplyCurves);
                     aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
 #else
                     aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorder.cs
@@ -5,11 +5,47 @@ using UnityEngine;
 using UnityEditor.Recorder;
 using UnityEditor.Recorder.Input;
 using UnityEditor;
+using UnityEditor.Animations;
+using System;
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
     class FbxRecorder : GenericRecorder<FbxRecorderSettings>
     {
+        static readonly CurveFilterOptions DefaultCurveFilterOptions = new CurveFilterOptions()
+        {
+            keyframeReduction = true,
+            positionError = 0.5f,
+            rotationError = 0.5f,
+            scaleError = 0.5f,
+            floatError = 0.5f
+        };
+
+        static readonly CurveFilterOptions RegularCurveFilterOptions = new CurveFilterOptions
+        {
+            keyframeReduction = true
+        };
+
+        static readonly CurveFilterOptions NoCurveFilterOptions = new CurveFilterOptions
+        {
+            keyframeReduction = false
+        };
+
+        internal CurveFilterOptions GetCurveFilterOptions(AnimationInputSettings.CurveSimplificationOptions options)
+        {
+            switch (options)
+            {
+                case AnimationInputSettings.CurveSimplificationOptions.Lossy:
+                    return DefaultCurveFilterOptions;
+                case AnimationInputSettings.CurveSimplificationOptions.Lossless:
+                    return RegularCurveFilterOptions;
+                case AnimationInputSettings.CurveSimplificationOptions.Disabled:
+                    return NoCurveFilterOptions;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         protected override void RecordFrame(RecordingSession ctx)
         {
         }
@@ -21,51 +57,53 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 throw new System.ArgumentNullException("session");
             }
 
-            var settings = (FbxRecorderSettings)session.settings;
-
-            foreach (var input in m_Inputs)
+            if (Recording)
             {
-                var aInput = (AnimationInput)input;
+                var settings = (FbxRecorderSettings)session.settings;
 
-                if (aInput.GameObjectRecorder == null)
-                    continue;
+                foreach (var input in m_Inputs)
+                {
+                    var aInput = (AnimationInput)input;
 
-                var clip = new AnimationClip();
+                    if (aInput.GameObjectRecorder == null)
+                        continue;
 
-                settings.FileNameGenerator.CreateDirectory(session);
+                    var clip = new AnimationClip();
 
-                var absolutePath = FileNameGenerator.SanitizePath(settings.FileNameGenerator.BuildAbsolutePath(session));
-                var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
+                    settings.FileNameGenerator.CreateDirectory(session);
+
+                    var absolutePath = FileNameGenerator.SanitizePath(settings.FileNameGenerator.BuildAbsolutePath(session));
+                    var clipName = absolutePath.Replace(FileNameGenerator.SanitizePath(Application.dataPath), "Assets");
 
 #if UNITY_2019_3_OR_NEWER
-                var options = new Animations.CurveFilterOptions();
-                options.keyframeReduction = false;
-                aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
+                    var options = GetCurveFilterOptions(settings.AnimationInputSettings.SimplyCurves);
+                    aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate, options);
 #else
-                aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);
+                    aInput.GameObjectRecorder.SaveToClip(clip, settings.FrameRate);
 #endif
-                var root = ((AnimationInputSettings)aInput.settings).gameObject;
-                clip.name = "recorded_clip";
+                    var root = ((AnimationInputSettings)aInput.settings).gameObject;
+                    clip.name = "recorded_clip";
 
-                var exportSettings = new ExportModelSettingsSerialize();
-                exportSettings.SetAnimationSource(settings.TransferAnimationSource);
-                exportSettings.SetAnimationDest(settings.TransferAnimationDest);
-                exportSettings.SetObjectPosition(ExportSettings.ObjectPosition.WorldAbsolute);
-                var toInclude = ExportSettings.Include.ModelAndAnim;
-                if (!settings.ExportGeometry)
-                {
-                    toInclude = ExportSettings.Include.Anim;
+                    var exportSettings = new ExportModelSettingsSerialize();
+                    exportSettings.SetAnimationSource(settings.TransferAnimationSource);
+                    exportSettings.SetAnimationDest(settings.TransferAnimationDest);
+                    exportSettings.SetObjectPosition(ExportSettings.ObjectPosition.WorldAbsolute);
+                    var toInclude = ExportSettings.Include.ModelAndAnim;
+                    if (!settings.ExportGeometry)
+                    {
+                        toInclude = ExportSettings.Include.Anim;
+                    }
+                    exportSettings.SetModelAnimIncludeOption(toInclude);
+
+                    var exportData = new AnimationOnlyExportData();
+                    exportData.CollectDependencies(clip, root, exportSettings);
+                    var exportDataContainer = new Dictionary<GameObject, IExportData>();
+                    exportDataContainer.Add(root, exportData);
+
+                    ModelExporter.ExportObjects(clipName, new UnityEngine.Object[] { root }, exportSettings, exportDataContainer);
+
+                    aInput.GameObjectRecorder.ResetRecording();
                 }
-                exportSettings.SetModelAnimIncludeOption(toInclude);
-
-                var exportData = new AnimationOnlyExportData();
-                exportData.CollectDependencies(clip, root, exportSettings);
-                var exportDataContainer = new Dictionary<GameObject, IExportData>();
-                exportDataContainer.Add(root, exportData);
-
-                ModelExporter.ExportObjects(clipName, new UnityEngine.Object[] { root }, exportSettings, exportDataContainer);
-
-                aInput.GameObjectRecorder.ResetRecording();
             }
             base.EndRecording(session);
         }

--- a/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
+++ b/com.unity.formats.fbx/Editor/Sources/Recorders/FbxRecorder/FbxRecorderSettings.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor.Recorder;
 using UnityEditor.Recorder.Input;
+using UnityEditor.Animations;
+using System;
 
 namespace UnityEditor.Formats.Fbx.Exporter
 {
@@ -85,6 +87,40 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     m_animDestBindingId = GenerateBindingId();
 
                 SetBinding(m_animDestBindingId, value);
+            }
+        }
+
+        static readonly CurveFilterOptions DefaultCurveFilterOptions = new CurveFilterOptions()
+        {
+            keyframeReduction = true,
+            positionError = 0.5f,
+            rotationError = 0.5f,
+            scaleError = 0.5f,
+            floatError = 0.5f
+        };
+
+        static readonly CurveFilterOptions RegularCurveFilterOptions = new CurveFilterOptions
+        {
+            keyframeReduction = true
+        };
+
+        static readonly CurveFilterOptions NoCurveFilterOptions = new CurveFilterOptions
+        {
+            keyframeReduction = false
+        };
+
+        internal CurveFilterOptions GetCurveFilterOptions(AnimationInputSettings.CurveSimplificationOptions options)
+        {
+            switch (options)
+            {
+                case AnimationInputSettings.CurveSimplificationOptions.Lossy:
+                    return DefaultCurveFilterOptions;
+                case AnimationInputSettings.CurveSimplificationOptions.Lossless:
+                    return RegularCurveFilterOptions;
+                case AnimationInputSettings.CurveSimplificationOptions.Disabled:
+                    return NoCurveFilterOptions;
+                default:
+                    throw new NotImplementedException();
             }
         }
 


### PR DESCRIPTION
Fix an error when recording from a recorder track (end recording is called twice, need to check if the recording has already ended to not try to export twice).

Also fix the animation compression setting not being used.