### PR TITLE
FBX-479: Pin mac image to v4.19.0 so that build job can pass on Mac

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -68,7 +68,7 @@ win_platform: &win
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
-  image: package-ci/macos-12:v4
+  image: package-ci/macos-12:v4.19.0
   flavor: b1.medium
 
 ubuntu_platform: &ubuntu

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -68,6 +68,7 @@ win_platform: &win
 mac_platform: &mac
   name: mac
   type: Unity::VM::osx
+  #Pin Mac image to v4.19.0 because of https://jira.unity3d.com/browse/FBX-479
   image: package-ci/macos-12:v4.19.0
   flavor: b1.medium
 


### PR DESCRIPTION
## Purpose of this PR:
`Build on Mac` job fails for `com.autodesk.fbx` package because of macos-12 image update from `v4.19.0` to `v.4.20.0`.
Because `com.unity.formats.fbx` package runs CI using `com.autodesk.fbx` repo, so a fix is also needed here.

**JIRA ticket:**
[FBX-479](https://jira.unity3d.com/browse/FBX-479) CI: Fix build job failures on Mac