### PR TITLE
CI: Add test jobs on ARM64 Win

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,49 +14,36 @@ all_test_editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.1
   - version: 2023.2
   - version: trunk
 
 clean_console_test_editors:
   - version: 2022.3
-  - version: 2023.1
   - version: 2023.2
+  - version: trunk
+
+mac_arm64_test_editors:
+  - version: 2022.3
+  - version: trunk
+
+win_arm64_test_editors:
   - version: trunk
 
 promotion_test_editors:
   - version: 2020.3
-  
-nightly_tested_releases:
-  - name: release_4_2
-    branch: release/4.2
-    nightly_editors: 
-      - version: 2019.4
-      - version: 2020.3
-      - version: 2021.3
-      - version: 2022.2
-  - name: release_4_1
-    branch: release/4.1
-    nightly_editors: 
-      - version: 2019.4
-      - version: 2020.3
-      - version: 2021.3
-      - version: 2022.1
-  - name: master
-    branch: master
-    nightly_editors: 
-      - version: 2020.3
-      - version: 2021.3
-      - version: 2022.3
-      - version: 2023.1
-      - version: 2023.2
-      - version: trunk
 
 win_platform: &win
   name: win
   type: Unity::VM
   image: package-ci/win10:v4
   flavor: b1.medium
+
+win_arm64_platform: &win_arm64
+  name: win_arm64
+  type: Unity::VM::Azure
+  model: arm
+  image: package-ci/win11-arm64:v4
+  flavor: b1.large
 
 mac_platform: &mac
   name: mac
@@ -81,6 +68,7 @@ ubuntu_platform: &ubuntu
   
 platforms:
   - *win
+  - *win_arm64
   - *mac
   - *mac_arm64
   - *ubuntu

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -19,7 +19,6 @@ all_test_editors:
 
 clean_console_test_editors:
   - version: 2022.3
-  - version: 2023.2
   - version: trunk
 
 mac_arm64_test_editors:

--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -21,13 +21,6 @@ clean_console_test_editors:
   - version: 2022.3
   - version: trunk
 
-mac_arm64_test_editors:
-  - version: 2022.3
-  - version: trunk
-
-win_arm64_test_editors:
-  - version: trunk
-
 promotion_test_editors:
   - version: 2020.3
 

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -33,7 +33,7 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
 # Editor 2020.3 doesn't have arm64 version. So when the platform is not a Silicon Mac or editor version is 2020.3, download x64 version which is the default of unity-downloader-cli for testing.
