### PR TITLE
FBX-369 CI: Change FBX's test_trigger to a PR trigger and add publish dryrun job

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -19,8 +19,9 @@ all_test_editors:
   - version: trunk
 
 clean_console_test_editors:
-  - version: 2022.2
+  - version: 2022.3
   - version: 2023.1
+  - version: 2023.2
   - version: trunk
 
 promotion_test_editors:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -13,23 +13,9 @@
 all_test_editors:
   - version: 2020.3
   - version: 2021.3
-  - version: 2022.1
-  - version: 2022.2
+  - version: 2022.3
   - version: 2023.1
-  - version: trunk
-
-test_trigger_editors:
-  - version: 2020.3
-  - version: 2021.3
-  - version: 2022.1
-  - version: 2023.1
-  - version: trunk
-
-publish_trigger_editors:
-  - version: 2020.3
-  - version: 2021.3
-  - version: 2022.1
-  - version: 2023.1
+  - version: 2023.2
   - version: trunk
 
 clean_console_test_editors:
@@ -60,8 +46,9 @@ nightly_tested_releases:
     nightly_editors: 
       - version: 2020.3
       - version: 2021.3
-      - version: 2022.2
+      - version: 2022.3
       - version: 2023.1
+      - version: 2023.2
       - version: trunk
 
 win_platform: &win

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -115,19 +115,16 @@ test_api_win:
       paths:
       - "upm-ci~/test-results/**/*"
 
-test_trigger:
-  name: Tests Trigger
+test_trigger_pr:
+  name: Pull Request Tests Trigger
   triggers:
-    branches:
-      only:
-        - "/.*/"
-      except:
-        - master
+    cancel_old_ci: true
+    expression: pull_request.(source match ".*" AND NOT draft)
   dependencies:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation
     - .yamato/upm-ci.yml#test_api_win
-{% for editor in test_trigger_editors %}
+{% for editor in all_test_editors %}
 {% for platform in platforms %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
 {% if use_autodesk_fbx_submodule_for_testing %}
@@ -160,7 +157,7 @@ test_trigger:
 {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
 {% else %}
-    - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -174,10 +171,10 @@ publish_test_trigger:
         - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?
   dependencies:
     - .yamato/upm-ci.yml#pack
-{% for editor in publish_trigger_editors %}
+{% for editor in all_test_editors %}
 {% for platform in platforms %}
-    - .yamato/upm-ci.yml#test_{{platform.name}}_{{editor.version}}
-    - .yamato/upm-ci.yml#validate_{{platform.name}}_{{editor.version}}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#validate_{{ platform.name }}_{{ editor.version }}
 {% endfor %}
 {% endfor %}  
       
@@ -203,5 +200,27 @@ publish:
         - "upm-ci~/packages/*.tgz"
   dependencies:
     - .yamato/upm-ci.yml#pack
-    - .yamato/upm-ci.yml#test_trigger
+    - .yamato/upm-ci.yml#publish_test_trigger
+
+publish_dry_run:
+  name: Publish to Internal Registry (Dry Run)
+  agent:
+    type: {{ win_platform.type }}
+    image: {{ win_platform.image }}
+    flavor: {{ win_platform.flavor }}
+  variables:
+    UPMCI_ENABLE_PACKAGE_SIGNING: 1
+  commands:
+    - npm install upm-ci-utils@latest -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    - upm-ci package publish --package-path com.unity.formats.fbx --dry-run
+  triggers:
+    tags:
+      only:
+        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#publish_test_trigger


### PR DESCRIPTION
## Purpose of this PR:
- Add a `publish dry-run` job 
- Change test_trigger to a PR trigger which only runs when a PR is created. Currently it runs with every push in any branch which is annoying
- Add 2022.3 and 2023.2 to CI

**JIRA ticket:**
[FBX-369](https://jira.unity3d.com/browse/FBX-369) CI: Change FBX's test_trigger to a PR trigger and add publish dryrun job

**Note:** This PR is mainly for adding publish dry run job (for the release) together with some minor changes and cleanup.
A refactoring of the CI is needed and will be done in a separate task.