### PR TITLE
Doc - Fix missing/incomplete property references

### DIFF
--- a/com.unity.formats.fbx/Documentation~/includes/transfer-animation.md
+++ b/com.unity.formats.fbx/Documentation~/includes/transfer-animation.md
@@ -1,8 +1,8 @@
-Optional. Transfer the animation from a GameObject to one of its descendants being in the exported GameObject hierarchy.
+Optionally transfer the animation from a GameObject to one of its descendants to export.
 
-For example, when you export a character with mesh and skeleton held by separate child GameObjects, you might need to transfer the animation of the character to its skeleton to avoid mesh/skeleton separation at import in another modeling application.
+For example, when you export a character with mesh and skeleton held by separate child GameObjects, you might want to transfer the animation of the character to its skeleton to avoid mesh/skeleton separation issues when using in another modeling application.
 
 | Property | Function |
 | :--- | :--- |
-| **Source** | The GameObject to transfer the animation from.<br /><br />• This GameObject must be an ancestor of the **Destination**.<br />• This GameObject can be an ancestor of the GameObject to export. |
-| **Destination** | The GameObject to transfer the animation to.<br /><br />• This GameObject receives the animation from the **Source** as well as from any objects in between in the hierarchy. |
+| **Source** | The GameObject to transfer the animation from.<br /><br />• This GameObject must be an ancestor of the **Destination**.<br />• This GameObject doesn't have to be part of the export, it can be an ancestor of the GameObject to export. |
+| **Destination** | The GameObject to transfer the animation to.<br /><br />• This GameObject receives the animation from the **Source** as well as from any GameObjects in between in the hierarchy. |

--- a/com.unity.formats.fbx/Documentation~/includes/transfer-animation.md
+++ b/com.unity.formats.fbx/Documentation~/includes/transfer-animation.md
@@ -1,0 +1,8 @@
+Optional. Transfer the animation from a GameObject to one of its descendants being in the exported GameObject hierarchy.
+
+For example, when you export a character with mesh and skeleton held by separate child GameObjects, you might need to transfer the animation of the character to its skeleton to avoid mesh/skeleton separation at import in another modeling application.
+
+| Property | Function |
+| :--- | :--- |
+| **Source** | The GameObject to transfer the animation from.<br /><br />• This GameObject must be an ancestor of the **Destination**.<br />• This GameObject can be an ancestor of the GameObject to export. |
+| **Destination** | The GameObject to transfer the animation to.<br /><br />• This GameObject receives the animation from the **Source** as well as from any objects in between in the hierarchy. |

--- a/com.unity.formats.fbx/Documentation~/ref-convert-options.md
+++ b/com.unity.formats.fbx/Documentation~/ref-convert-options.md
@@ -15,10 +15,7 @@ Use the **Convert Options** window to [convert a GameObject](prefab-variants-con
 
 ## Transfer Animation
 
-| Property | Function |
-| :--- | :--- |
-| **Source** | Transfer the transform animation from this object to the **Destination** transform.<br/><br/>**NOTES:**<br/> - **Source** must be an ancestor of **Destination**.<br/> - **Source** may be an ancestor of the selected object. |
-| **Destination** | Which object to transfer the transform animation to.<br/><br/>This object receives the transform animation on objects between **Source** and **Destination** as well as the animation on the **Source** itself. |
+[!INCLUDE [transfer-animation](includes/transfer-animation.md)]
 
 ## Options
 

--- a/com.unity.formats.fbx/Documentation~/ref-export-options.md
+++ b/com.unity.formats.fbx/Documentation~/ref-export-options.md
@@ -13,10 +13,7 @@ Use the **Export Options** window to [export a GameObject from the Hierarchy](ex
 
 ## Transfer Animation
 
-| Property | Function |
-| :--- | :--- |
-| **Source** | Transfer the transform animation from this object to the **Destination** transform. <br/><br/>**NOTES:**<br/> - **Source** must be an ancestor of **Destination**<br/> - **Source** may be an ancestor of the selected object. |
-| **Destination** | Which object to transfer the transform animation to.<br/><br/>This object receives the transform animation on objects between **Source** and **Destination** as well as the animation on the Source itself. |
+[!INCLUDE [transfer-animation](includes/transfer-animation.md)]
 
 ## Options
 

--- a/com.unity.formats.fbx/Documentation~/ref-recorder-properties.md
+++ b/com.unity.formats.fbx/Documentation~/ref-recorder-properties.md
@@ -22,6 +22,7 @@ Define the source and the content of your recording.
 | | Lossy | Applies an overall keyframe reduction. The Recorder removes animation keys based on a relative tolerance of 0.5 percent, to overall simplify the curve. This reduces the file size but directly affects the original curve accuracy. |
 | | Lossless | Applies keyframe reduction to constant curves only. The Recorder removes all unnecessary keys when the animation curve is a straight line, but keeps all recorded keys as long as the animation is not constant. |
 | | Disabled | Disables the animation compression. The Recorder saves all animation keys throughout the recording, even when the animation curve is a straight line. This might result in large files and slow playback. |
+| **Render Frame Step** || Available when you set **Playback** to **Variable**. Specifies the number of rendered frames to discard between recorded frames. The duration of the discarded frames is preserved, reducing frames per second. Example: if the value is 2, every second frame is discarded, but the duration of the recording remains the same. |
 
 ## Output Format
 

--- a/com.unity.formats.fbx/Documentation~/ref-recorder-properties.md
+++ b/com.unity.formats.fbx/Documentation~/ref-recorder-properties.md
@@ -33,10 +33,7 @@ Define the source and the content of your recording.
 
 ### Transfer Animation
 
-| Property | Function |
-| :--- | :--- |
-| **Source** | The object to transfer the transform animation from. <br/><br/>**Note:**<br/>• **Source** must be an ancestor of **Destination**.<br/>• **Source** may be an ancestor of the selected object. |
-| **Destination** | The object to transfer the transform animation to.<br/><br/>This object receives the transform animation on objects between **Source** and **Destination** as well as the animation on the **Source** itself. |
+[!INCLUDE [transfer-animation](includes/transfer-animation.md)]
 
 ## Output File
 


### PR DESCRIPTION
## Purpose of the PR

Fix missing/incomplete property references according to various feedback sources:

- [x] [DOCATT-5033](https://jira.unity3d.com/browse/DOCATT-5033) - Add Render Frame Step to FBX Recorder properties
- [x] [DOCATT-5030](https://jira.unity3d.com/browse/DOCATT-5030) - Clarify the purpose of Transfer Animation section