### PR TITLE
Revert "FBX 382 export focus distance"

### DIFF
--- a/com.unity.formats.fbx/Editor/CameraVisitor.cs
+++ b/com.unity.formats.fbx/Editor/CameraVisitor.cs
@@ -127,11 +127,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
                 // FarPlane
                 fbxCamera.SetFarPlane((float)unityCamera.farClipPlane.Meters().ToCentimeters());
-
-#if UNITY_2022_2_OR_NEWER
-                fbxCamera.UseDepthOfField.Set(true);
-                fbxCamera.FocusDistance.Set(unityCamera.focusDistance.Meters().ToCentimeters());
-#endif
                 return;
             }
         }

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxCameraTests.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxCameraTests.cs
@@ -92,10 +92,6 @@ namespace FbxExporter.UnitTests
             origCam.nearClipPlane = 30f.Centimeters().ToMeters();
             origCam.farClipPlane = 600000f.Centimeters().ToMeters();
 
-#if UNITY_2022_2_OR_NEWER
-            origCam.focusDistance = 500f.Centimeters().ToMeters();
-#endif
-
             // Convert it to FBX. The asset file will be deleted automatically
             // on termination.
             var fbxAsset = ModelExporter.ExportObject(
@@ -114,9 +110,6 @@ namespace FbxExporter.UnitTests
             Assert.That(srcCam.lensShift.y, Is.EqualTo(origCam.lensShift.y).Within(EPSILON));
             Assert.That(srcCam.nearClipPlane, Is.EqualTo(origCam.nearClipPlane));
             Assert.That(srcCam.farClipPlane, Is.EqualTo(origCam.farClipPlane));
-#if UNITY_2022_2_OR_NEWER
-            Assert.That(srcCam.focusDistance, Is.EqualTo(origCam.focusDistance));
-#endif
         }
     }
 }


### PR DESCRIPTION
This reverts commit 3ea2afb4801338ea3a5dff78b4047b763aed6a7f.

Reverting this change as it breaks the automated tests as this change is partially on com.autodesk.fbx repo, which would need to be republished for the tests here to find it.