-{% if platform.model != "M1" and platform.model != "arm" or editor.version == "2020.3" %}
+{% if editor.version == "2020.3" or platform.model != "M1" and platform.model != "arm" %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
 {% else %}
 # Download arm64 editor when on Silicon Mac, but only for version 2021.3 and above.

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -32,12 +32,11 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.unity.formats.fbx@file:../../../com.unity.formats.fbx
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
-# Editor 2020.3 doesn't have arm64 version. So when the platform is not a Silicon Mac or editor version is 2020.3, download x64 version which is the default of unity-downloader-cli for testing.
-{% if editor.version == "2020.3" or platform.model != "M1" and platform.model != "arm" %}
-    - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
-{% else %}
-# Download arm64 editor when on Silicon Mac, but only for version 2021.3 and above.
+# When the platform is Silicon Mac or ARM64 Win, explicitly download ARM64 vesion editor.
+{% if platform.model == "M1" and platform.model == "arm" %}
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
+{% else %}
+    - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
 {% endif %}
     - >
       UnifiedTestRunner

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -19,6 +19,7 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
   commands:
 {% if platform.name contains "win" -%}
 # Run build script to copy CHANGELOG.md into com.unity.formats.fbx package. Currently it is outside the package folder under repo root.
+    - choco install cmake -y
     - build.cmd
 {% elsif platform.name contains "mac" -%}
     - cmake --version || brew install cmake

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -19,7 +19,7 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
   commands:
 {% if platform.name contains "win" -%}
 # Run build script to copy CHANGELOG.md into com.unity.formats.fbx package. Currently it is outside the package folder under repo root.
-    - choco install cmake -y
+    - gsudo choco install cmake -y
     - build.cmd
 {% elsif platform.name contains "mac" -%}
     - cmake --version || brew install cmake

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -5,6 +5,8 @@ npm_registry: "https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/
 
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
+# If on "win_arm64" platform, only run tests in "trunk".
+{% if platform.name != "win_arm64" or editor.version == "trunk" %}
 test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
   name : Test version {{ editor.version }} on {{ platform.name }} using autodesk.fbx submodule
   agent:
@@ -30,7 +32,7 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
 # Editor 2020.3 doesn't have arm64 version. So when the platform is not a Silicon Mac or editor version is 2020.3, download x64 version which is the default of unity-downloader-cli for testing.
-{% if platform.model != "M1" or editor.version == "2020.3" %}
+{% if platform.model != "M1" and platform.model != "arm" or editor.version == "2020.3" %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only
 {% else %}
 # Download arm64 editor when on Silicon Mac, but only for version 2021.3 and above.
@@ -48,5 +50,6 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     TestResults:
       paths:
         - "TestResults/**/*"
+{% endif %}
 {% endfor %}
 {% endfor %}

--- a/.yamato/package-test-utr.yml
+++ b/.yamato/package-test-utr.yml
@@ -33,7 +33,7 @@ test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule:
     - unity-config project add dependency com.autodesk.fbx@file:../../../External/com.autodesk.fbx/com.autodesk.fbx
     - unity-config project set registry {{ npm_registry }}
 # When the platform is Silicon Mac or ARM64 Win, explicitly download ARM64 vesion editor.
-{% if platform.model == "M1" and platform.model == "arm" %}
+{% if platform.model == "M1" or platform.model == "arm" %}
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
 {% else %}
     - unity-downloader-cli -u {{ editor.version }} -c Editor --wait --published-only

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -85,7 +85,7 @@ test_{{ platform.name }}_{{ editor.version }}:
 # upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac and ARM64 Windows which is a known bug.
 # 2020.3 doesn't support Silicon Editor which means we always need x64 version Editor for 2020.3.
 # So when the platform is not a Silicon Mac nor ARM64 Windows, or it is a 2020.3 Editor, we just call upm-ci to run tests which will download x64 version Editor. Otherwise, we need to explicitly download ARM64 vesion editor.
-{% if platform.model != "M1" and platform.model != "arm" or editor.version == "2020.3" %}
+{% if editor.version == "2020.3" or platform.model != "M1" and platform.model != "arm" %}
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% else %}
 # Explicitly download arm64 Editor if on ARM devices

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -140,12 +140,11 @@ test_api_win:
     image: {{ win_platform.image }}
     flavor: {{ win_platform.flavor }}
   commands:
-    - git clone git@github.cds.internal.unity3d.com:unity/utr.git utr
     - gsudo choco source add -n Unity -s https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/unity-choco-local
     - gsudo choco install unity-config
     - unity-config project set registry candidates --project-path TestProjects/fbx-api-tests
     - unity-downloader-cli -u {{ all_test_editors[2].version }} -c Editor
-    - utr/utr.bat --suite=editor --editor-location=.Editor --testproject=TestProjects/fbx-api-tests --artifacts_path=artifacts --reruncount=0
+    - UnifiedTestRunner --suite=editor --editor-location=.Editor --testproject=TestProjects/fbx-api-tests --artifacts_path=artifacts --reruncount=0
   artifacts:
     logs:
       paths:
@@ -171,37 +170,20 @@ test_trigger_pr:
     - .yamato/upm-ci.yml#api_doc_validation
     - .yamato/upm-ci.yml#test_api_win
 {% for platform in platforms %}
-# On Silicon Mac, test in 2022.3 and trunk
-{% if platform.model == "M1" %}
-  {% for editor in mac_arm64_test_editors %}
-  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-    {% if use_autodesk_fbx_submodule_for_testing %}
+{% for editor in all_test_editors %}
+# If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
+{% if use_autodesk_fbx_submodule_for_testing %}
+  # Only run tests in trunk if on Silicon Mac or ARM64 Windows. On other platforms, run tests in all Editor versions.
+  {% if editor.version == "trunk" or platform.model != "M1" and platform.model != "arm" %}
     - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-    {% else %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endif %}
-  {% endfor %}
-# On ARM64 Windows, only test in trunk
-{% elsif platform.model == "arm" %}
-  {% for editor in win_arm64_test_editors %}
-  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-    {% if use_autodesk_fbx_submodule_for_testing %}
-    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-    {% else %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endif %}
-  {% endfor %}
-# On other platforms, test in all editor versions
+  {% endif %}
 {% else %}
-  {% for editor in all_test_editors %}
-  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-    {% if use_autodesk_fbx_submodule_for_testing %}
-    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-    {% else %}
+  # Only run tests in trunk if on Silicon Mac or ARM64 Windows. On other platforms, run tests in all Editor versions.
+  {% if editor.version == "trunk" or platform.model != "M1" and platform.model != "arm" %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endif %}
-  {% endfor %}
+  {% endif %}
 {% endif %}
+{% endfor %}
 {% endfor %}
 # Only run clean console tests on Win for PR trigger
 {% for editor in clean_console_test_editors %}
@@ -230,24 +212,14 @@ publish_test_trigger:
         - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?
   dependencies:
     - .yamato/upm-ci.yml#pack
-#On Silicon Mac
 {% for platform in platforms %}
-{% if platform.model == "M1" %}
-  {% for editor in mac_arm64_test_editors %}
+{% for editor in all_test_editors %}
+# Only run tests in trunk if on Silicon Mac or ARM64 Windows. On other platforms, run tests in all Editor versions.
+{% if editor.version == "trunk" or platform.model != "M1" and platform.model != "arm" %}
     - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endfor %}
