### PR TITLE
CI: Update bokken images for release 4.1 branch

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -99,9 +99,6 @@ nightly_test_trigger:
   name: Nightly tests Trigger
   triggers:
     recurring:
-      - branch: wind/update_bokken_image_release_4.1
-        frequency: daily
-        rerun: always
       - branch: release/4.1
         frequency: daily
         rerun: always

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -99,7 +99,7 @@ nightly_test_trigger:
   name: Nightly tests Trigger
   triggers:
     recurring:
-      - branch: master
+      - branch: wind/update_bokken_image_release_4.1
         frequency: daily
         rerun: always
       - branch: release/4.1

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,19 +1,19 @@
 test_trigger_editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.2
+  - version: 2021.3
 publish_trigger_editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.2
+  - version: 2021.3
 platforms:
   - name: win
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.medium
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:v4
     flavor: b1.medium
 coverage:
     minPercent: 57.0
@@ -22,7 +22,7 @@ pack:
   name: Pack
   agent:
     type: Unity::VM
-    image: package-ci/ubuntu:stable
+    image: package-ci/ubuntu-18.04:v4
     flavor: b1.small
   commands:
     - ./build.sh
@@ -133,7 +133,7 @@ publish:
   name: Publish to Internal Registry
   agent:
     type: Unity::VM
-    image: package-ci/win10:stable
+    image: package-ci/win10:v4
     flavor: b1.small
   variables:
     UPMCI_ENABLE_PACKAGE_SIGNING: 1


### PR DESCRIPTION
## Purpose of this PR:
Update deprecated bokken images for release 4.1 branch. 
Currently release/4.1 branch is still using old bokken images such as `upm-ci/win10:stable`. Because of that we can see following errors in CI:
```
Please switch to 'package-ci/win10:v4' or another supported Bokken image (note that package-ci/*:stable is deprecated and should no longer be used).
```
Besides, I also see CI failures caused by UPM-CI because of the following error:
```
Could not use "nc", falling back to slower node.js method for sync requests.
```

Updating deprecated bokken images seems to solve the issues above.

**JIRA ticket:**
[FBX-497](https://jira.unity3d.com/browse/FBX-497) CI: Update bokken images for release/4.1