### PR TITLE
FbxExporter.cs Improvements

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -1,4 +1,3 @@
-
 using System.IO;
 using System.Collections.Generic;
 using UnityEngine;
@@ -1039,7 +1038,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return false;
             }
 
-            
             if (!unityGo.TryGetComponent<SkinnedMeshRenderer>(out var unitySkin))
             {
                 return false;
@@ -1632,7 +1630,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 return false;
             }
 
-            
             if (!unityGo.TryGetComponent<Light>(out var unityLight))
                 return false;
 
@@ -2088,7 +2085,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     var fbxTime = FbxTime.FromSecondDouble(uniKeyFrame.time);
 
                     int fbxKeyIndex = fbxAnimCurve.KeyAdd(fbxTime);
-
 
                     // configure tangents
                     var lTangent = AnimationUtility.GetKeyLeftTangentMode(uniAnimCurve, keyIndex);
@@ -3778,7 +3774,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             {
                 return meshFilter.mesh.bounds;
             }
-           
+
             if (t.TryGetComponent<Collider>(out Collider collider))
             {
                 return collider.bounds;

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -771,10 +771,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // We'll export either Phong or Lambert. Phong if it calls
             // itself specular, Lambert otherwise.
-            System.StringComparison strignComparison = System.StringComparison.OrdinalIgnoreCase;
+            System.StringComparison stringComparison = System.StringComparison.OrdinalIgnoreCase;
             var shader = unityMaterial.shader;
-            bool specular = shader.name.IndexOf("specular", strignComparison) >= 0;
-            bool hdrp = shader.name.IndexOf("hdrp", strignComparison) >= 0;
+            bool specular = shader.name.IndexOf("specular", stringComparison) >= 0;
+            bool hdrp = shader.name.IndexOf("hdrp", stringComparison) >= 0;
 
             var fbxMaterial = specular
                 ? FbxSurfacePhong.Create(fbxScene, fbxName)

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -772,9 +772,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
             // We'll export either Phong or Lambert. Phong if it calls
             // itself specular, Lambert otherwise.
+            System.StringComparison strignComparison = System.StringComparison.OrdinalIgnoreCase;
             var shader = unityMaterial.shader;
-            bool specular = shader.name.Contains("specular", System.StringComparison.OrdinalIgnoreCase);
-            bool hdrp = shader.name.Contains("hdrp", System.StringComparison.OrdinalIgnoreCase);
+            bool specular = shader.name.IndexOf("specular", strignComparison) >= 0;
+            bool hdrp = shader.name.IndexOf("hdrp", strignComparison) >= 0;
 
             var fbxMaterial = specular
                 ? FbxSurfacePhong.Create(fbxScene, fbxName)
@@ -3423,7 +3424,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             var completeExpSet = new HashSet<GameObject>();
             foreach (var data in hierarchyToExportData.Values)
             {
-                if (data == null || data.Objects == null || data.Objects.Count <= 0)
+                if (data == null || data.Objects == null || data.Objects.Count == 0)
                 {
                     continue;
                 }
@@ -3581,9 +3582,10 @@ namespace UnityEditor.Formats.Fbx.Exporter
                 if (controller)
                 {
                     var dController = controller as UnityEditor.Animations.AnimatorController;
-                    if (dController && dController.layers.Length > 0)
+                    var controllerLayers = dController != null ? dController.layers : null;
+                    if (controllerLayers != null && controllerLayers.Length > 0)
                     {
-                        var motion = dController.layers[0].stateMachine.defaultState.motion;
+                        var motion = controllerLayers[0].stateMachine.defaultState.motion;
                         var defaultClip = motion as AnimationClip;
                         if (defaultClip)
                         {


### PR DESCRIPTION
New PR to fix issues with following PR: https://github.com/Unity-Technologies/com.unity.formats.fbx/pull/652

Contents:
Use count and length properties instead of LINQ call.
Array/List can not be under 0, so array size will be checked as == 0 instead of <= 0.
Use TryGetComponent to reduce memory allocation when no component is found.
GetComponent Mesh will always return null. Get MeshFilter.mesh instead.
Simplify string comparison using IndexOf, which does not create garbage.
Cache animation controller layers to avoid an extra internal call