### PR TITLE
Remove 2023.2 from main branch CI

### DIFF
--- a/.yamato/global.metafile
+++ b/.yamato/global.metafile
@@ -14,7 +14,6 @@ all_test_editors:
   - version: 2020.3
   - version: 2021.3
   - version: 2022.3
-  - version: 2023.2
   - version: trunk
 
 clean_console_test_editors:


### PR DESCRIPTION
## Purpose of this PR:
Remove 2023.2 from main branch CI

**JIRA ticket:**
[FBX-535](https://jira.unity3d.com/browse/FBX-535) CI: Remove 2023.2 from FBX Exporter's Editor list