### PR TITLE
Clean up API doc landing page

### DIFF
--- a/com.unity.formats.fbx/Documentation~/api_index.md
+++ b/com.unity.formats.fbx/Documentation~/api_index.md
@@ -4,7 +4,11 @@ uid: api_index
 
 # FBX Exporter scripting API
 
-The FBX Exporter package includes an API that allows to create C# scripts and applications to handle FBX export processes based on your custom needs.
+The FBX Exporter package includes an API that allows you to write C# scripts and applications to handle FBX export processes based on your custom needs.
+
+> [!NOTE]
+> While technically possible, it's not recommended to use the API for FBX import, as it wasn't designed for such a use case.
+
 
 ## Get started
 

--- a/com.unity.formats.fbx/Documentation~/api_index.md
+++ b/com.unity.formats.fbx/Documentation~/api_index.md
@@ -75,14 +75,20 @@ public static GameObject ConvertGameObject(GameObject go)
 ```
 
 
-## Runtime
+## FBX export at runtime
 
-The FBX SDK bindings can be executed during gameplay allowing import and export at runtime. Currently a custom importer/exporter needs to be written in order to do so, as the FBX Exporter is Editor only.
+By default, the FBX Exporter is Editor only. However, you can script a custom exporter to execute the FBX SDK bindings during gameplay to perform FBX exports at runtime.
 
->[!NOTE]
->The FBX SDK bindings are Editor only by default and will not be included in a build. In order for the package to be included in the build, add the FBXSDK_RUNTIME define to Edit > Project Settings... > Player > Other Settings > Scripting Define Symbols.
+### Prerequisite
 
-### Basic Exporter:
+The FBX SDK bindings are Editor only by default and are not included in builds.  
+To include the package in the build, add the `FBXSDK_RUNTIME` define to **Edit** > **Project Settings** > **Player** > **Other Settings** > **Scripting Define Symbols**.
+
+### Limitations
+
+* Only 64 bit Windows, MacOS and Ubuntu standalone player builds are supported.
+
+### Basic exporter example script
 
 ```
 using Autodesk.Fbx;
