### PR TITLE
Use array length instead of vertexCount

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -4073,7 +4073,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// Gets the vertex count.
             /// </summary>
             /// <value>The vertex count.</value>
-            public int VertexCount { get { return mesh.vertexCount; } }
+            public int VertexCount { get { return m_vertices.Length; } }
 
             /// <summary>
             /// Gets the triangles. Each triangle is represented as 3 indices from the vertices array.

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -4073,7 +4073,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             /// Gets the vertex count.
             /// </summary>
             /// <value>The vertex count.</value>
-            public int VertexCount { get { return m_vertices.Length; } }
+            public int VertexCount { get { return Vertices.Length; } }
 
             /// <summary>
             /// Gets the triangles. Each triangle is represented as 3 indices from the vertices array.


### PR DESCRIPTION
Seeing some cases where vertexCount != vertices.Length