### PR TITLE
CI: Add documentation generation job for FBX CI and a corresponding doc change trigger.

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -59,8 +59,8 @@ generate_documentation:
         EDITOR_VERSION: {{ all_test_editors.last.version }}
         PACKAGE_NAME: com.unity.formats.fbx
         PACKAGE_PATH: com.unity.formats.fbx
-        #Treat doc build warnings as errors
-        WARNINGS_AS_ERRORS: true
+        #Set to false because some file links such as api/index.html don't exist in local Documentation folder and will cause warnings. They only exist in generated documentation. 
+        WARNINGS_AS_ERRORS: false
 
 {% for editor in all_test_editors %}
 {% for platform in platforms %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -54,6 +54,9 @@ generate_documentation:
     image: {{ mac_platform.image }}
     flavor: {{ mac_platform.flavor }}
   commands:
+# Run build script to copy CHANGELOG.md and LICENSE.md into com.unity.formats.fbx package.
+    - brew install cmake
+    - ./build.sh
     - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.0
       variables:
         EDITOR_VERSION: {{ all_test_editors.last.version }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -54,7 +54,7 @@ generate_documentation:
     image: {{ mac_platform.image }}
     flavor: {{ mac_platform.flavor }}
   commands:
-# Run build script to copy CHANGELOG.md and LICENSE.md into com.unity.formats.fbx package.
+    # Run build script to copy CHANGELOG.md and LICENSE.md into com.unity.formats.fbx package.
     - brew install cmake
     - ./build.sh
     - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.0
@@ -159,7 +159,7 @@ test_trigger_pr_documentation:
   name: Pull Request Tests Trigger for documentation changes
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(source match ".*" AND push.changes.all match "**/*.md" AND NOT draft)
+    expression: pull_request.(source match ".*" AND push.changes.any match "com.unity.formats.fbx/Documentation~/**" AND NOT draft)
   dependencies:
     - .yamato/upm-ci.yml#generate_documentation
 
@@ -167,7 +167,7 @@ test_trigger_pr:
   name: Pull Request Tests Trigger
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(source match ".*" AND NOT push.changes.all match "**/*.md" AND NOT draft)
+    expression: pull_request.(source match ".*" AND NOT push.changes.all match ["com.unity.formats.fbx/Documentation~/**", "**/*.md"] AND NOT draft)
   dependencies:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -46,6 +46,21 @@ api_doc_validation:
   dependencies:
     - .yamato/upm-ci.yml#pack
 
+# Job to generate documentation for the package
+generate_documentation:
+  name : Generate documentation
+  agent:
+    type: {{ mac_platform.type }}
+    image: {{ mac_platform.image }}
+    flavor: {{ mac_platform.flavor }}
+  commands:
+    - brick_source: git@github.cds.internal.unity3d.com:wind-xu/virtual_production_doc_generation.git@v0.3.0
+      variables:
+        EDITOR_VERSION: {{ all_test_editors.last.version }}
+        PACKAGE_NAME: com.unity.formats.fbx
+        PACKAGE_PATH: com.unity.formats.fbx
+        #Treat doc build warnings as errors
+        WARNINGS_AS_ERRORS: true
 
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
@@ -136,11 +151,20 @@ test_api_win:
       paths:
       - "upm-ci~/test-results/**/*"
 
+# PR trigger for doc only changes, it will run generate_documentation job.
+test_trigger_pr_documentation:
+  name: Pull Request Tests Trigger for documentation changes
+  triggers:
+    cancel_old_ci: true
+    expression: pull_request.(source match ".*" AND push.changes.all match "**/*.md" AND NOT draft)
+  dependencies:
+    - .yamato/upm-ci.yml#generate_documentation
+
 test_trigger_pr:
   name: Pull Request Tests Trigger
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(source match ".*" AND NOT draft)
+    expression: pull_request.(source match ".*" AND NOT push.changes.all match "**/*.md" AND NOT draft)
   dependencies:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -154,7 +154,7 @@ test_api_win:
       paths:
       - "upm-ci~/test-results/**/*"
 
-# PR trigger for doc only changes, it will run generate_documentation job.
+# PR trigger for doc only changes, it will run generate_documentation job and package vetting test in trunk on Windows.
 test_trigger_pr_documentation:
   name: Pull Request Tests Trigger for documentation changes
   triggers:
@@ -162,6 +162,7 @@ test_trigger_pr_documentation:
     expression: pull_request.(source match ".*" AND push.changes.any match "com.unity.formats.fbx/Documentation~/**" AND NOT draft)
   dependencies:
     - .yamato/upm-ci.yml#generate_documentation
+    - .yamato/upm-ci.yml#validate_win_trunk
 
 test_trigger_pr:
   name: Pull Request Tests Trigger
@@ -227,8 +228,10 @@ publish_test_trigger:
     - .yamato/upm-ci.yml#pack
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
+# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
+{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    - .yamato/upm-ci.yml#validate_{{ platform.name }}_{{ editor.version }}
+{% endif %}
 {% endfor %}
 {% endfor %}  
       


### PR DESCRIPTION
## Purpose of this PR:
Add doc generation job to FBX Exporter package and add a PR trigger for doc only changes.

**JIRA ticket:**
[FBX-496](https://jira.unity3d.com/browse/FBX-496) CI: Add documentation generation job for FBX CI and a corresponding doc change trigger.