@@ -110,36 +116,3 @@ protected void ExportScene (string fileName)
     }
 }
 ```
-
-### Basic Importer:
-
-```
-using Autodesk.Fbx;
-using UnityEngine;
-using UnityEditor;
-
-protected void ImportScene (string fileName)
-{
-    using(FbxManager fbxManager = FbxManager.Create ()){
-        // configure IO settings.
-        fbxManager.SetIOSettings (FbxIOSettings.Create (fbxManager, Globals.IOSROOT));
-
-        // Import the scene to make sure file is valid
-        using (FbxImporter importer = FbxImporter.Create (fbxManager, "myImporter")) {
-
-            // Initialize the importer.
-            bool status = importer.Initialize (fileName, -1, fbxManager.GetIOSettings ());
-
-            // Create a new scene so it can be populated by the imported file.
-            FbxScene scene = FbxScene.Create (fbxManager, "myScene");
-
-            // Import the contents of the file into the scene.
-            importer.Import (scene);
-        }
-    }
-}
-```
-
-### Limitations
-
-* Only 64 bit Windows, MacOS and Ubuntu standalone player builds are supported

--- a/com.unity.formats.fbx/Documentation~/api_index.md
+++ b/com.unity.formats.fbx/Documentation~/api_index.md
@@ -1,33 +1,43 @@
-# FBX Exporter scripting API reference
+---
+uid: api_index
+---
+
+# FBX Exporter scripting API
 
 The FBX Exporter package includes an API that allows to create C# scripts and applications to handle FBX export processes based on your custom needs.
 
 ## Get started
 
-This section points out the base elements to know to get started with the FBX Exporter API.
+This section points out the base elements you need to know to get started with the FBX Exporter API. [Example scripts](#example-scripts) and [additional resources](#additional-resources) are also provided below.
 
-### Use cases
+### Export to FBX
 
-* To export Unity GameObjects to FBX, use the [`ModelExporter` class](xref:UnityEditor.Formats.Fbx.Exporter.ModelExporter).  
-  Depending on the method, you can specify a single GameObject or a list of GameObjects to export to FBX.
+To export Unity GameObjects to FBX, use the [`ModelExporter` class](xref:UnityEditor.Formats.Fbx.Exporter.ModelExporter).  
+Depending on the method, you can specify a single GameObject or a list of GameObjects to export to FBX.
 
-* To convert a GameObject hierarchy to an FBX Prefab Variant, use the The `ConvertToNestedPrefab` class.
+### Convert to FBX Prefab Variant
 
-### Export settings
+To convert a GameObject hierarchy to an FBX Prefab Variant, use the The [`ConvertToNestedPrefab` class](xref:UnityEditor.Formats.Fbx.Exporter.ConvertToNestedPrefab).
 
-* To use custom export settings, you can create and pass an instance of `ExportModelOptions` class with modified settings.
-* If you don't pass any export settings, Unity uses default export settings.
+### Use custom export settings
 
-### Underlying concepts and features
+To use custom export settings, create and pass an instance of [`ExportModelOptions` class](xref:UnityEditor.Formats.Fbx.Exporter.ExportModelOptions) with modified settings. If you don't pass any export settings, Unity uses default export settings.
 
-For more details about the FBX package concepts and features, refer to the user manual pages:
-* [FBX Exporter features and behaviors](../manual/features-behaviors.html)
-* [Export models and animations to FBX](../manual/export.html)
-* [Work with FBX Prefab Variants](../manual/prefab-variants.html)
+### Export FBX at runtime
+
+By default, the FBX Exporter is Editor only and the FBX SDK bindings are not included in builds. To enable FBX export at runtime, you have to perform some Editor configuration and custom scripting.
+
+1. Include the FBX SDK bindings in the build: go to **Edit** > **Project Settings** > **Player** > **Other Settings** > **Script Compilation** > **Scripting Define Symbols** and add `FBXSDK_RUNTIME` to the list.
+1. Script a custom exporter like in the [basic example](#runtime-fbx-exporter) provided below.
+
+> [!NOTE]
+> Runtime FBX export only works with 64 bit Windows, MacOS and Ubuntu standalone player builds.
 
 ## Example scripts
 
-### Export to FBX
+### FBX export
+
+Use this script as an example to export GameObjects to FBX files within the Unity Editor.
 
 ```
 using System.IO;
@@ -51,7 +61,9 @@ public static void ExportGameObjects(Object[] objects)
 }
 ```
 
-### Create an FBX Prefab Variant
+### FBX Prefab Variant conversion
+
+Use this script as an example to convert a GameObject hierarchy to an FBX Prefab Variant within the Unity Editor.
 
 ```
 using System.IO;
@@ -74,21 +86,12 @@ public static GameObject ConvertGameObject(GameObject go)
 }
 ```
 
+### Runtime FBX exporter
 
-## FBX export at runtime
+Use this script as an example to export FBX at runtime.
 
-By default, the FBX Exporter is Editor only. However, you can script a custom exporter to execute the FBX SDK bindings during gameplay to perform FBX exports at runtime.
-
-### Prerequisite
-
-The FBX SDK bindings are Editor only by default and are not included in builds.  
-To include the package in the build, add the `FBXSDK_RUNTIME` define to **Edit** > **Project Settings** > **Player** > **Other Settings** > **Scripting Define Symbols**.
-
-### Limitations
-
-* Only 64 bit Windows, MacOS and Ubuntu standalone player builds are supported.
-
-### Basic exporter example script
+> [!NOTE]
+> Before you move forward with this scenario, review the [specific requirements and implications](#export-fbx-at-runtime) about using the FBX Exporter at runtime.
 
 ```
 using Autodesk.Fbx;
