### PR TITLE
Remove trunk from nightly testing for 4.2

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -40,7 +40,6 @@ nightly_tested_releases:
       - version: 2020.3
       - version: 2021.3
       - version: 2022.2
-      - version: trunk
   - name: release_4_1
     branch: release/4.1
     nightly_editors: 


### PR DESCRIPTION
4.2 is no longer the latest version and it is taking the newer 5.0.0-pre.1 com.autodesk.fbx package instead of 4.2.1.