### PR TITLE
Fix CI failures on Ubuntu for release/4.2 branch by using ubuntu:stab…

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,7 +68,7 @@ platforms:
     flavor: b1.medium
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:prev-stable
+    image: package-ci/ubuntu:stable
     flavor: b1.medium
 coverage:
     minPercent: 57.5


### PR DESCRIPTION
**Purpose of this PR:**
**This is an integration PR of pull/658 for release/4.2 branch.**
In order to fix CI failures because of upm-ci update to 1.28.0, specifically this change: Deprecated downloading unity-downloader-cli on the fly and making it a hard dependency.
Image ubuntu:prev-stable has no unity-downloader-cli pre-installed, but ubuntu:stable has.
By updating Ubuntu image to ubuntu:stable, it will resolve the "unity-downloader-cli" not being installed issue, unless there are specific reasons that we have to stick with ubuntu:prev-stable.

JIRA ticket:
[FBX-333](https://jira.unity3d.com/browse/FBX-333): CI jobs fail for FBX on Linux platform because of upm-ci update.