### PR TITLE
CI: Only run clean console test in trunk if on ARM64 Win

### DIFF
--- a/.yamato/clean-console-test.yml
+++ b/.yamato/clean-console-test.yml
@@ -36,6 +36,9 @@ clean_console_test_trigger:
   dependencies:
 {% for platform in platforms %}
 {% for editor in clean_console_test_editors %}
+# On ARM64 Windows, only run clean console test in trunk. On other platforms, run clean console tests in all editor versions.
+{% if editor.version == "trunk" or platform.model != "arm" %}
     - .yamato/clean-console-test.yml#clean_console_test_{{ platform.name }}_{{ editor.version }}
+{% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
## Purpose of this PR:
This is a complementary PR to #716 in which I forgot to make sure clean console test only run in trunk if on ARM64 Windows.

**JIRA ticket:**
[FBX-519](https://jira.unity3d.com/browse/FBX-519) CI: Add package test jobs for ARM64 Windows
