### PR TITLE
Fixed exception when exporting with an LOD containing a null renderer (FBX-344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes in Fbx Exporter
 
+## [Unreleased]
+- Fixed an exception occurring during hierarchy export when an LOD contains a null renderer.
+
 ## [5.1.1] - 2024-03-18
 ### Changed
 - Updated the FBX SDK bindings to 5.1.1.

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -3047,6 +3047,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
                     bool exportedRenderer = false;
                     foreach (var renderer in lod.renderers)
                     {
+                        if (renderer == null)
+                            continue;
                         // only export if parented under LOD group
                         if (renderer.transform.parent == unityGo.transform)
                         {

--- a/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/ModelExporterTest.cs
@@ -1129,6 +1129,28 @@ namespace FbxExporter.UnitTests
 #endif
         }
 
+        [Test]
+        public void TestNullRendererLODExportTransformHierarchy()
+        {
+            // Create a GO with an LOD that contains a null renderer
+            var gameObject = new GameObject("TestObject");
+            var lodGroup = gameObject.AddComponent<LODGroup>();
+            var lods = new LOD[1];
+            lods[0] = new LOD(0.5f, new Renderer[] {null});
+            lodGroup.SetLODs(lods);
+
+            var fbxScene = FbxScene.Create(FbxManager.Create(), "TestScene");
+            var fbxNodeParent = FbxNode.Create(fbxScene, "ParentNode");
+            var modelExporter = new ModelExporter();
+
+            // Assert we don't raise an exception anymore
+            Assert.DoesNotThrow(() =>
+            {
+                modelExporter.ExportTransformHierarchy(gameObject, fbxScene, fbxNodeParent, 0, 1, Vector3.zero,
+                    ModelExporter.TransformExportType.Local, LODExportType.Lowest);
+            });
+        }
+
         /// <summary>
         /// Compares obj's children to the expected children in the hashset.
         /// Doesn't recurse through the children.

--- a/com.unity.formats.fbx/package.json
+++ b/com.unity.formats.fbx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.formats.fbx",
   "displayName": "FBX Exporter",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "dependencies": {
     "com.unity.timeline": "1.7.1",
     "com.autodesk.fbx": "5.1.1"


### PR DESCRIPTION
Jira issue: https://jira.unity3d.com/browse/FBX-344

It was raised by Viktoria a while ago. Not sure how she bumped into it but after a quick search, it is indeed possible to have an LOD with a null renderer. Cf issue for more details.

Note I also upgraded the version of the package because it seems it is the workflow APV 2.0 wants us to have (aka as soon as you add an Unreleased section, version should be updated).