-#On ARM64 Windows
-{% elsif platform.model == "arm" %}
-  {% for editor in win_arm64_test_editors %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endfor %}
-#On other platforms
-{% else %}
-  {% for editor in all_test_editors %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endfor %}
 {% endif %}
-{% endfor %}      
+{% endfor %}
+{% endfor %}  
 
 publish:
   name: Publish to Internal Registry

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -176,9 +176,9 @@ test_trigger_pr:
   {% for editor in mac_arm64_test_editors %}
   # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
     {% if use_autodesk_fbx_submodule_for_testing %}
-      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
     {% else %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endif %}
   {% endfor %}
 # On ARM64 Windows, only test in trunk
@@ -186,9 +186,9 @@ test_trigger_pr:
   {% for editor in win_arm64_test_editors %}
   # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
     {% if use_autodesk_fbx_submodule_for_testing %}
-      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
     {% else %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endif %}
   {% endfor %}
 # On other platforms, test in all editor versions
@@ -196,9 +196,9 @@ test_trigger_pr:
   {% for editor in all_test_editors %}
   # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
     {% if use_autodesk_fbx_submodule_for_testing %}
-      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
     {% else %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -234,17 +234,17 @@ publish_test_trigger:
 {% for platform in platforms %}
 {% if platform.model == "M1" %}
   {% for editor in mac_arm64_test_editors %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
   {% endfor %}
 #On ARM64 Windows
 {% elsif platform.model == "arm" %}
   {% for editor in win_arm64_test_editors %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
   {% endfor %}
 #On other platforms
 {% else %}
   {% for editor in all_test_editors %}
-      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
   {% endfor %}
 {% endif %}
 {% endfor %}      

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -82,15 +82,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-# upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac and ARM64 Windows which is a known bug.
-# 2020.3 doesn't support Silicon Editor which means we always need x64 version Editor for 2020.3.
-# So when the platform is not a Silicon Mac nor ARM64 Windows, or it is a 2020.3 Editor, we just call upm-ci to run tests which will download x64 version Editor. Otherwise, we need to explicitly download ARM64 vesion editor.
-{% if editor.version == "2020.3" or platform.model != "M1" and platform.model != "arm" %}
-    - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
-{% else %}
-# Explicitly download arm64 Editor if on ARM devices
+# upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac or ARM64 Windows which is a known bug.
+# So when the platform is Silicon Mac or ARM64 Windows, we need to explicitly download ARM64 vesion editor.
+{% if platform.model == "M1" or platform.model == "arm" %}
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version .Editor --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
+{% else %}
+    - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% endif %}
     - python tests/yamato/check_coverage_percent.py upm-ci~/test-results/ {{ coverage.minPercent }}
   artifacts:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -67,6 +67,8 @@ generate_documentation:
 
 {% for editor in all_test_editors %}
 {% for platform in platforms %}
+# If on "win_arm64" platform, only run tests in "trunk".
+{% if platform.name != "win_arm64" or editor.version == "trunk" %}
 test_{{ platform.name }}_{{ editor.version }}:
   name : Test version {{ editor.version }} on {{ platform.name }}
   agent:
@@ -80,13 +82,13 @@ test_{{ platform.name }}_{{ editor.version }}:
     UPMCI_ENABLE_APV_CLEAN_CONSOLE_TEST: 1
   commands:
     - npm install -g upm-ci-utils@stable --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-# upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac which is a known bug.
+# upm-ci uses unity-downloader-cli under the hood to download Editor and currently unity-downloader-cli always downloads x64 verion Editor even on Silicon Mac and ARM64 Windows which is a known bug.
 # 2020.3 doesn't support Silicon Editor which means we always need x64 version Editor for 2020.3.
-# So when the platform is non-Silicon Mac, or it is a 2020.3 Editor, we just call upm-ci to run tests which will download x64 version Editor.
-{% if platform.model != "M1" or editor.version == "2020.3" %}
+# So when the platform is not a Silicon Mac nor ARM64 Windows, or it is a 2020.3 Editor, we just call upm-ci to run tests which will download x64 version Editor. Otherwise, we need to explicitly download ARM64 vesion editor.
+{% if platform.model != "M1" and platform.model != "arm" or editor.version == "2020.3" %}
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version {{ editor.version }} --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% else %}
-# Explicitly download arm64 Editor if on Silicon Mac, but only for version 2021.3 and above.
+# Explicitly download arm64 Editor if on ARM devices
     - unity-downloader-cli -u {{ editor.version }} -a arm64 -c Editor --wait --published-only
     - upm-ci package test --extra-create-project-arg="-upmNoDefaultPackages" --unity-version .Editor --package-path com.unity.formats.fbx --enable-code-coverage --code-coverage-options 'generateHtmlReport;assemblyFilters:+Unity.Formats.Fbx.Editor,+Unity.Formats.Fbx.Runtime'
 {% endif %}
@@ -124,6 +126,7 @@ validate_{{ platform.name }}_{{ editor.version }}:
         - "upm-ci~/packages/**/*"
   dependencies:
     - .yamato/upm-ci.yml#pack
+{% endif %}
 {% endfor %}
 {% endfor %}
 
@@ -167,50 +170,57 @@ test_trigger_pr:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation
     - .yamato/upm-ci.yml#test_api_win
-{% for editor in all_test_editors %}
 {% for platform in platforms %}
-# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
-{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
-# If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-  {% if use_autodesk_fbx_submodule_for_testing %}
-    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-  {% else %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endif %}
+# On Silicon Mac, test in 2022.3 and trunk
+{% if platform.model == "M1" %}
+  {% for editor in mac_arm64_test_editors %}
+  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
+    {% if use_autodesk_fbx_submodule_for_testing %}
+      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    {% else %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endif %}
+  {% endfor %}
+# On ARM64 Windows, only test in trunk
+{% elsif platform.model == "arm" %}
+  {% for editor in win_arm64_test_editors %}
+  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
+    {% if use_autodesk_fbx_submodule_for_testing %}
+      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    {% else %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endif %}
+  {% endfor %}
+# On other platforms, test in all editor versions
+{% else %}
+  {% for editor in all_test_editors %}
+  # If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
+    {% if use_autodesk_fbx_submodule_for_testing %}
+      - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
+    {% else %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endif %}
+  {% endfor %}
 {% endif %}
-{% endfor %}
 {% endfor %}
 # Only run clean console tests on Win for PR trigger
 {% for editor in clean_console_test_editors %}
     - .yamato/clean-console-test.yml#clean_console_test_win_{{ editor.version }}
 {% endfor %}
 
-{% for release in nightly_tested_releases %}
-{{release.name}}_nightly_test_trigger:
-  name: {{release.branch}} nightly tests Trigger
+
+nightly_test_trigger:
+  name: Nightly tests Trigger
   triggers:
     recurring:
-      - branch: {{release.branch}}
+      - branch: master
         frequency: daily
         rerun: always
   dependencies:
     - .yamato/upm-ci.yml#pack
     - .yamato/upm-ci.yml#api_doc_validation
     - .yamato/clean-console-test.yml#clean_console_test_trigger
-{% for editor in {{release.nightly_editors}} %}
-{% for platform in platforms %}
-# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
-{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
-# If use_autodesk_fbx_submodule_for_testing is set, com.unity.formats.fbx package will test against com.autodesk.fbx repo instead of published package.
-  {% if use_autodesk_fbx_submodule_for_testing %}
-    - .yamato/package-test-utr.yml#test_{{ platform.name }}_{{ editor.version }}_using_autodesk_fbx_submodule
-  {% else %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-  {% endif %}
-{% endif %}
-{% endfor %}
-{% endfor %}
-{% endfor %}
+    - .yamato/upm-ci.yml#test_trigger_pr
 
 publish_test_trigger:
   name: Publish Tests Trigger
@@ -220,15 +230,24 @@ publish_test_trigger:
         - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?
   dependencies:
     - .yamato/upm-ci.yml#pack
-{% for editor in all_test_editors %}
+#On Silicon Mac
 {% for platform in platforms %}
-# Only run tests in 2023.2 and trunk if on Silicon Mac. If on other platforms (non M1), run tests in all Editor versions.
-{% if platform.model != "M1" or editor.version == "2023.2" or editor.version == "trunk" %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+{% if platform.model == "M1" %}
+  {% for editor in mac_arm64_test_editors %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
+#On ARM64 Windows
+{% elsif platform.model == "arm" %}
+  {% for editor in win_arm64_test_editors %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
+#On other platforms
+{% else %}
+  {% for editor in all_test_editors %}
+      - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+  {% endfor %}
 {% endif %}
-{% endfor %}
-{% endfor %}  
-      
+{% endfor %}      
 
 publish:
   name: Publish to Internal Registry

--- a/build.cmd
+++ b/build.cmd
@@ -5,6 +5,8 @@ if exist build (
 )
 md build
 cd build
-cmake ..
+REM Explicitly specify the target platform as "x64". Otherwise it fails on ARM64 Windows which has x86 VS2022 installed.
+REM This build script doesn't really build anything, it just installs Max/Maya scripts and CHANGELOG.md/LICENSE.md into the package. So the target platform actually doesn't matter.
+cmake .. -Ax64
 cmake --build . --target install
 cd ..


### PR DESCRIPTION
## Purpose of this PR:
Add test jobs on ARM64 Win. 
I also did some cleanup to the CI.

**JIRA ticket:**
[FBX-519](https://jira.unity3d.com/browse/FBX-519) CI: Add package test jobs for ARM64 Windows