### PR TITLE
FBX-477 Add clean console test to FBX packages

### DIFF
--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -11,11 +11,28 @@ clean_console_test_{{ platform.name }}_{{ editor.version }}:
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:
+{% if platform.name contains "win" -%}
+    - build.cmd
+{% elsif platform.name contains "mac" -%}
+    - cmake --version || brew install cmake
+    - ./build.sh
+{% else %}
+    - ./build.sh
+{% endif %}
     - brick_source: git@github.cds.internal.unity3d.com:wind-xu/clean_console_test_brick.git@v0.1.0
       variables:
         CLEAN_CONSOLE_TEST_FOR: package
         PACKAGE_PATH: ./com.unity.formats.fbx
         EDITOR_VERSION: {{ editor.version }}
         WARNINGS_AS_ERRORS: false
+{% endfor %}
+{% endfor %}
+
+clean_console_test_trigger:
+  name: Clean console test trigger
+  dependencies:
+{% for platform in platforms %}
+{% for editor in clean_console_test_editors %}
+    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor }}
 {% endfor %}
 {% endfor %}

--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -33,6 +33,6 @@ clean_console_test_trigger:
   dependencies:
 {% for platform in platforms %}
 {% for editor in clean_console_test_editors %}
-    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor }}
+    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor.version }}
 {% endfor %}
 {% endfor %}

--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -17,3 +17,5 @@ clean_console_test_{{ platform.name }}_{{ editor.version }}:
         PACKAGE_PATH: ./com.unity.formats.fbx
         EDITOR_VERSION: {{ editor.version }}
         WARNINGS_AS_ERRORS: false
+{% endfor %}
+{% endfor %}

--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -1,0 +1,19 @@
+{% metadata_file .yamato/global.metafile %}
+---
+
+{% for platform in platforms %}
+{% for editor in clean_console_test_editors %}
+# Clean console test jobs
+clean_console_test_{{ platform.name }}_{{ editor.version }}:
+  name: Clean console test in {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  commands:
+    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/clean_console_test_brick.git@v0.1.0
+      variables:
+        CLEAN_CONSOLE_TEST_FOR: package
+        PACKAGE_PATH: ./com.unity.formats.fbx
+        EDITOR_VERSION: {{ editor.version }}
+        WARNINGS_AS_ERRORS: false

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -32,6 +32,11 @@ publish_trigger_editors:
   - version: 2023.1
   - version: trunk
 
+clean_console_test_editors:
+  - version: 2022.2
+  - version: 2023.1
+  - version: trunk
+
 promotion_test_editors:
   - version: 2020.3
   

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -135,7 +135,7 @@ test_trigger:
 {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
 {% else %}
-    - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -143,7 +143,7 @@ test_trigger:
 {% for platform in platforms %}
 {% for editor in clean_console_test_editors %}
 {% if platform.name == "win" %}
-    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor }}
+    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor.version }}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -140,12 +140,8 @@ test_trigger:
 {% endfor %}
 {% endfor %}
 # Only run clean console tests on Win for PR trigger
-{% for platform in platforms %}
 {% for editor in clean_console_test_editors %}
-{% if platform.name == "win" %}
-    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor.version }}
-{% endif %}
-{% endfor %}
+    - .yamato/clean-console-test.yml#clean_console_test_win_{{ editor.version }}
 {% endfor %}
 
 {% for release in nightly_tested_releases %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -139,6 +139,14 @@ test_trigger:
 {% endif %}
 {% endfor %}
 {% endfor %}
+# Only run clean console tests on Win for PR trigger
+{% for platform in platforms %}
+{% for editor in clean_console_test_editors %}
+{% if platform.name == "win" %}
+    - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor }}
+{% endif %}
+{% endfor %}
+{% endfor %}
 
 {% for release in nightly_tested_releases %}
 {{release.name}}_nightly_test_trigger:
@@ -151,6 +159,7 @@ test_trigger:
   dependencies:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation
+    - .yamato/clean-console-test.yml#clean_console_test_trigger
 {% for editor in {{release.nightly_editors}} %}
 {% for platform in platforms %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -353,7 +353,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             InitializeReceiver();
             Receiver.SetTarget(target);
             Receiver.SetInitialValue(new Preset(target));
-#pragma warning disable CS0618 // Suppress the warning about obsolete API "PresetSelector.ShowSelector"
+#pragma warning disable CS0618 // Suppress the warning about obsolete API "PresetSelector.ShowSelector" FBX-452
             UnityEditor.Presets.PresetSelector.ShowSelector(target, null, true, Receiver);
 #pragma warning restore CS0618 // Restore the warning
         }

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -353,7 +353,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
             InitializeReceiver();
             Receiver.SetTarget(target);
             Receiver.SetInitialValue(new Preset(target));
+#pragma warning disable CS0618 // Suppress the warning about obsolete API "PresetSelector.ShowSelector"
             UnityEditor.Presets.PresetSelector.ShowSelector(target, null, true, Receiver);
+#pragma warning restore CS0618 // Restore the warning
         }
 
         #endif

--- a/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
@@ -6,7 +6,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal delegate void SelectionChangedDelegate();
     internal delegate void DialogClosedDelegate();
 
-#pragma warning disable CS0618 // Suppress the warning about obsolete class "PresetSelectorReceiver"
+#pragma warning disable CS0618 // Suppress the warning about obsolete class "PresetSelectorReceiver" FBX-452
     internal class FbxExportPresetSelectorReceiver : PresetSelectorReceiver
 #pragma warning restore CS0618 // Restore the warning
     {

--- a/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
@@ -6,7 +6,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal delegate void SelectionChangedDelegate();
     internal delegate void DialogClosedDelegate();
 
+#pragma warning disable CS0618 // Suppress the warning about obsolete class "PresetSelectorReceiver"
     internal class FbxExportPresetSelectorReceiver : PresetSelectorReceiver
+#pragma warning restore CS0618 // Restore the warning
     {
         UnityEngine.Object m_Target;
         Preset m_InitialValue;


### PR DESCRIPTION
## Purpose of this PR:
Add clean console tests to FBX packages.
In PR trigger, clean console tests only run on Windows.
In nightly trigger, clean console tests run on all platforms.

In this PR, I also temporarily disabled the obsolete warnings about class `PresetSelectorReceiver` and `PresetSelector.ShowSelector` which are tracked as FBX452.

**JIRA ticket:**
[FBX-477](https://jira.unity3d.com/browse/FBX-477) Add clean console test to FBX packages

