### PR TITLE
Disable AnimOnlyExportTest for release 4.2

### DIFF
--- a/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
+++ b/com.unity.formats.fbx/Tests/FbxTests/FbxAnimationTest.cs
@@ -864,6 +864,7 @@ namespace FbxExporter.UnitTests
             return tester.DoIt() <= propertyNames.Length ? 1 : 0;
         }
 
+        [Ignore("FBX-525 FBX Exporter exports AnimationCurve tangent 0 as -2147483648")]
         [Test, TestCaseSource (typeof (AnimationTestDataClass), "AnimOnlyTestCases")]
         public void AnimOnlyExportTest(string prefabPath)
         {


### PR DESCRIPTION
## Purpose of this PR:
Disable AnimOnlyExportTest for release 4.2

**JIRA ticket:**
[FBX-536](https://jira.unity3d.com/browse/FBX-536) CI: Disable test FbxAnimationTest.AnimOnlyExportTest for release/4.2 and release/5.0 branch