@@ -116,3 +119,10 @@ protected void ExportScene (string fileName)
     }
 }
 ```
+
+## Additional resources
+
+For more details about the FBX package concepts and features, refer to the user manual pages:
+* [FBX Exporter features and behaviors](xref:features-behaviors)
+* [Export models and animations to FBX](xref:export)
+* [Work with FBX Prefab Variants](xref:prefab-variants)

--- a/com.unity.formats.fbx/Documentation~/api_index.md
+++ b/com.unity.formats.fbx/Documentation~/api_index.md
@@ -1,16 +1,33 @@
-# Developer’s Guide
+# FBX Exporter scripting API reference
 
-As a developer, you have access to the FBX Exporter from C# scripting. You can use the basic API by providing a single GameObject or a list of GameObjects.
+The FBX Exporter package includes an API that allows to create C# scripts and applications to handle FBX export processes based on your custom needs.
 
-## Managing export settings
+## Get started
 
-To use custom export settings, you can create and pass an instance of `ExportModelOptions` class with modified settings.
+This section points out the base elements to know to get started with the FBX Exporter API.
 
-If you don't pass any export settings, Unity uses default export settings to export the GameObjects to the FBX file.
+### Use cases
 
-## Calling the FBX Exporter
+* To export Unity GameObjects to FBX, use the [`ModelExporter` class](xref:UnityEditor.Formats.Fbx.Exporter.ModelExporter).  
+  Depending on the method, you can specify a single GameObject or a list of GameObjects to export to FBX.
 
-You can call the FBX Exporter from C# using methods found in the [UnityEditor.Formats.Fbx.Exporter](UnityEditor.Formats.Fbx.Exporter.html) namespace, for example:
+* To convert a GameObject hierarchy to an FBX Prefab Variant, use the The `ConvertToNestedPrefab` class.
+
+### Export settings
+
+* To use custom export settings, you can create and pass an instance of `ExportModelOptions` class with modified settings.
+* If you don't pass any export settings, Unity uses default export settings.
+
+### Underlying concepts and features
+
+For more details about the FBX package concepts and features, refer to the user manual pages:
+* [FBX Exporter features and behaviors](../manual/features-behaviors.html)
+* [Export models and animations to FBX](../manual/export.html)
+* [Work with FBX Prefab Variants](../manual/prefab-variants.html)
+
+## Example scripts
+
+### Export to FBX
 
 ```
 using System.IO;
@@ -34,13 +51,7 @@ public static void ExportGameObjects(Object[] objects)
 }
 ```
 
-## Creating an FBX Prefab Variant
-
-You can convert a GameObject hierarchy to an [FBX Prefab Variant](../manual/prefab-variants.html) using the API.
-
-The principle is to export the GameObject hierarchy to an FBX and then convert the exported FBX Model Prefab into a Prefab Variant while maintaining the components from the original hierarchy.
-
-For example:
+### Create an FBX Prefab Variant
 
 ```
 using System.IO;

--- a/com.unity.formats.fbx/Documentation~/export.md
+++ b/com.unity.formats.fbx/Documentation~/export.md
@@ -1,3 +1,7 @@
+---
+uid: export
+---
+
 # Export models and animations to FBX
 
 Export GameObjects from the Hierarchy, or animation clips from Timeline, to FBX.

--- a/com.unity.formats.fbx/Documentation~/features-behaviors.md
+++ b/com.unity.formats.fbx/Documentation~/features-behaviors.md
@@ -1,3 +1,7 @@
+---
+uid: features-behaviors
+---
+
 # FBX Exporter features and behaviors
 
 Reference and guidelines to better understand the FBX export process and expectable results.

--- a/com.unity.formats.fbx/Documentation~/index.md
+++ b/com.unity.formats.fbx/Documentation~/index.md
@@ -15,4 +15,4 @@ The FBX Exporter package enables round-trip workflows between Unity and 3D model
 | [Integrate Unity with 3D modeling software](integration.md) | Use the Unity Integration tool in Autodesk® Maya®, Autodesk® Maya LT™ or Autodesk® 3ds Max® to import and export FBX files directly to and from Unity without having to specify filenames, select objects, or set FBX importer or exporter settings. |
 | [Project Settings](ref-project-settings.md) | Manage the Unity Editor project settings dedicated to the FBX Exporter package features. |
 | [Known issues and limitations](knownissues.md) | See the list of known issues and limitations that you might experience with the FBX Exporter package, along with some workarounds. |
