### PR TITLE
CI: FBX-132 Add silicon Mac to FBX exporter CI

### DIFF
--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -8,6 +8,9 @@ clean_console_test_{{ platform.name }}_{{ editor.version }}:
   name: Clean console test in {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
+{% if platform.model %}
+    model: {{ platform.model }}
+{% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -65,6 +65,13 @@ mac_platform: &mac
   image: package-ci/macos-12:v4.19.0
   flavor: b1.medium
 
+mac_arm64_platform: &mac_arm64
+  name: mac_arm64
+  type: Unity::VM::osx
+  model: M1
+  image: package-ci/macos-13-arm64:v4
+  flavor: m1.mac
+
 ubuntu_platform: &ubuntu
   name: ubuntu
   type: Unity::VM
@@ -75,6 +82,7 @@ ubuntu_platform: &ubuntu
 platforms:
   - *win
   - *mac
+  - *mac_arm64
   - *ubuntu
 
 promotion_test_platforms:

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -1,5 +1,4 @@
 {% metadata_file .yamato/global.metafile %}
-artifactory_url: "https://artifactory.prd.cds.internal.unity3d.com/artifactory"
 npm_registry: "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-candidates"
 
 ---
@@ -17,43 +16,31 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     flavor: {{ platform.flavor}}
   commands:
 {% if platform.name contains "win" -%}
-# Copy CHANGELOG.md into com.unity.formats.fbx package. Currently it is outside the package folder under repo root.
+# Run build script to copy CHANGELOG.md into com.unity.formats.fbx package. Currently it is outside the package folder under repo root.
     - build.cmd
-    - gsudo choco source add --priority 1 -n Unity -s {{ artifactory_url }}/api/nuget/unity-choco-local
-    - gsudo choco install unity-config -y
-    - curl -s {{ artifactory_url }}/unity-tools-local/utr-standalone/utr.bat --output utr.bat
 {% elsif platform.name contains "mac" -%}
     - cmake --version || brew install cmake
     - ./build.sh
-    - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git
-    - brew install unity-config
-    - curl -s {{ artifactory_url }}/unity-tools-local/utr-standalone/utr --output ./utr
-    - chmod +x ./utr
 {% else %}
 # FBX sdk is built on Ubuntu 18. Because of that, FBX exporter tests also have to run on Ubuntu 18, but with gcc9 and g++9 installed.
 # Otherwise, tests will fail to run on Ubuntu 18.
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -y install gcc-9 g++-9
     - ./build.sh
-    - curl -L {{ artifactory_url }}/api/gpg/key/public | sudo apt-key add -
-    - sudo sh -c "echo 'deb {{ artifactory_url }}/unity-apt-local bionic main' > /etc/apt/sources.list.d/unity.list"
-    - sudo apt update
-    - sudo apt install unity-config
-    - curl -s {{ artifactory_url }}/unity-tools-local/utr-standalone/utr --output ./utr
-    - chmod +x ./utr
 {% endif -%}
     - unity-config project create TestProjects/TestProjectUsingAutodeskFbxSubmodule
     - unity-config project add testable com.unity.formats.fbx
     - unity-config project add dependency com.unity.formats.fbx@file:../../../com.unity.formats.fbx
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
-    - unity-downloader-cli -u {{ editor.version }} --path .Editor -c Editor --wait --published-only
+{% if platform.model == "M1" %}
+# Download Silicon Unity Editor if on Silicon Mac
+    - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
+{% else %}
+    - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
+{% endif %}
     - >
-{%- if platform.name == "win" -%}
-      utr.bat
-{%- else -%}
-      ./utr
-{%- endif -%}
+      UnifiedTestRunner
       --testproject=TestProjects/TestProjectUsingAutodeskFbxSubmodule
       --editor-location=.Editor
       --suite=editor --suite=playmode

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -33,8 +33,8 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.unity.formats.fbx@file:../../../com.unity.formats.fbx
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
-# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac
-{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2020.3" %}
+# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac. On other platforms, always download x64 Editor version.
+{% if platform.model != "M1" or editor.version == "2020.3" %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
 {% else %}
 # Download Silicon Unity Editor (arm64) if on Silicon Mac, but only for version 2021.3 and above.

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -33,11 +33,11 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.unity.formats.fbx@file:../../../com.unity.formats.fbx
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
-# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac. On other platforms, always download x64 Editor version.
+# Editor 2020.3 doesn't have arm64 version. So when the platform is not a Silicon Mac or editor version is 2020.3, download x64 version which is the default of unity-downloader-cli for testing.
 {% if platform.model != "M1" or editor.version == "2020.3" %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
 {% else %}
-# Download Silicon Unity Editor (arm64) if on Silicon Mac, but only for version 2021.3 and above.
+# Download arm64 editor when on Silicon Mac, but only for version 2021.3 and above.
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
 {% endif %}
     - >

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -33,11 +33,12 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.unity.formats.fbx@file:../../../com.unity.formats.fbx
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
-{% if platform.model == "M1" %}
-# Download Silicon Unity Editor if on Silicon Mac
-    - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
-{% else %}
+# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac
+{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2020.3" %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
+{% else %}
+# Download Silicon Unity Editor (arm64) if on Silicon Mac, but only for version 2021.3 and above.
+    - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
 {% endif %}
     - >
       UnifiedTestRunner
@@ -47,5 +48,9 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
       --artifacts_path=TestResults
   dependencies:
     - .yamato/pack-autodesk-fbx.yml#pack_autodesk_fbx
+  artifacts:
+    TestResults:
+      paths:
+        - "TestResults/**/*"
 {% endfor %}
 {% endfor %}

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -10,6 +10,9 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
   name : Test version {{ editor.version }} on {{ platform.name }} using autodesk.fbx submodule
   agent:
     type: {{ platform.type }}
+{% if platform.model %}
+    model: {{ platform.model }}
+{% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   commands:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,8 +68,8 @@ test_{{ platform.name }}_{{ editor.version }}:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -y install gcc-9 g++-9
 {% endif %}
-# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac
-{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2020.3" %}
+# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac. On other platforms, download x64 version Editor.
+{% if platform.model != "M1" or editor.version == "2020.3" %}
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% else %}
 # Download Silicon Unity Editor if on Silicon Mac, but only for version 2021.3 and above.
@@ -145,8 +145,8 @@ test_trigger_pr:
     - .yamato/upm-ci.yml#test_api_win
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
-# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests anyway.
-{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2023.2" or editor.version == "trunk" %}
+# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
+{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
   {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
@@ -175,8 +175,8 @@ test_trigger_pr:
     - .yamato/clean-console-test.yml#clean_console_test_trigger
 {% for editor in {{release.nightly_editors}} %}
 {% for platform in platforms %}
-# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests anyway.
-{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2023.2" or editor.version == "trunk" %}
+# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
+{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
   {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,11 +68,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -y install gcc-9 g++-9
 {% endif %}
-# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac. On other platforms, download x64 version Editor.
+# upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac which is a known bug.
+# 2020.3 doesn't support Silicon Editor which means we always need x64 version Editor for 2020.3.
+# So when the platform is non-Silicon Mac, or it is a 2020.3 Editor, we just call upm-ci to run tests which will download x64 version Editor.
 {% if platform.model != "M1" or editor.version == "2020.3" %}
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% else %}
-# Download Silicon Unity Editor if on Silicon Mac, but only for version 2021.3 and above.
+# Explicitly download arm64 Editor if on Silicon Mac, but only for version 2021.3 and above.
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version .Editor --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% endif %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,12 +68,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -y install gcc-9 g++-9
 {% endif %}
-# Download Silicon Unity Editor if on Silicon Mac 
-{% if platform.model == "M1" %}
+# Editor 2020.3 doesn't support Silicon Mac, so still download x64 version of 2020.3 even on M1 Mac
+{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2020.3" %}
+    - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
+{% else %}
+# Download Silicon Unity Editor if on Silicon Mac, but only for version 2021.3 and above.
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version .Editor --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
-{% else %}
-    - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% endif %}
     - python tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
   artifacts:
@@ -144,11 +145,14 @@ test_trigger_pr:
     - .yamato/upm-ci.yml#test_api_win
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
+# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests anyway.
+{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2023.2" or editor.version == "trunk" %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-{% if use_autodesk_fbx_submodule_for_testing %}
+  {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-{% else %}
+  {% else %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}
@@ -171,11 +175,14 @@ test_trigger_pr:
     - .yamato/clean-console-test.yml#clean_console_test_trigger
 {% for editor in {{release.nightly_editors}} %}
 {% for platform in platforms %}
+# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests anyway.
+{% if platform.model != "M1" or platform.model == "M1" and editor.version == "2023.2" or editor.version == "trunk" %}
 # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-{% if use_autodesk_fbx_submodule_for_testing %}
+  {% if use_autodesk_fbx_submodule_for_testing %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-{% else %}
+  {% else %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -53,6 +53,9 @@ test_{{ platform.name }}_{{ editor.version }}:
   name : Test version {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
+{% if platform.model %}
+    model: {{ platform.model }}
+{% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   variables:
@@ -81,6 +84,9 @@ validate_{{ platform.name }}_{{ editor.version }}:
   name : Validate version {{ editor.version }} on {{ platform.name }}
   agent:
     type: {{ platform.type }}
+{% if platform.model %}
+    model: {{ platform.model }}
+{% endif %}
     image: {{ platform.image }}
     flavor: {{ platform.flavor}}
   variables:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,7 +68,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     - sudo apt-get -y install gcc-9 g++-9
 {% endif %}
+# Download Silicon Unity Editor if on Silicon Mac 
+{% if platform.model == "M1" %}
+    - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
+    - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version .Editor --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
+{% else %}
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
+{% endif %}
     - python tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
   artifacts:
     logs:


### PR DESCRIPTION
## Purpose of this PR:
-  Add Silicon Mac to FBX exporter's CI.
- Only run tests in 2023.2 and trunk on Silicon Mac because of known issues in older Editor versions caused by .NET.
- In this PR, I also removed some unless codes related to download UTR because `UnifiedTestRunner` is pre-installed on package-ci bokken images now.

**JIRA ticket:**
[FBX-132](https://jira.unity3d.com/browse/FBX-132) Run automated tests on Apple Silicon machine