### PR TITLE
FBX-451 Enable APV clean console test in FBX packages

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -59,19 +59,19 @@ nightly_tested_releases:
 win_platform: &win
   name: win
   type: Unity::VM
-  image: package-ci/win10:stable
+  image: package-ci/win10:v4
   flavor: b1.medium
 
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/mac:stable
+  image: package-ci/macos-12:v4
   flavor: b1.medium
 
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu:stable
+  image: package-ci/ubuntu18.04:v4
   flavor: b1.medium
 
   

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -71,7 +71,7 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu18.04:v4
+  image: package-ci/ubuntu-18.04:v4
   flavor: b1.medium
 
   

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -54,6 +54,8 @@ test_{{ platform.name }}_{{ editor.version }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
@@ -76,6 +78,8 @@ validate_{{ platform.name }}_{{ editor.version }}:
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test --unity-version {{ editor.version }} --type vetting-tests --platform editmode --package-path com.unity.formats.fbx

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -8,6 +8,7 @@ pack:
     image: {{ ubuntu_platform.image }}
     flavor: {{ ubuntu_platform.flavor }}
   commands:
+    - sudo apt-get -y install cmake
     - ./build.sh
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path com.unity.formats.fbx

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+## Any subsequent(*) commands which fail will cause the shell script to exit immediately
+set -e
+
 if [[ -e build ]]; then
     rm -rf build
 fi


### PR DESCRIPTION
## Purpose of this PR:
Enable APV clean console test in FBX packages

**JIRA tickets:**
[FBX-451](https://jira.unity3d.com/browse/FBX-451): Enable APV clean console test in FBX packages

**List of changes:**
- Enable APV clean console test for package test
- Update deprecated bokken images with new ones
- Install cmake on new Ubuntu18.04 image, new image doesn't have cmake preinstalled
- Add `set -e` to build.sh so that the build script will fail immediately if any build command fails. Otherwise build.sh just fails silently and pack job will give false positive, then all CI jobs fail. This problem has bited people several times.

**Notes to reviewers:**
You can see there are instabilities in trunk tests on Mac and Win, that's because of `'Object.FindObjectsOfType<T>()' is obsolete: 'Object.FindObjectsOfType has been deprecated` which is the reason of this PR: **to catch logs in console**.