### PR TITLE
Remove usage of deprecated PresetSelectorReceiver (FBX-452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Fixed an exception occurring during hierarchy export when an LOD contains a null renderer.
 - Removed the deprecated Component Updater from FBX Export Project Settings.
+- Fixed Presets creation in Unity 2023.1+.
 
 ## [5.1.1] - 2024-03-18
 ### Changed

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -39,7 +39,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             get { return m_innerEditor; }
             set { m_innerEditor = value; }
         }
-#if UNITY_2018_1_OR_NEWER
+#if UNITY_2018_1_OR_NEWER && !UNITY_2023_1_OR_NEWER
         private FbxExportPresetSelectorReceiver m_receiver;
         protected FbxExportPresetSelectorReceiver Receiver
         {
@@ -249,7 +249,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         protected virtual void OnEnable()
         {
-            #if UNITY_2018_1_OR_NEWER
+            #if UNITY_2018_1_OR_NEWER && !UNITY_2023_1_OR_NEWER
             InitializeReceiver();
             #endif
             m_showOptions = true;
@@ -267,7 +267,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             this.SetFilename(filename);
         }
 
-        #if UNITY_2018_1_OR_NEWER
+        #if UNITY_2018_1_OR_NEWER && !UNITY_2023_1_OR_NEWER
         protected void InitializeReceiver()
         {
             if (!Receiver)
@@ -345,7 +345,14 @@ namespace UnityEditor.Formats.Fbx.Exporter
         /// </summary>
         protected virtual void CreateCustomUI() {}
 
-        #if UNITY_2018_1_OR_NEWER
+        #if UNITY_2023_1_OR_NEWER
+        protected abstract void ShowPresetReceiver();
+
+        protected void ShowPresetReceiver(UnityEngine.Object target)
+        {
+            PresetSelector.ShowSelector(new []{target}, null, true);
+        }
+        #elif UNITY_2018_1_OR_NEWER
         protected abstract void ShowPresetReceiver();
 
         protected void ShowPresetReceiver(UnityEngine.Object target)
@@ -353,11 +360,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
             InitializeReceiver();
             Receiver.SetTarget(target);
             Receiver.SetInitialValue(new Preset(target));
-#pragma warning disable CS0618 // Suppress the warning about obsolete API "PresetSelector.ShowSelector" FBX-452
             UnityEditor.Presets.PresetSelector.ShowSelector(target, null, true, Receiver);
-#pragma warning restore CS0618 // Restore the warning
         }
-
         #endif
 
         protected Transform TransferAnimationSource

--- a/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
+++ b/com.unity.formats.fbx/Editor/ExportModelEditorWindow.cs
@@ -350,8 +350,9 @@ namespace UnityEditor.Formats.Fbx.Exporter
 
         protected void ShowPresetReceiver(UnityEngine.Object target)
         {
-            PresetSelector.ShowSelector(new []{target}, null, true);
+            PresetSelector.ShowSelector(new[] {target}, null, true);
         }
+
         #elif UNITY_2018_1_OR_NEWER
         protected abstract void ShowPresetReceiver();
 
@@ -362,6 +363,7 @@ namespace UnityEditor.Formats.Fbx.Exporter
             Receiver.SetInitialValue(new Preset(target));
             UnityEditor.Presets.PresetSelector.ShowSelector(target, null, true, Receiver);
         }
+
         #endif
 
         protected Transform TransferAnimationSource

--- a/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
@@ -8,7 +8,6 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal delegate void DialogClosedDelegate();
 
     internal class FbxExportPresetSelectorReceiver : PresetSelectorReceiver
-
     {
         UnityEngine.Object m_Target;
         Preset m_InitialValue;

--- a/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
+++ b/com.unity.formats.fbx/Editor/FbxExportPresetSelectorReceiver.cs
@@ -1,4 +1,5 @@
-#if UNITY_2018_1_OR_NEWER
+#if UNITY_2018_1_OR_NEWER && !UNITY_2023_1_OR_NEWER
+
 using UnityEditor.Presets;
 
 namespace UnityEditor.Formats.Fbx.Exporter
@@ -6,9 +7,8 @@ namespace UnityEditor.Formats.Fbx.Exporter
     internal delegate void SelectionChangedDelegate();
     internal delegate void DialogClosedDelegate();
 
-#pragma warning disable CS0618 // Suppress the warning about obsolete class "PresetSelectorReceiver" FBX-452
     internal class FbxExportPresetSelectorReceiver : PresetSelectorReceiver
-#pragma warning restore CS0618 // Restore the warning
+
     {
         UnityEngine.Object m_Target;
         Preset m_InitialValue;


### PR DESCRIPTION
`PresetSelectorReceiver` was deprecated in 2023.1 and presets were actually not working anymore in 2023 stream.
Replaced PresetSelectorReceiver by the new API for 2023.1+.
Removed the pragmas to prevent warnings.

Tested in 6000 and 2022.3:
* Presets are working
* There is no warning 