-| [API samples and reference](../api/index.html) | Get an introduction to scripting with the FBX Exporter API, and access the API reference documentation. |
+| [API samples and reference](xref:api_index) | Get an introduction to scripting with the FBX Exporter API, and access the API reference documentation. |

--- a/com.unity.formats.fbx/Documentation~/prefab-variants.md
+++ b/com.unity.formats.fbx/Documentation~/prefab-variants.md
@@ -1,3 +1,7 @@
+---
+uid: prefab-variants
+---
+
 # Work with FBX Prefab Variants
 
 Easily convert GameObjects and Prefab assets to Prefab Variants based on FBX files to enable a convenient FBX model workflow between Unity and your 3D modeling application.

--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -36,7 +36,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
     /// <summary>
     /// <para>Class for converting an exported FBX to a Prefab Variant.</para>
-    /// <para>See the <a href="index.html#example-scripts">example script</a> on the API documentation homepage.</para>
+    /// <para>For API overview and example scripts, refer to @api_index.</para>
     /// </summary>
     public static class ConvertToNestedPrefab
     {

--- a/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
+++ b/com.unity.formats.fbx/Editor/ConvertToNestedPrefab.cs
@@ -35,7 +35,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
     }
 
     /// <summary>
-    /// Class for converting an exported FBX to a Prefab Variant.
+    /// <para>Class for converting an exported FBX to a Prefab Variant.</para>
+    /// <para>See the <a href="index.html#example-scripts">example script</a> on the API documentation homepage.</para>
     /// </summary>
     public static class ConvertToNestedPrefab
     {

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -62,7 +62,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     /// Use the ExportObject and ExportObjects methods. The default export
     /// options are used when exporting the objects to the FBX file.
     /// </para>
-    /// <para>For information on using the ModelExporter class, see <a href="index.html">the Developer's Guide</a>.</para>
+    /// <para>See the <a href="index.html#example-scripts">example script</a> on the API documentation homepage.</para>
     /// </summary>
     public sealed class ModelExporter
     {

--- a/com.unity.formats.fbx/Editor/FbxExporter.cs
+++ b/com.unity.formats.fbx/Editor/FbxExporter.cs
@@ -62,7 +62,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
     /// Use the ExportObject and ExportObjects methods. The default export
     /// options are used when exporting the objects to the FBX file.
     /// </para>
-    /// <para>See the <a href="index.html#example-scripts">example script</a> on the API documentation homepage.</para>
+    /// <para>For API overview and example scripts, refer to @api_index.</para>
     /// </summary>
     public sealed class ModelExporter
     {


### PR DESCRIPTION
### Purpose of the PR

Clean up the landing page of the FBX Exporter package Scripting API documentation.

- [DOCATT-5036](https://jira.unity3d.com/browse/DOCATT-5036) - Rewrite Developer's Guide to match landing page standards
- [DOCATT-5034](https://jira.unity3d.com/browse/DOCATT-5034) - Move Runtime section
- [DOCATT-5031](https://jira.unity3d.com/browse/DOCATT-5031) - Find better places for use cases

**Note:** in KTLO context, we don't push too much for moving things around. The three tickets listed above actually converged to a straightforward cleanup of the targeted page.

In the end:
- Adjusted the page title and added a short intro sentence.
- Grouped/identified all topics in a Get started section with subsections.
- Presented topics from use case to main corresponding class and provided links to these classes.
- Reformulated the Runtime section to a straightforward short section with instructions.
- Grouped all script examples in the same section, with short descriptions.
- Removed any mention and script example about import in runtime.
- Fixed the cross-referencing strategy to get proper links that don't produce warnings in the doc build.

### Built documentation

To help the review with better context: [FBX Exporter Scripting API](https://yamato-artifactviewer.prd.cds.internal.unity3d.com/d347d6d2-fba8-4e45-ac4e-d39788159c5f%2Fdocumentation%2FPackage_Doc/api/index.html) page.