### PR TITLE
FBX-377 make sure GetFbxBlendshapeProperty only happens for blendshapes

### DIFF
--- a/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
+++ b/com.unity.formats.fbx/Editor/FbxPropertyChannelPair.cs
@@ -1,4 +1,4 @@
-﻿using Autodesk.Fbx;
+using Autodesk.Fbx;
 using System.Collections.Generic;
 
 namespace UnityEditor.Formats.Fbx.Exporter
@@ -292,7 +292,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
                         // check if it's a constraint source property
                         fbxProperty = GetFbxConstraintSourceProperty(uniPropChannelPair.property, constraint, propertyChannelMap.MapUnityPropToFbxProp);
                     }
-                    else
+                    else if (propertyChannelMap.MapUnityPropToFbxProp == MapBlendshapesPropToFbxProp)
                     {
                         // check if it's a blendshape property
                         fbxProperty = GetFbxBlendshapeProperty(uniPropChannelPair.property, propertyChannelMap.MapUnityPropToFbxProp);


### PR DESCRIPTION
if the other attempts to get the property would fail it would try to regex regular properties like LocalPosition with this function.