### PR TITLE
Remove 2023.1 from CI for release/5.0 branch

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,19 +14,16 @@ all_test_editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.1
 
 test_trigger_editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.1
 
 publish_trigger_editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.1
 
 promotion_test_editors:
   - version: 2020.3
@@ -38,7 +35,6 @@ nightly_tested_releases:
       - version: 2020.3
       - version: 2021.3
       - version: 2022.3
-      - version: 2023.1
 
 win_platform: &win
   name: win


### PR DESCRIPTION
## Purpose of this PR:
Remove 2023.1 from CI of release/5.0 branch.

**JIRA ticket:**
[FBX-494](https://jira.unity3d.com/browse/FBX-494) CI: Editor cleanup in CI of both FBX SDK and FBX Exporter for release/5.0 branch