### PR TITLE
CI: Use YAMATO_OWNER_EMAIL environment variable in package format job

### DIFF
--- a/.yamato/package-format.yml
+++ b/.yamato/package-format.yml
@@ -8,8 +8,8 @@
      image: {{ mac_platform.image }}
      flavor: {{ mac_platform.flavor }}
    commands:
-     - git config --global user.name "noreply@unity3d.com"
-     - git config --global user.email "noreply@unity3d.com"
+     - git config --global user.name "FBX Exporter CI"
+     - git config --global user.email $YAMATO_OWNER_EMAIL
      - git checkout $GIT_BRANCH
      - git pull origin $GIT_BRANCH # In case the job was not run on the latest commit, attempt to get it. There may be situations with merge conflicts, in that case wait for everyone to push their changes and then only run the formatting job on HEAD.
      - brew tap --force-auto-update unity/unity git@github.cds.internal.unity3d.com:unity/homebrew-unity.git


### PR DESCRIPTION
## Purpose of this PR:
Use YAMATO_OWNER_EMAIL environment variable instead of [noreply@unity3d.com](mailto:noreply@unity3d.com) in format_code job.
By doing that, whoever runs that job will be the author of that commit which formats the codes.

**Ticket/Jira #:**
[CST-1470](https://jira.unity3d.com/browse/CST-1470) CI: Use YAMATO_OWNER_EMAIL in format_code jobs