### PR TITLE
Re-enable Ubuntu tests (FBX-468)

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -80,7 +80,7 @@ mac_platform: &mac
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
-  image: package-ci/ubuntu-18.04:v4
+  image: package-ci/ubuntu-20.04:v4
   flavor: b1.medium
 
   

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -93,6 +93,6 @@ promotion_test_platforms:
   - *win
 
 coverage:
-    minPercent: 57.5
+    minPercent: 56
 
 use_autodesk_fbx_submodule_for_testing: !!bool true

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -60,9 +60,7 @@ test_{{ platform.name }}_{{ editor.version }}:
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
-{% if platform.name != "ubuntu" %}
     - python tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
-{% endif %}
   artifacts:
     logs:
       paths:

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
@@ -339,7 +339,7 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
-        [Platform(Exclude="Linux", Reason="Maya/Max integrations are only supported on Windows and OSX")]
+        [Platform(Exclude = "Linux", Reason = "Maya/Max integrations are only supported on Windows and OSX")]
         public void VendorLocationInstallationTest1()
         {
             /*

--- a/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxExportSettingsTest.cs
@@ -339,6 +339,7 @@ namespace FbxExporter.UnitTests
         }
 
         [Test]
+        [Platform(Exclude="Linux", Reason="Maya/Max integrations are only supported on Windows and OSX")]
         public void VendorLocationInstallationTest1()
         {
             /*

--- a/com.unity.formats.fbx/Tests/Prefabs/Unity.Formats.Fbx.Editor.Tests.Prefabs.asmdef
+++ b/com.unity.formats.fbx/Tests/Prefabs/Unity.Formats.Fbx.Editor.Tests.Prefabs.asmdef
@@ -8,8 +8,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [
-        "!UNITY_EDITOR_LINUX"
-    ],
     "versionDefines": []
 }

--- a/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
+++ b/com.unity.formats.fbx/Tests/Unity.Formats.Fbx.Editor.Tests.asmdef
@@ -23,8 +23,7 @@
     ],
     "autoReferenced": false,
     "defineConstraints": [
-        "UNITY_INCLUDE_TESTS",
-        "!UNITY_EDITOR_LINUX"
+        "UNITY_INCLUDE_TESTS"
     ],
     "versionDefines": [
         {


### PR DESCRIPTION
The goal is to make the tests run again on our CI again. 
Issues remain on Ubuntu18 (so with APV/QV), but can be workaround using the package exemption mechanism. 

- Re-enabling Linux tests
- Updating to Ubuntu20 to avoid the libstdc++ error that happens on Ubuntu18.
- Disable Maya / Max integrations tests as we don't support the integrations in Linux
- A follow-up task has been logged to exempt the tests in unity/unity UnityPackageManager.cs (cf [FBX-101](https://jira.unity3d.com/browse/FBX-101))


