### PR TITLE
JIRA FBX-338: Add API docs validation to CI

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -92,6 +92,8 @@ api_doc_validation:
     type: Unity::VM
     image: package-ci/ubuntu:stable
     flavor: b1.medium
+  variables:
+    UPM_REGISTRY: https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-candidates
   commands:
     # Needed for now, until we get a recent upm-pvp into the image.
     - sudo apt-get update && sudo apt-get install -y upm-pvp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -84,6 +84,33 @@ pack:
      paths:
        - "upm-ci~/**/*"
 
+# The following job runs PVP API docs validation to validate all public APIs (classes and methods) have documentation.
+# For APIs which are exempted from API docs validartion, they are put in pvp_exemptions.json
+api_doc_validation:
+  name: API documentation validation
+  agent:
+    type: Unity::VM
+    image: package-ci/ubuntu:stable
+    flavor: b1.medium
+  commands:
+    # Needed for now, until we get a recent upm-pvp into the image.
+    - sudo apt-get update && sudo apt-get install -y upm-pvp
+    # Download Unity.
+    - unity-downloader-cli --fast --wait -u {{ all_test_editors[0].version }} -c editor
+    # Run PVS in PVP mode.
+    - upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results "upm-ci~/pvp"
+    # Require that PVP-20-1 (API docs validation) passed
+    - upm-pvp require PVP-20-1 --results "upm-ci~/pvp" --failures "upm-ci~/pvp/failures.json"
+  artifacts:
+    pvp:
+      paths:
+        - upm-ci~/pvp/**
+    logs:
+      paths:
+        - upm-ci~/test-results/**
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+
 
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
@@ -140,6 +167,7 @@ test_trigger:
         - master
   dependencies:
     - .yamato/upm-ci.yml#pack
+    - .yamato/upm-ci.yml#api_doc_validation
 {% for editor in test_trigger_editors %}
 {% for platform in platforms %}
     - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
@@ -156,6 +184,7 @@ test_trigger:
         rerun: always
   dependencies:
     - .yamato/upm-ci.yml#pack
+    - .yamato/upm-ci.yml#api_doc_validation
       {% for editor in {{release.nightly_editors}} %}
       {% for platform in platforms %}
     - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}


### PR DESCRIPTION
## Purpose of PR:
This is to add API docs validation test to FBX's CI.

**JIRA Ticket:**
[FBX-338](https://jira.unity3d.com/browse/FBX-338) CI: Add Package Validation Profiles (PVP)'s API docs validation test to FBX package