### PR TITLE
CI: Disable test AnimOnlyExportTest because of an issue in FBX SDK

### DIFF
--- a/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
@@ -905,6 +905,7 @@ namespace FbxExporter.UnitTests
             return tester.DoIt() <= propertyNames.Length ? 1 : 0;
         }
 
+        [Ignore("FBX-525 FBX Exporter 5.1.1 exports AnimationCurve tangent 0 as -2147483648")]
         [Test, TestCaseSource(typeof(AnimationTestDataClass), "AnimOnlyTestCases")]
         public void AnimOnlyExportTest(string prefabPath)
         {


### PR DESCRIPTION
## Purpose of this PR:
Disable test AnimOnlyExportTest because of an issue in FBX Export SDK. For the details of the issue, see [FBX-525](https://jira.unity3d.com/browse/FBX-525).

**JIRA ticket:**
[FBX-530](https://jira.unity3d.com/browse/FBX-530) CI: Disable test FbxAnimationTest.AnimOnlyExportTest