### PR TITLE
Add build job on Win Arm64 for autodesk.fbx submodule 

### DIFF
--- a/.yamato/pack-autodesk-fbx.yml
+++ b/.yamato/pack-autodesk-fbx.yml
@@ -25,6 +25,7 @@ build_win_arm64:
   name: Build on win arm64
   agent:
     type: {{ win_arm64_platform.type }}
+    model: {{ win_arm64_platform.model }}
     image: {{ win_arm64_platform.image }}
     flavor: {{ win_arm64_platform.flavor}}
   commands:

--- a/.yamato/pack-autodesk-fbx.yml
+++ b/.yamato/pack-autodesk-fbx.yml
@@ -21,6 +21,24 @@ build_win:
       paths:
         - "External/com.autodesk.fbx/build-win/install/**"
 
+build_win_arm64:
+  name: Build on win arm64
+  agent:
+    type: {{ win_arm64_platform.type }}
+    image: {{ win_arm64_platform.image }}
+    flavor: {{ win_arm64_platform.flavor}}
+  commands:
+    # Load submodule and update it
+    - git submodule update --init --recursive
+    - git submodule update --remote
+    - |
+      cd External\com.autodesk.fbx
+      build_win.cmd
+  artifacts:
+    build:
+      paths:
+        - "External/com.autodesk.fbx/build-win/install/**"
+
 build_mac:
   name: Build on mac
   agent:
@@ -73,14 +91,10 @@ pack_autodesk_fbx:
     - upm-ci package pack --package-path External/com.autodesk.fbx/com.autodesk.fbx
   dependencies:
     - .yamato/pack-autodesk-fbx.yml#build_win
+    - .yamato/pack-autodesk-fbx.yml#build_win_arm64
     - .yamato/pack-autodesk-fbx.yml#build_mac
     - .yamato/pack-autodesk-fbx.yml#build_ubuntu
   artifacts:
-    build:
-      paths:
-        - "External/com.autodesk.fbx/build-ubuntu/install/**"
-        - "External/com.autodesk.fbx/build-mac/install/**"
-        - "External/com.autodesk.fbx/build-win/install/**"
     packages:
       paths:
         - "upm-ci~/packages/**"


### PR DESCRIPTION
## Purpose of this PR:
ARM64 Win build job has been added to `com.autodesk.fbx` package through [PR](https://github.com/Unity-Technologies/com.autodesk.fbx/pull/414).

This PR is to add an ARM64 Win build job for CI of `com.unity.formats.fbx` when it uses submodule `com.autodesk.fbx`.

**JIRA ticket:**
[FBX-517](https://jira.unity3d.com/browse/FBX-517) Create Yamato job to build library on Win ARM64